### PR TITLE
fix(citest): Make integration test instance preemptiable.

### DIFF
--- a/dev/validate_bom__deploy.py
+++ b/dev/validate_bom__deploy.py
@@ -1431,6 +1431,7 @@ class GoogleValidateBomDeployer(GenericVmValidateBomDeployer):
         ' --project {project} --zone {zone}'
         ' --network {network}'
         ' --tags {network_tags}'
+        ' --preemptible'
         ' --scopes {scopes}'
         ' {instance}'
         .format(gcloud_account=options.deploy_hal_google_service_account,


### PR DESCRIPTION
This should make it so that VMs stood up for integration testing don't live longer than 24 hours, with a small chance they'll get killed mid-testing. If we find that these VMs are getting preempted a lot, we can remove this setting.