### PR TITLE
chore(builds/containers): Enable moving builds to spinnaker-community…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.idea/

--- a/dev/buildtool/cloudbuild-build-java8.yml
+++ b/dev/buildtool/cloudbuild-build-java8.yml
@@ -13,8 +13,8 @@ steps:
     name: gcr.io/cloud-builders/docker
     args: [
             "build",
-            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME",
-            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim",
+            "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME",
+            "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim",
             "-f", "Dockerfile.slim",
             ".",
           ]
@@ -23,7 +23,7 @@ steps:
     name: gcr.io/cloud-builders/docker
     args: [
             "build",
-            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu",
+            "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu",
             "-f", "Dockerfile.ubuntu",
             ".",
           ]
@@ -32,7 +32,7 @@ steps:
     name: gcr.io/cloud-builders/docker
     args: [
             "build",
-            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8",
+            "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-java8",
             "-f", "Dockerfile.java8",
             ".",
           ]
@@ -41,16 +41,16 @@ steps:
     name: gcr.io/cloud-builders/docker
     args: [
             "build",
-            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8",
+            "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8",
             "-f", "Dockerfile.ubuntu-java8",
             ".",
           ]
 images:
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8
+  - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME
+  - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim
+  - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-java8
+  - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu
+  - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8
 timeout: 3600s
 options:
   machineType: N1_HIGHCPU_8

--- a/dev/buildtool/cloudbuild-tag-java8.yml
+++ b/dev/buildtool/cloudbuild-tag-java8.yml
@@ -13,9 +13,9 @@ steps:
     name: gcr.io/cloud-builders/docker
     args: [
             "build",
-            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME",
-            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim",
-            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8",
+            "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME",
+            "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim",
+            "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-java8",
             "-f", "Dockerfile.slim",
             ".",
           ]
@@ -24,17 +24,17 @@ steps:
     name: gcr.io/cloud-builders/docker
     args: [
             "build",
-            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu",
-            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8",
+            "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu",
+            "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8",
             "-f", "Dockerfile.ubuntu",
             ".",
           ]
 images:
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8
+  - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME
+  - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim
+  - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-java8
+  - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu
+  - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8
 timeout: 3600s
 options:
   machineType: N1_HIGHCPU_8

--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -102,10 +102,11 @@ class BuildContainerCommand(GradleCommandProcessor):
     # Note this command assumes a cwd of git_dir
     command = ('gcloud builds submit '
                ' --account={account} --project={project}'
-               ' --substitutions=TAG_NAME={tag_name},_IMAGE_NAME={image_name}'
+               ' --substitutions=TAG_NAME={tag_name},_IMAGE_NAME={image_name},_DOCKER_REGISTRY={docker_registry}'
                ' --config={cloudbuild_config} .'
                .format(account=options.gcb_service_account,
                        project=options.gcb_project,
+                       docker_registry=options.docker_registry,
                        tag_name=build_version,
                        image_name=service_name,
                        cloudbuild_config=cloudbuild_config))
@@ -136,7 +137,7 @@ class BuildContainerFactory(GradleCommandFactory):
     self.add_bom_parser_args(parser, defaults)
     self.add_argument(
         parser, 'gcb_project', defaults, None,
-        help='The GCP project ID to publish containers to when'
+        help='The GCP project ID that builds the containers when'
         ' using Google Container Builder.')
     self.add_argument(
         parser, 'gcb_service_account', defaults, None,


### PR DESCRIPTION
… GCP project.

This is controlled by a few options in the `buildtool.yml` file:

```
docker_registry: gcr.io/spinnaker-marketplace
gcb_project: spinnaker-marketplace
```

Once this change is in, `gcb_project` will change to `spinnaker-community` and the GCB service account will be granted permission to push to GCR in `spinnaker-marketplace`. 

This is only one step to moving container builds to the community project. See the remaining work [here](https://github.com/orgs/spinnaker/projects/11)

Fixes https://github.com/spinnaker/spinnaker/issues/5437
