### PR TITLE
fix(kubernetes): explicitly set v1 k8s account providerVersion

### DIFF
--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -961,7 +961,8 @@ class KubernetesConfigurator(Configurator):
     account_params = [options.k8s_account_name]
     account_params.extend([
         '--docker-registries', options.k8s_account_docker_account,
-        '--kubeconfig-file', os.path.basename(options.k8s_account_credentials)
+        '--kubeconfig-file', os.path.basename(options.k8s_account_credentials),
+        '--provider-version', 'v1'
     ])
     if options.k8s_account_context:
       account_params.extend(['--context', options.k8s_account_context])


### PR DESCRIPTION
In order to prepare for the upcoming removal of Spinnaker's Kubernetes V1 provider, we [changed the default for accounts without a `providerVersion` from `v1` to `v2`](https://github.com/spinnaker/halyard/pull/1549). To fix the integration tests, we need to explicitly specify `v1` as the `providerVersion` for the v1 tests.

(Apologies for not anticipating that the `providerVersion` would be unspecified in these tests!)