### PR TITLE
chore(container builds): log the output of gcloud list-tags

### DIFF
--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -70,6 +70,7 @@ class BuildContainerCommand(GradleCommandProcessor):
                '--filter="%s"' % version,
                '--format=json']
     got = check_subprocess(' '.join(command))
+    logging.info("list-tags returned: %s", got)
     if got.strip() != '[]':
       return True
     return False


### PR DESCRIPTION
To debug the issue I mention in spinnaker/spinnaker#5510