### PR TITLE
feat(bintray): publish to bintray from GCB

### DIFF
--- a/dev/buildtool/cloudbuild/README.md
+++ b/dev/buildtool/cloudbuild/README.md
@@ -1,8 +1,9 @@
 ## Google Cloud Build files
 
-The `containers-build-java8` and `containers-tag-java8` files are
+The `containers-build-java8.yml` and `containers-tag-java8.yml` files are
 [Google Cloud Build build configurations](https://cloud.google.com/cloud-build/docs/build-config)
-for building the Spinnaker microservices.
+for building the Spinnaker microservices. Similarly, `debs.yml` is for building
+(and publishing) the Debian packages.
 
 In order to use them, there must be a `save_cache` and `restore_cache` image in
 the Google Container Registry of the project in which the configurations are

--- a/dev/buildtool/cloudbuild/debs.yml
+++ b/dev/buildtool/cloudbuild/debs.yml
@@ -1,0 +1,61 @@
+steps:
+- id: restoreCache
+  name: gcr.io/$PROJECT_ID/restore_cache:latest
+  args:
+  - "--bucket=gs://$_COMPILE_CACHE_BUCKET"
+  - "--key=$_IMAGE_NAME-$_BRANCH_NAME"
+- id: buildCompileImage
+  waitFor: ["restoreCache"]
+  name: gcr.io/cloud-builders/docker
+  args: ["build", "-t", "compile", "-f", "Dockerfile.compile", "."]
+- id: publishDeb
+  waitFor: ["buildCompileImage"]
+  name: compile
+  args:
+  - "./gradlew"
+  - "--stacktrace"
+  - "--info"
+  - "--gradle-user-home=/workspace/.gradle"
+  - "-PbintrayOrg=spinnaker-releases"
+  - "-PbintrayPackageRepo=$_BINTRAY_PACKAGE_REPO"
+  - "-PbintrayJarRepo=$_BINTRAY_JAR_REPO"
+  - "-PbintrayUser=cloud-build@spinnaker-releases"
+  - "-PbintrayPackageDebDistribution=trusty,xenial,bionic"
+  - "-PbintrayPublishWaitForSecs=-1"
+  - "-PenablePublishing=true"
+  - "-Prelease.disableGitChecks=true"
+  - "-Prelease.version=$_VERSION-$_BUILD_NUMBER"
+  - "-PbintrayPackageBuildNumber=$_BUILD_NUMBER"
+  - "-Dorg.gradle.internal.http.socketTimeout=120000"
+  - "-Dorg.gradle.internal.http.connectionTimeout=120000"
+  - "-Dorg.gradle.jvmargs=-Xmx4g"
+  - "-x"
+  - "test"
+  - "-x"
+  - "javadoc"
+  - "candidate"
+  env:
+  - 'ORG_GRADLE_PROJECT_org.gradle.jvmargs=-Xmx4g'
+  secretEnv: ['ORG_GRADLE_PROJECT_bintrayKey']
+- id: saveCache
+  waitFor: ["publishDeb"]
+  name: gcr.io/$PROJECT_ID/save_cache:latest
+  args:
+  - "--bucket=gs://$_COMPILE_CACHE_BUCKET"
+  - "--key=$_IMAGE_NAME-$_BRANCH_NAME"
+  - "--path=.gradle/caches"
+  - "--path=.gradle/wrapper"
+secrets:
+- kmsKeyName: projects/spinnaker-community/locations/global/keyRings/build-secrets/cryptoKeys/build-secrets
+  secretEnv:
+    ORG_GRADLE_PROJECT_bintrayKey:
+      CiQAyyijOXkj3ydSGmPDpXMNOdA4XF9fWVP6yDmyVKB0E9XPGcESUQAZ27TDp+VMDm/CvmTNu55W
+      ffjjgHSh9T3eqPQ9RmnQDOpuUtOxjnpc0RSXxqfvuaqeG7F6fmrX5oLxXIyichHuKyhEE3RMsuxY
+      1kwEo+HO6A==
+timeout: 3600s
+options:
+  machineType: N1_HIGHCPU_8
+substitutions:
+  _COMPILE_CACHE_BUCKET: spinnaker-build-cache
+  _BINTRAY_PACKAGE_REPO: debians
+  _BINTRAY_JAR_REPO: jars

--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -79,21 +79,6 @@ class BuildContainerCommand(GradleCommandProcessor):
     name = repository.name
     options = self.options
 
-    # Local .gradle dir stomps on GCB's .gradle directory when the gradle
-    # wrapper is installed, so we need to delete the local one.
-    # The .gradle dir is transient and will be recreated on the next gradle
-    # build, so this is OK.
-    #
-    # This can still be shared among components as long as the
-    # output directory remains around.
-    git_dir = repository.git_dir
-    # If we're going to delete existing ones, then keep each component
-    # separate so they dont stomp on one another
-    gradle_cache = os.path.abspath(os.path.join(git_dir, '.gradle'))
-
-    if os.path.isdir(gradle_cache):
-      shutil.rmtree(gradle_cache)
-
     cloudbuild_file_name = 'containers-tag-java8.yml'
     if os.path.exists(os.path.join(git_dir, 'Dockerfile.java8')):
       cloudbuild_file_name = 'containers-build-java8.yml'

--- a/dev/buildtool/debian_commands.py
+++ b/dev/buildtool/debian_commands.py
@@ -19,10 +19,12 @@ from threading import Semaphore
 
 from buildtool import (
     BomSourceCodeManager,
+    BranchSourceCodeManager,
     GradleCommandProcessor,
     GradleCommandFactory,
 
     check_options_set,
+    check_subprocesses_to_logfile,
     raise_and_log_error,
     ConfigError)
 
@@ -56,31 +58,65 @@ class BuildDebianCommand(GradleCommandProcessor):
     options = self.options
     name = repository.name
     args = self.gradle.get_common_args()
-    if options.gradle_cache_path:
-      args.append('--gradle-user-home=' + options.gradle_cache_path)
-
-    if (not options.run_unit_tests
-        or (name == 'deck' and not 'CHROME_BIN' in os.environ)):
-      args.append('-x test')
-
-    args.extend(self.gradle.get_debian_args('trusty,xenial,bionic'))
-
+    cloudbuild_config = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), 'cloudbuild', 'debs.yml')
+    service_name = self.scm.repository_name_to_service_name(repository.name)
     source_info = self.scm.lookup_source_info(repository)
-    with self.__semaphore:
-      self.gradle.check_run(args, self, repository, 'candidate', 'debian-build',
-                            source_info.summary.version,
-                            source_info.build_number)
+    command = ('gcloud builds submit '
+               ' --account={account} --project={project}'
+               ' --substitutions='
+               '_IMAGE_NAME={image_name},'
+               '_BRANCH_NAME={branch_name},'
+               '_VERSION={version},'
+               '_BUILD_NUMBER={build_number}'
+               ' --config={cloudbuild_config} .'
+               .format(account=options.gcb_service_account,
+                       project=options.gcb_project,
+                       image_name=service_name,
+                       branch_name=options.git_branch,
+                       version = source_info.summary.version,
+                       build_number = source_info.build_number,
+                       cloudbuild_config=cloudbuild_config))
+
+    logfile = self.get_logfile_path(repository.name + '-gcb-build')
+    labels = {'repository': repository.name}
+    self.metrics.time_call(
+        'DebBuild', labels, self.metrics.default_determine_outcome_labels,
+        check_subprocesses_to_logfile,
+        repository.name + ' deb build', logfile, [command], cwd=repository.git_dir)
+
+
+class BuildDebianFactory(GradleCommandFactory):
+  @staticmethod
+  def add_bom_parser_args(parser, defaults):
+    """Adds publishing arguments of interest to the BOM commands as well."""
+    if hasattr(parser, 'added_debian'):
+      return
+    parser.added_debian = True
+    GradleCommandFactory.add_bom_parser_args(parser, defaults)
+
+  def init_argparser(self, parser, defaults):
+    super(BuildDebianFactory, self).init_argparser(parser, defaults)
+
+    self.add_bom_parser_args(parser, defaults)
+    BranchSourceCodeManager.add_parser_args(parser, defaults)
+    self.add_argument(
+        parser, 'gcb_project', defaults, None,
+        help='The GCP project ID when using the GCP Container Builder.')
+    self.add_argument(
+        parser, 'gcb_service_account', defaults, None,
+        help='Google Service Account when using the GCP Container Builder.')
 
 
 def add_bom_parser_args(parser, defaults):
   """Adds parser arguments pertaining to publishing boms."""
   # These are implemented by the gradle factory, but conceptually
   # for debians, so are exported this way.
-  GradleCommandFactory.add_bom_parser_args(parser, defaults)
+  BuildDebianFactory.add_bom_parser_args(parser, defaults)
 
 
 def register_commands(registry, subparsers, defaults):
-  build_debian_factory = GradleCommandFactory(
+  build_debian_factory = BuildDebianFactory(
       'build_debians', BuildDebianCommand,
       'Build one or more debian packages from the local git repository.',
       BomSourceCodeManager)

--- a/dev/buildtool/flow_build.sh
+++ b/dev/buildtool/flow_build.sh
@@ -45,8 +45,7 @@ function run_build_flow() {
   start_command_unless NO_CONTAINERS "build_bom_containers" \
       $EXTRA_BOM_COMMAND_ARGS --git_branch $BOM_BRANCH
   start_command_unless NO_DEBIANS "build_debians" \
-      $EXTRA_BOM_COMMAND_ARGS \
-      "--max_local_builds=6"
+      $EXTRA_BOM_COMMAND_ARGS --git_branch $BOM_BRANCH
 
   start_command_unless NO_HALYARD "build_halyard" \
       $EXTRA_BUILD_HALYARD_ARGS --git_branch $HAL_BRANCH


### PR DESCRIPTION
In addition to the obvious and previously-discussed benefits, of interest to me is that this uses the same environment (that of the `Dockerfile.compile` container) to compile the containers and the Debian packages.