### PR TITLE
chore(containers): ignore stderr of `gcloud container images list-tags`

### DIFF
--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -18,6 +18,7 @@ import copy
 import logging
 import os
 import shutil
+import subprocess
 
 from buildtool import (
   SPINNAKER_HALYARD_REPOSITORY_NAME,
@@ -69,7 +70,7 @@ class BuildContainerCommand(GradleCommandProcessor):
                options.docker_registry + '/' + image_name,
                '--filter="%s"' % version,
                '--format=json']
-    got = check_subprocess(' '.join(command))
+    got = check_subprocess(' '.join(command), stderr=subprocess.PIPE)
     if got.strip() != '[]':
       return True
     return False


### PR DESCRIPTION
A manual cherry-pick of spinnaker/buildtool#20