### PR TITLE
feat(spinrel): use spinrel to publish BOMs, profiles, and container tags

### DIFF
--- a/dev/buildtool/__init__.py
+++ b/dev/buildtool/__init__.py
@@ -10,7 +10,7 @@ SPINNAKER_RUNNABLE_REPOSITORY_NAMES = [
     'gate', 'igor', 'kayenta', 'orca', 'rosco']
 
 # For building and validating a release
-SPINNAKER_PROCESS_REPOSITORY_NAMES = ['buildtool']
+SPINNAKER_PROCESS_REPOSITORY_NAMES = ['buildtool', 'spinrel']
 
 # Additional tools that accompany a release
 SPIN_REPOSITORY_NAMES = ['spin']


### PR DESCRIPTION
This takes care of tags like `spinnaker-master-20200303124043` and `spinnaker-master-latest-unvalidated`, but doesn't handle `master-latest-validated` or `1.19.2`. For those I have to change the Jenkins jobs directly, so will happen in a fog with no record of my changes. Yay?