### PR TITLE
fix(deploy): Fix base image used in deploy tests

### DIFF
--- a/testing/citest/spinnaker_testing/google_scenario_support.py
+++ b/testing/citest/spinnaker_testing/google_scenario_support.py
@@ -108,7 +108,7 @@ class GoogleScenarioSupport(BaseScenarioPlatformSupport):
     builder.add_argument(
         '--test_gce_image_name',
         default=defaults.get('TEST_GCE_IMAGE_NAME',
-                             'citest-boot-image'),
+                             'apache-base-image'),
         help='Default Google Compute Engine image name to use when'
              ' creating test instances.')
 

--- a/testing/citest/tests/bake_and_deploy_test.py
+++ b/testing/citest/tests/bake_and_deploy_test.py
@@ -371,8 +371,6 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
         'zone': self.bindings['TEST_GCE_ZONE'],
         'network': 'default',
         'instanceMetadata': {
-          'startup-script':
-            'sudo apt-get update && sudo apt-get install apache2 -y',
           'load-balancer-names': self.__full_lb_name
         },
         'tags': [],

--- a/testing/citest/tests/google_http_lb_upsert_scenario.py
+++ b/testing/citest/tests/google_http_lb_upsert_scenario.py
@@ -634,8 +634,6 @@ class GoogleHttpLoadBalancerTestScenario(sk.SpinnakerTestScenario):
           bindings['TEST_GCE_REGION']: [bindings['TEST_GCE_ZONE']]
         },
         'instanceMetadata': {
-          'startup-script': ('sudo apt-get update'
-                             ' && sudo apt-get install apache2 -y'),
           'global-load-balancer-names': self.__lb_name,
           'backend-service-names': 'bs-' + self.TEST_APP,
           'load-balancing-policy': json.dumps(policy)

--- a/testing/citest/tests/google_smoke_test.py
+++ b/testing/citest/tests/google_smoke_test.py
@@ -283,8 +283,6 @@ class GoogleSmokeTestScenario(sk.SpinnakerTestScenario):
                 bindings['TEST_GCE_REGION']: [bindings['TEST_GCE_ZONE']]
             },
             'instanceMetadata': {
-                'startup-script': ('sudo apt-get update'
-                                   ' && sudo apt-get install apache2 -y'),
                 'load-balancer-names': self.__lb_name
             },
             'account': bindings['SPINNAKER_GOOGLE_ACCOUNT'],


### PR DESCRIPTION
The tests to deploy a server group to GCE take a base image, then use a startup script to install apache using apt. At some point recently, the command to install apache started pausing for user
input (despite passing the -y flag to apt-get install), meaning that the startup script would hang forever, and the health check waiting for the instance to respond on port 80 would also hang forever. This was making tests of deploying to GCE fail.

In general, a pre-baked image should have all of the dependencies already installed. I've made a new image called apache-base-image, which is just Debian 10 with apache2 already installed and configured. Let's use this image in the tests instead of installing apache as a startup script, which is both less hermetic and less similar to the common use case we'd like to support.

This PR updates the image name and removes the startup script.