### PR TITLE
fix(citest): Revert change to make instance pre-emptible

### DIFF
--- a/dev/validate_bom__deploy.py
+++ b/dev/validate_bom__deploy.py
@@ -1431,7 +1431,6 @@ class GoogleValidateBomDeployer(GenericVmValidateBomDeployer):
         ' --project {project} --zone {zone}'
         ' --network {network}'
         ' --tags {network_tags}'
-        ' --preemptible'
         ' --scopes {scopes}'
         ' {instance}'
         .format(gcloud_account=options.deploy_hal_google_service_account,


### PR DESCRIPTION
This reverts commit 414bc35231609acbefc5dbe3cb362a5ff728aacc.

The change to make instances pre-emptible appears to be adding to an unacceptable level of flakiness in the integration tests.