### PR TITLE
feat(kubernetes): run distributed install on kubernetes v2

### DIFF
--- a/dev/validate_bom__deploy.py
+++ b/dev/validate_bom__deploy.py
@@ -47,6 +47,7 @@ from buildtool import (
 
 
 SUPPORTED_DEPLOYMENT_TYPES = ['localdebian', 'distributed']
+# TODO(mneterval): remove 'kubernetes' (V1) support after Spinnaker release 1.21
 SUPPORTED_DISTRIBUTED_PLATFORMS = ['kubernetes', 'kubernetes_v2']
 HALYARD_SERVICES = ['halyard']
 SPINNAKER_SERVICES = [
@@ -1586,7 +1587,7 @@ def init_argument_parser(parser, defaults):
            ' This is used to scp and ssh from this machine.')
 
   add_parser_argument(
-      parser, 'deploy_distributed_platform', defaults, 'kubernetes',
+      parser, 'deploy_distributed_platform', defaults, 'kubernetes_v2',
       choices=SUPPORTED_DISTRIBUTED_PLATFORMS,
       help='The platform to deploy spinnaker to when'
            ' --deploy_spinnaker_type=distributed')


### PR DESCRIPTION
Currently, the end-to-end tests run against a `Distributed` installation of Spinnaker on a V1 provider account. Let's switch them to use the V2 installation path.