### PR TITLE
fix(kubernetes): Fix race condition in V2 deployment

### DIFF
--- a/dev/validate_bom__deploy.py
+++ b/dev/validate_bom__deploy.py
@@ -445,9 +445,25 @@ class KubernetesValidateBomDeployer(BaseValidateBomDeployer):
                           .format(options.injected_deploy_spinnaker_account)))
     options.injected_deploy_spinnaker_account = options.k8s_account_name
 
+  def __wait_for_deployment(self, k8s_namespace, service):
+    options = self.options
+    kubectl_command = 'kubectl {context} wait deployment/spin-{service} --timeout=300s --for=condition=available  --namespace {namespace}'.format(
+        context=('--context {0}'.format(options.k8s_account_context)
+                 if options.k8s_account_context
+                 else ''),
+        service=service,
+        namespace=k8s_namespace)
+    retcode, stdout = run_subprocess(kubectl_command)
+    if retcode != 0:
+      message = 'Timed out waiting for deployment to be available for service "{service}".: {error}'.format(
+        service=service,
+        error=stdout.strip())
+      raise_and_log_error(ExecutionError(message, program='kubectl'))
+
   def __get_pod_name(self, k8s_namespace, service):
     """Determine the pod name for the deployed service."""
     options = self.options
+    self.__wait_for_deployment(k8s_namespace, service)
     flags = ' --namespace {namespace} --logtostderr=false'.format(
         namespace=k8s_namespace)
     label_selector = '-l app.kubernetes.io/name={service}'.format(


### PR DESCRIPTION
* fix(kubernetes): Fix race condition in V2 deployment 

  When deploying using the V2 provider, control is ceded back to the CI tests once the deployments have been applied, whether or not they are stable yet.  This is causing errors on setting up port forwarding, as the pods are sometimes not running when we try to forward to them. To address this, let's block on deployment availability before trying to port forward.
