### PR TITLE
refactor(kubernetes): remove V1 deployer logic

### DIFF
--- a/dev/all_tests.yaml
+++ b/dev/all_tests.yaml
@@ -195,6 +195,7 @@ tests:
     args:
       alias: [standard_google_provider_params]
 
+  # TODO(mneterval): remove after 1.20 release branches are cut
   kube_smoke_test:
     requires:
       configuration:

--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -921,7 +921,7 @@ class KubernetesV2Configurator(Configurator):
     if options.k8s_v2_account_credentials:
       file_set.add(options.k8s_v2_account_credentials)
 
-
+# TODO(mneterval): remove after 1.20 release branches are cut
 class KubernetesConfigurator(Configurator):
   """Controls hal config provider kubernetes."""
 

--- a/testing/citest/tests/kube_smoke_test.py
+++ b/testing/citest/tests/kube_smoke_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO(mneterval): remove after 1.20 release branches are cut
 """
 Integration test to see if the image promotion process is working for the
 Spinnaker Kubernetes integration.


### PR DESCRIPTION
- **refactor(kubernetes): remove V1 deployer logic**

  Remove the Kubernetes V1 provider as one of the `SUPPORTED_DISTRIBUTED_PLATFORMS` for deploying Spinnaker. Master and all future release branches will only deploy Spinnaker using the V2 provider.

- **chore(kubernetes): add todos for V1 tests to be removed**

  1.20 will be the last Spinnaker release to include support for the V1 provider. After the 1.20 release branches are cut, we can remove all of the logic supporting the V1 `kube_smoke_test`. Adds todos above blocks to be removed as part of this cleanup.