### PR TITLE
chore(build): Update docs site changelog generation

### DIFF
--- a/dev/buildtool/changelog_commands.py
+++ b/dev/buildtool/changelog_commands.py
@@ -467,7 +467,8 @@ class PublishChangelogCommand(RepositoryCommandProcessor):
     changelog_filename = '{version}-changelog.md'.format(version=version)
     target_path = os.path.join(repository.git_dir,
                                '_changelogs', changelog_filename)
-    major, minor, _ = version.split('.')
+    major, minor, patch = version.split('.')
+    patch = int(patch)
     logging.debug('Adding changelog file %s', target_path)
     with open(target_path, 'w') as f:
       # pylint: disable=trailing-whitespace
@@ -485,8 +486,12 @@ class PublishChangelogCommand(RepositoryCommandProcessor):
               timestamp=timestamp,
               major=major, minor=minor))
       f.write(header)
-      f.write('<script src="%s.js"/>' % self.options.changelog_gist_url)
-      f.write('\n')
+      for i in reversed(range(patch + 1)):
+        patchVersion = '.'.join([major, minor, str(i)])
+        f.write('<script src="{gist_url}.js?file={version}.md"></script>'.format(
+            gist_url=self.options.changelog_gist_url,
+            version=patchVersion))
+        f.write('\n')
 
     return target_path
 


### PR DESCRIPTION
Instead of making a new gist for each patch release, we'll now use a single top-level gist for each minor release, and put the release notes for each patch version in a separate file in the gist (ex: 1.18.0.md, 1.19.1.md).

We'll no longer copy-paste the prior release's full changelog into each patch release's changes. Instead, we'll just refer to all prior patch releases by reference in the docs site, avoiding a lot of copy-paste and duplication.  (And if ever we needed to amend the release notes for an old version we'd currently need to do that everywhere it was copy-pasted but now only in one place.)

This commit updates the code that generates the new file in spinnaker.github.io to pull in the new changelog. It pulls in reverse order the file corresponding to every patch release in the current minor version. It also fixes the fact that we were incorrectly using a self-closing tag for the script element which is not allowed.