### PR TITLE
fix(buildtool): Push changelog command should pull origin

### DIFF
--- a/dev/buildtool/changelog_commands.py
+++ b/dev/buildtool/changelog_commands.py
@@ -580,6 +580,7 @@ class PushChangelogCommand(CommandProcessor):
       logging.debug('Updating gist in "%s"', git_dir)
       self.git_run_with_retries(git_dir, 'fetch origin master')
       self.git_run_with_retries(git_dir, 'checkout master')
+      self.git_run_with_retries(git_dir, 'reset --hard origin/master')
 
     dest_path = os.path.join(
         git_dir, '%s-raw-changelog.md' % options.git_branch)
@@ -591,7 +592,7 @@ class PushChangelogCommand(CommandProcessor):
         git_dir, '-a -m "Updated %s"' % os.path.basename(dest_path))
 
     logging.debug('Pushing back gist')
-    self.git_run_with_retries(git_dir, 'push -f origin master')
+    self.git_run_with_retries(git_dir, 'push origin master')
 
 
   # For some reason gist.github.com seems to have a lot of connection timeout


### PR DESCRIPTION
I was trying to figure out why any manual changes I made to the raw changelog (notably deleting the no-longer-needed 1.14, 1.15, 1.16 entries) were disappearing.  It turns out that while we fetch the origin commit, we don't do anything with it, and commit on top of what's currently on the jenkins machine, then force push that to the origin.

Instead, just reset master to origin/master before making any changes. There should not be any local changes in this directory; if there are, it would be from an error in some prior run, and we'd rather just start fresh (as we do in the first block where we just clone).

Also remove the force push; if the origin *has* changed since we fetched a few lines above, let's fail rather than overwrite what's there.