### PR TITLE
chore(build): Automatically create release notes when publishing

### DIFF
--- a/dev/buildtool/changelog_commands.py
+++ b/dev/buildtool/changelog_commands.py
@@ -565,7 +565,7 @@ class CreateReleaseChangelogFactory(CommandFactory):
         help='The Spinnaker version for which we are creating a changelog.')
     self.add_argument(
         parser, 'build_changelog_gist_url', defaults, None,
-        help='The gist containing raw the raw changelog.')
+        help='The gist containing the raw changelog.')
     self.add_argument(
         parser, 'changelog_gist_url', defaults, None,
         help='The gist to which to push the release changelog.')


### PR DESCRIPTION
One of the more tedious aspects of cutting a new patch release is logging into github as spinnaker-release, creating a new gist, and copy-pasting some information into that gist. Instead of having the release manager do this manually expose a command in the buildtool to do this, so it can be called directly as part of the Jenkins job.

This change now exposes a command that creates a new file in the minor release's gist, adds a title with the Spinnaker version, then copies over the raw changelog for the corresponding branch. (This builds on the prior changes, which moved to using the same top-level gist for all patch releases of a given minor version, and updated the changelog generation to stop outputting "No changes" for unchanged services.)

The command will short-circuit with a log message if the version being released is not a patch release; for these releases, we add manually-curated notes to the top, so the creation of this will still be done by hand.

The workflow for the release manager will be:
* For the initial release, make a top-level gist with a file
  (ex: 1.19.0.md) containing the curated release notes as well as the full changelog. This will still be done manually, and this command will not affect that gist when releasing a *.0 version.
* For any future patch release, just pass in the uri of the same gist to the Publish_SpinnakerRelease job. It will create a new file in the gist (ex: 1.19.1.md) containing the release notes for that minor release based on the raw changelog, and will update spinnaker.github.io to point to these release notes. It should not be necessary to log in as spinnaker-release at all (though of course this is still possible if manual edits beyond what is automatically generated are needed).