### PR TITLE
chore(release): Auto-deprecate last patch release

### DIFF
--- a/dev/buildtool/hal_support.py
+++ b/dev/buildtool/hal_support.py
@@ -132,6 +132,11 @@ class HalRunner(object):
     logging.info('Publishing latest halyard version "%s"', release_version)
     self.check_run('admin publish latest-halyard ' + release_version)
 
+  def deprecate_spinnaker_release(self, release_version):
+    """Deprecate release_version."""
+    logging.info('Deprecating Spinnaker version "%s"', release_version)
+    self.check_run('admin deprecate version --version ' + release_version)
+
   def publish_spinnaker_release(
       self, release_version, alias_name, changelog_uri, min_halyard_version,
       latest=True):

--- a/dev/buildtool/spinnaker_commands.py
+++ b/dev/buildtool/spinnaker_commands.py
@@ -300,8 +300,19 @@ class PublishSpinnakerCommand(CommandProcessor):
         spinnaker_version, options.spinnaker_release_alias, changelog_gist_url,
         options.min_halyard_version)
 
+    prior_version = get_prior_version(spinnaker_version)
+    if prior_version != None:
+      self.__hal.deprecate_spinnaker_release(prior_version)
+
     logging.info('Publishing changelog')
     publish_changelog_command()
+
+def get_prior_version(version):
+  major, minor, patch = version.split('.')
+  patch = int(patch)
+  if patch == 0:
+    return None
+  return '.'.join([major, minor, str(patch - 1)])
 
 
 def register_commands(registry, subparsers, defaults):


### PR DESCRIPTION
One of the manual steps in doing a patch release of Spinnaker is to manually run hal admin deprecate ... to deprecate the prior patch release. Instead of having this as a manual step in the runbook, just run this automatically after publishing the new release.

If this is not a patch release (ie, 1.X.0) then this will not deprecate anything. It will still be a manual step to deprecate the last patch release of the N-3 minor release when releasing a new minor release (both by running the hal admin deprecate command and by marking the changelog as deprecated on spinnaker.io). But as that only happens once every two months, while we often do several patch releases a week (over the three supported versions) this should significantly cut back on toil and human error. (Not that I have ever accidentally deprecated the wrong release...😬.)