### PR TITLE
fix(changelog): Changelog generation should use origin/master

### DIFF
--- a/dev/buildtool/git_support.py
+++ b/dev/buildtool/git_support.py
@@ -830,7 +830,7 @@ class GitRunner(object):
     # Get the master commit so we can use it in the merge-base call below.
     # If we checked out some branch other than master, we might not have
     # the actual branch so cannot use the symbolic name.
-    master_commit = self.check_run(git_dir, 'show-ref master').split(' ')[0]
+    master_commit = self.check_run(git_dir, 'show-ref origin/master').split(' ')[0]
     logging.debug('  master_commit=%s may be used to locate the branch.', master_commit)
 
     # Find branch our commit is on. There could be multiple branches.


### PR DESCRIPTION
The changelog generation is using the master branch as part of its logic to compute what changes are part of a particular build; while we fetch origin/master every time the build runs, we never update the local master with the changes, so it is currently very out of date on the Jenkins machine. Rather than rely on this local branch, just refer to origin/master directly.