### PR TITLE
chore(mergify): Add mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,23 @@
+pull_request_rules:
+  - name: Automatically merge on review
+    conditions:
+      - base=master
+      - "label=ready to merge"
+      - "approved-reviews-by=@oss-approvers"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+      label:
+        add: ["auto merged"]
+  - name: Automatically merge release branch changes on release manager review
+    conditions:
+      - base~=^release-
+      - "label=ready to merge"
+      - "approved-reviews-by=@release-managers"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+      label:
+        add: ["auto merged"]


### PR DESCRIPTION
There was no mergify config for this repo; add one, copying the same template
that is in other repos (including the pending changes to require a release
manager to sign off on release branch changes).

As there does not seem to be any CI set up for the repo, I did not include
that condition in the mergify config, though of course we can add that
as a condition (and likely also at the Github branch level) if we do
ever add that.