### PR TITLE
fix(halyard release): ignore invalid lines from `gsutil cat`

### DIFF
--- a/dev/buildtool/subprocess_support.py
+++ b/dev/buildtool/subprocess_support.py
@@ -93,7 +93,7 @@ def wait_subprocess(process, stream=None, echo=False, postprocess_hook=None):
     log_level = logging.INFO if echo else logging.DEBUG
     # stderr isn't going to another file handle; log it
     for raw_line in iter(process.stderr.readline, ''):
-      decoded_line = raw_line.decode(encoding='utf-8')
+      decoded_line = raw_line.decode(encoding='utf-8').rstrip('\n')
       logging.log(log_level, 'PID %s wrote to stderr: %s', process.pid, decoded_line)
 
    


### PR DESCRIPTION
More details are in your Release manager notes (seemed like the best place for them, hope that's okay) but I can reproduce this "warnings on stdout" issue on my workstation, so it seems like a genuine `gsutil` bug and not something wrong with the Jenkins box. :man_shrugging: 