### PR TITLE
chore(containers): don't save the cache until the end

### DIFF
--- a/dev/buildtool/cloudbuild/containers-build-java8.yml
+++ b/dev/buildtool/cloudbuild/containers-build-java8.yml
@@ -11,14 +11,6 @@ steps:
   - id: compile
     waitFor: ["buildCompileImage"]
     name: compile
-  - id: saveCache
-    waitFor: ["compile"]
-    name: gcr.io/$PROJECT_ID/save_cache:latest
-    args:
-      - "--bucket=gs://$_COMPILE_CACHE_BUCKET"
-      - "--key=$_IMAGE_NAME-$_BRANCH_NAME"
-      - "--path=.gradle/caches"
-      - "--path=.gradle/wrapper"
   - id: buildSlimImage
     waitFor: ["compile"]
     name: gcr.io/cloud-builders/docker
@@ -56,6 +48,14 @@ steps:
             "-f", "Dockerfile.ubuntu-java8",
             ".",
           ]
+  - id: saveCache
+    waitFor: ["buildSlimImage", "buildUbuntuImage", "buildJava8Image", "buildUbuntuJava8Image"]
+    name: gcr.io/$PROJECT_ID/save_cache:latest
+    args:
+      - "--bucket=gs://$_COMPILE_CACHE_BUCKET"
+      - "--key=$_IMAGE_NAME-$_BRANCH_NAME"
+      - "--path=.gradle/caches"
+      - "--path=.gradle/wrapper"
 images:
   - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME
   - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim

--- a/dev/buildtool/cloudbuild/containers-tag-java8.yml
+++ b/dev/buildtool/cloudbuild/containers-tag-java8.yml
@@ -11,14 +11,6 @@ steps:
   - id: compile
     waitFor: ["buildCompileImage"]
     name: compile
-  - id: saveCache
-    waitFor: ["compile"]
-    name: gcr.io/$PROJECT_ID/save_cache:latest
-    args:
-      - "--bucket=gs://$_COMPILE_CACHE_BUCKET"
-      - "--key=$_IMAGE_NAME-$_BRANCH_NAME"
-      - "--path=.gradle/caches"
-      - "--path=.gradle/wrapper"
   - id: buildSlimImage
     waitFor: ["compile"]
     name: gcr.io/cloud-builders/docker
@@ -40,6 +32,14 @@ steps:
             "-f", "Dockerfile.ubuntu",
             ".",
           ]
+  - id: saveCache
+    waitFor: ["buildSlimImage", "buildUbuntuImage"]
+    name: gcr.io/$PROJECT_ID/save_cache:latest
+    args:
+      - "--bucket=gs://$_COMPILE_CACHE_BUCKET"
+      - "--key=$_IMAGE_NAME-$_BRANCH_NAME"
+      - "--path=.gradle/caches"
+      - "--path=.gradle/wrapper"
 images:
   - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME
   - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim


### PR DESCRIPTION
The problem with saving the cache in parallel with building the
containers is that docker tries to include the cache file in the build
context, but the file is still being written as the context is being
prepared. This leads to this error:

> Can't add file /workspace/clouddriver-master.tgz to tar: archive/tar: write too long

It's essentially harmless since we don't want that file in the context
anyway, but still.