### PR TITLE
fix(version): Ignore whitespace in semantic commits

### DIFF
--- a/dev/buildtool/git_support.py
+++ b/dev/buildtool/git_support.py
@@ -322,7 +322,7 @@ class CommitMessage(
       # Some tags indicate only a patch release.
       re.compile(r'^\s*'
                  r'(?:\*\s+)?'
-                 r'((?:fix|bug|chore|docs?|perf|refactor|test)[\(:].*)',
+                 r'((?:fix|bug|chore|docs?|perf|refactor|test)\s*[\(:].*)',
                  re.MULTILINE)
   ]
   DEFAULT_MINOR_REGEXS = [
@@ -331,7 +331,7 @@ class CommitMessage(
       # implementation changes that suggest a higher level of risk.
       re.compile(r'^\s*'
                  r'(?:\*\s+)?'
-                 r'((?:feat|feature|config)[\(:].*)',
+                 r'((?:feat|feature|config)\s*[\(:].*)',
                  re.MULTILINE)
   ]
   DEFAULT_MAJOR_REGEXS = [


### PR DESCRIPTION
A commit was added to the 1.18 branch that had a title 'fix (...)' (note the space after 'fix'). This broke the regex that should have only incremented the patch version 😭😭😭. Allow whitespace, and hope that now I can release 1.18.x.