### PR TITLE
fix(test): Reduce logging for GKE tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 .pyre/
 
 .idea/
+*.iml
+*.ipr
+*.iws

--- a/dev/validate_bom__test.py
+++ b/dev/validate_bom__test.py
@@ -508,10 +508,8 @@ class ValidateBomTestController(object):
       def run(self):
         while True:
           try:
-            logging.info('KeepAlive %s polling', service_name)
-            got = urlopen('http://localhost:{port}/health'
+            urlopen('http://localhost:{port}/health'
                           .format(port=local_port))
-            logging.info('KeepAlive %s -> %s', service_name, got.getcode())
           except Exception as ex:
             logging.info('KeepAlive %s -> %s', service_name, ex)
 


### PR DESCRIPTION
Most of the logs for the GKE tests are continued polling of the services to keep the tunnel alive; remove the logging for successful polls and only print when there's an error.