### PR TITLE
fix(containers): Don't check for java8 containers

### DIFF
--- a/dev/buildtool/cloudbuild/README.md
+++ b/dev/buildtool/cloudbuild/README.md
@@ -1,9 +1,9 @@
 ## Google Cloud Build files
 
-The `containers-build-java8.yml` and `containers-tag-java8.yml` files are
+The `containers.yml` and `debs.yml` files are
 [Google Cloud Build build configurations](https://cloud.google.com/cloud-build/docs/build-config)
-for building the Spinnaker microservices. Similarly, `debs.yml` is for building
-(and publishing) the Debian packages.
+for building and publishing the Spinnaker microservice containers and Debian
+packages.
 
 In order to use them, there must be a `save_cache` and `restore_cache` image in
 the Google Container Registry of the project in which the configurations are

--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -46,7 +46,7 @@ class BuildContainerCommand(GradleCommandProcessor):
     image_name = self.scm.repository_name_to_service_name(repository.name)
     version = self.scm.get_repository_service_build_version(repository)
 
-    for variant in ('slim', 'ubuntu', 'java8', 'ubuntu-java8'):
+    for variant in ('slim', 'ubuntu'):
       tag = "{version}-{variant}".format(version=version, variant=variant)
       if not self.__gcb_image_exists(image_name, tag):
         return False


### PR DESCRIPTION
This was causing every microservice container to be built on every Build_PrimaryArtifacts run, even if there were no changes, since it was looking for java8 containers that were missing.

I don't know why I didn't just search the repo for java8, but I think this is the last of it :/