### PR TITLE
fix(gradle): adds version property for newer gradle project

### DIFF
--- a/dev/buildtool/cloudbuild/debs.yml
+++ b/dev/buildtool/cloudbuild/debs.yml
@@ -25,6 +25,7 @@ steps:
   - "-PenablePublishing=true"
   - "-Prelease.disableGitChecks=true"
   - "-Prelease.version=$_VERSION-$_BUILD_NUMBER"
+  - "-Pversion=$_VERSION-$_BUILD_NUMBER"
   - "-PbintrayPackageBuildNumber=$_BUILD_NUMBER"
   - "-Dorg.gradle.internal.http.socketTimeout=120000"
   - "-Dorg.gradle.internal.http.connectionTimeout=120000"

--- a/dev/buildtool/gradle_support.py
+++ b/dev/buildtool/gradle_support.py
@@ -355,6 +355,7 @@ class GradleRunner(object):
     if self.__is_plugin_version_6(repository):
       args.extend(['-PenablePublishing=true',
                    '-Prelease.disableGitChecks=true',
+                   '-Pversion=%s-%s' % (version, build_number),
                    '-Prelease.version=%s-%s' % (version, build_number)])
     else:
       args.append('-Prelease.useLastTag=true')


### PR DESCRIPTION
This change works with both the 7.x gradle plugins, and 8.x newer plugin, at some point we can come
back and remove the unnecessary flags for 8.x but for now they don't affect the build so they are
harmless