### PR TITLE
feat(gcb): add some tags to our cloud builds

### DIFF
--- a/dev/buildtool/cloudbuild/containers.yml
+++ b/dev/buildtool/cloudbuild/containers.yml
@@ -42,8 +42,10 @@ images:
   - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME
   - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim
   - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu
+tags: ["type_containers", "repo_$_IMAGE_NAME", "branch_$_BRANCH_TAG"]
 timeout: 3600s
 options:
   machineType: N1_HIGHCPU_8
 substitutions:
   _COMPILE_CACHE_BUCKET: spinnaker-build-cache
+  _BRANCH_TAG: unknown

--- a/dev/buildtool/cloudbuild/debs.yml
+++ b/dev/buildtool/cloudbuild/debs.yml
@@ -50,6 +50,7 @@ secrets:
       CiQAyyijOXkj3ydSGmPDpXMNOdA4XF9fWVP6yDmyVKB0E9XPGcESUQAZ27TDp+VMDm/CvmTNu55W
       ffjjgHSh9T3eqPQ9RmnQDOpuUtOxjnpc0RSXxqfvuaqeG7F6fmrX5oLxXIyichHuKyhEE3RMsuxY
       1kwEo+HO6A==
+tags: ["type_debs", "repo_$_IMAGE_NAME", "branch_$_BRANCH_TAG"]
 timeout: 3600s
 options:
   machineType: N1_HIGHCPU_8
@@ -57,3 +58,4 @@ substitutions:
   _COMPILE_CACHE_BUCKET: spinnaker-build-cache
   _BINTRAY_PACKAGE_REPO: debians
   _BINTRAY_JAR_REPO: jars
+  _BRANCH_TAG: unknown

--- a/dev/buildtool/cloudbuild/halyard-tars.yml
+++ b/dev/buildtool/cloudbuild/halyard-tars.yml
@@ -49,9 +49,11 @@ steps:
   - "--key=$_IMAGE_NAME-$_BRANCH_NAME"
   - "--path=.gradle/caches"
   - "--path=.gradle/wrapper"
+tags: ["type_tars", "repo_$_IMAGE_NAME", "branch_$_BRANCH_TAG"]
 timeout: 3600s
 options:
   machineType: N1_HIGHCPU_8
 substitutions:
   _HALYARD_BUCKET: spinnaker-artifacts
   _COMPILE_CACHE_BUCKET: spinnaker-build-cache
+  _BRANCH_TAG: unknown

--- a/dev/buildtool/halyard_commands.py
+++ b/dev/buildtool/halyard_commands.py
@@ -180,10 +180,12 @@ class BuildHalyardCommand(GradleCommandProcessor):
 
   def gcloud_command(self, name, config_filename, git_dir, substitutions):
     options = self.options
+    branch = options.git_branch
     config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                'cloudbuild', config_filename)
-    standard_substitutions = {'_IMAGE_NAME': 'halyard',
-                              '_BRANCH_NAME': options.git_branch}
+    standard_substitutions = {'_BRANCH_NAME': branch,
+                              '_BRANCH_TAG': re.sub(r'\W', '_', branch),
+                              '_IMAGE_NAME': 'halyard'}
     full_substitutions = dict(standard_substitutions, **substitutions)
     # Convert it to the format expected by gcloud: "_FOO=bar,_BAZ=qux"
     substitutions_arg = ','.join('='.join((str(k), str(v))) for k, v in


### PR DESCRIPTION
This allows us to find builds a little easier in the GCB history dashboard. It has a lot of useful filters but they're pretty much all based on the CI trigger. Since we don't trigger from a commit, we can't really use any of them. But we can use tags!