### PR TITLE
chore(tests): Use libatm1 instead of vim, as we think it may have few…

### DIFF
--- a/testing/citest/tests/bake_and_deploy_test.py
+++ b/testing/citest/tests/bake_and_deploy_test.py
@@ -425,7 +425,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     name = 'BakeDocker'
     self.docker_pipeline_id = name
     bake_stage = self.make_bake_stage(
-        package='vim', providerType='docker', region='global')
+        package='libatm1', providerType='docker', region='global')
 
     pipeline_spec = dict(
       name=name,
@@ -455,7 +455,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     name = 'BakeAndDeployGoogle'
     self.google_bake_pipeline_id = name
     bake_stage = self.make_bake_stage(
-        package='vim', providerType='gce', region='global')
+        package='libatm1', providerType='gce', region='global')
     deploy_stage = self.make_deploy_google_stage(requisiteStages=['BAKE'])
 
     pipeline_spec = dict(
@@ -520,7 +520,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     name = 'BakeAndDeployAws'
     self.aws_bake_pipeline_id = name
     bake_stage = self.make_bake_stage(
-        package='vim',
+        package='libatm1',
         providerType='aws',
         regions=[self.bindings['TEST_AWS_REGION']],
         vmType='hvm', storeType='ebs')


### PR DESCRIPTION
…er revisions.

Some more context: Occasionally, we'd get build test failures because the `bake_and_deploy_test` requires a specific version of a software package from a Jenkins trigger (that version was previously `vim_2:7.4.1689-3ubuntu1.4_amd64.deb`. When this version gets updated, our tests fail because this specific version is no longer available.

We think the `libatm1` package is much more stable and updated less often - https://packages.ubuntu.com/search?suite=xenial&searchon=names&keywords=libatm1 makes it look like it only gets updated during each major version release.