### PR TITLE
feat(containers): Start checking for containers in Google Artifact Registry

### DIFF
--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -65,9 +65,11 @@ class BuildContainerCommand(GradleCommandProcessor):
   def __gcb_image_exists(self, image_name, version):
     """Determine if gcb image already exists."""
     options = self.options
-    command = ['gcloud', '--account', options.gcb_service_account,
-               'container', 'images', 'list-tags',
+    command = ['gcloud', 'beta',
+               '--account', options.gcb_service_account,
+               'artifacts', 'docker', 'images', 'list',
                options.docker_registry + '/' + image_name,
+               '--include-tags',
                '--filter="%s"' % version,
                '--format=json']
     got = check_subprocess(' '.join(command), stderr=subprocess.PIPE)


### PR DESCRIPTION
The local `docker_registry` value on the Jenkins machine will be updated from `gcr.io/spinnaker-community` to `us-docker.pkg.dev/spinnaker-community/nightly`. 

If merged as is, this would have be to cherry picked back to the previous release branches too, since they also share the docker_regsistry setting.

The `spinrel` tool should probably also be updated to move candidate containers from `nightly` registry to the `releases` registry