### PR TITLE
feat(containers): Start publishing containers to Artifact Registry

### DIFF
--- a/dev/buildtool/cloudbuild/containers.yml
+++ b/dev/buildtool/cloudbuild/containers.yml
@@ -18,6 +18,8 @@ steps:
             "build",
             "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME",
             "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim",
+            "-t", "$_ARTIFACT_REGISTRY/$_IMAGE_NAME:$TAG_NAME",
+            "-t", "$_ARTIFACT_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim",
             "-f", "Dockerfile.slim",
             ".",
           ]
@@ -27,6 +29,7 @@ steps:
     args: [
             "build",
             "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu",
+            "-t", "$_ARTIFACT_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu",
             "-f", "Dockerfile.ubuntu",
             ".",
           ]
@@ -42,6 +45,10 @@ images:
   - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME
   - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim
   - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu
+  - $_ARTIFACT_REGISTRY/$_IMAGE_NAME:$TAG_NAME
+  - $_ARTIFACT_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim
+  - $_ARTIFACT_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu
+
 tags: ["type_containers", "repo_$_IMAGE_NAME", "branch_$_BRANCH_TAG"]
 timeout: 3600s
 options:
@@ -49,3 +56,4 @@ options:
 substitutions:
   _COMPILE_CACHE_BUCKET: spinnaker-build-cache
   _BRANCH_TAG: unknown
+  _ARTIFACT_REGISTRY: us-docker.pkg.dev/spinnaker-community/nightly


### PR DESCRIPTION
This allows us to start working on migrating containers from `spinnaker-marketplace` to Google Artifact Registries in `spinnaker-community`