### PR TITLE
feat(containers): Use Artifact Registry as primary source & destinati…

### DIFF
--- a/dev/buildtool/bom_commands.py
+++ b/dev/buildtool/bom_commands.py
@@ -175,7 +175,7 @@ class BomBuilder(object):
         name: source
         for name, source in [
             ('debianRepository', debian_repository),
-            ('dockerRegistry', options.docker_registry),
+            ('dockerRegistry', options.artifact_registry),
             ('googleImageProject', options.publish_gce_image_project)
         ]
         if source

--- a/dev/buildtool/halyard_commands.py
+++ b/dev/buildtool/halyard_commands.py
@@ -161,16 +161,20 @@ class BuildHalyardCommand(GradleCommandProcessor):
                             config_filename='containers.yml',
                             git_dir=git_dir,
                             substitutions={'TAG_NAME': self.__build_version,
-                                           '_DOCKER_REGISTRY': options.docker_registry}),
+                                           '_DOCKER_REGISTRY': options.docker_registry,
+                                           '_ARTIFACT_REGISTRY': options.artifact_registry,
+                                           '_COMPILE_CACHE_BUCKET': options.gcb_cache_bucket}),
         self.gcloud_command(name='halyard-deb-build',
                             config_filename='debs.yml',
                             git_dir=git_dir,
                             substitutions={'_VERSION': summary.version,
-                                           '_BUILD_NUMBER': options.build_number}),
+                                           '_BUILD_NUMBER': options.build_number,
+                                           '_COMPILE_CACHE_BUCKET': options.gcb_cache_bucket}),
         self.gcloud_command(name='halyard-tar-build',
                             config_filename='halyard-tars.yml',
                             git_dir=git_dir,
-                            substitutions={'TAG_NAME': self.__build_version}),
+                            substitutions={'TAG_NAME': self.__build_version,
+                                           '_COMPILE_CACHE_BUCKET': options.gcb_cache_bucket}),
     ]
 
     pool = ThreadPool(len(commands))
@@ -306,6 +310,12 @@ class BuildHalyardFactory(GradleCommandFactory):
     self.add_argument(
         parser, 'docker_registry', defaults, None,
         help='Docker registry to push the container images to.')
+    self.add_argument(
+        parser, 'artifact_registry', defaults, None,
+        help='Artifact registry to push the container images to.')
+    self.add_argument(
+        parser, 'gcb_cache_bucket', defaults, "spinnaker-build-cache",
+        help='Google Storage Bucket for build caches when using the GCP Container Builder.')
 
 
 class PublishHalyardCommandFactory(CommandFactory):
@@ -366,8 +376,8 @@ class PublishHalyardCommandFactory(CommandFactory):
         parser, 'gcb_service_account', defaults, None,
         help='Google Service Account when using the GCP Container Builder.')
     self.add_argument(
-        parser, 'docker_registry', defaults, None,
-        help='Docker registry to push the container images to.')
+        parser, 'artifact_registry', defaults, None,
+        help='Artifact registry to push the container images to.')
 
 
 class PublishHalyardCommand(CommandProcessor):

--- a/unittest/buildtool/bom_command_test.py
+++ b/unittest/buildtool/bom_command_test.py
@@ -62,7 +62,7 @@ def make_default_options(options):
   options.build_number = 'OptionBuildNumber'
   options.bintray_org = 'test-bintray-org'
   options.bintray_debian_repository = 'test-debian-repo'
-  options.docker_registry = 'test-docker-registry'
+  options.artifact_registry = 'test-docker-registry'
   options.publish_gce_image_project = 'test-image-project-name'
   options.github_upstream_owner = 'spinnaker'
   return options
@@ -279,7 +279,7 @@ class TestBomBuilder(BaseGitRepoTestFixture):
     golden_bom['artifactSources'] = {
       'debianRepository': 'https://dl.bintray.com/%s/%s' % (
           options.bintray_org, options.bintray_debian_repository),
-      'dockerRegistry': options.docker_registry,
+      'dockerRegistry': options.artifact_registry,
       'googleImageProject': options.publish_gce_image_project,
       'gitPrefix': os.path.dirname(self.repo_commit_map[NORMAL_REPO]['ORIGIN'])
     }
@@ -328,7 +328,7 @@ class TestBomBuilder(BaseGitRepoTestFixture):
     updated_bom['artifactSources'] = {
         'debianRepository': 'https://dl.bintray.com/%s/%s' % (
             options.bintray_org, options.bintray_debian_repository),
-        'dockerRegistry': options.docker_registry,
+        'dockerRegistry': options.artifact_registry,
         'googleImageProject': options.publish_gce_image_project,
         'gitPrefix': self.golden_bom['artifactSources']['gitPrefix']
     }


### PR DESCRIPTION
…on for containers.

Replaces https://github.com/spinnaker/buildtool/pull/105

Since the `docker_registry` option is shared between `master` and all release branches, I opted to add an additional `artifact_registry` option to start generating and using BOMs that reference the new container home (`us-docker.pkg.dev/spinnaker-community/nightly`). 

This allows us to test out GAR with nightly builds and whatnot without having to modify `spinrel` yet (since the same containers will still exist in their previous home, `gcr.io/spinnaker-marketplace`)

A couple of additional changes are included to make local builds work, like `_COMPILE_CACHE_BUCKET`. A full run on the real infra is needed to ferret out any other areas I may have missed (a local test _mostly_ worked - service containers got built [except for Clouddriver], and Halyard got built [but debs and tars failed because of missing publishing secrets/access]) 