### PR TITLE
feat(halyard): Make Halyard nightly and stable releases use GAR

### DIFF
--- a/dev/buildtool/halyard_commands.py
+++ b/dev/buildtool/halyard_commands.py
@@ -134,13 +134,19 @@ class BuildHalyardCommand(GradleCommandProcessor):
     env = dict(os.environ)
     env.update({
         'PUBLISH_HALYARD_BUCKET_BASE_URL': options.halyard_bucket_base_url,
-        'PUBLISH_HALYARD_DOCKER_IMAGE_BASE': options.halyard_docker_image_base
+        'PUBLISH_HALYARD_DOCKER_IMAGE_BASE': options.halyard_docker_image_base,
+        'PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_SRC_BASE': options.halyard_artifacts_docker_image_nightly_base,
+        'PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_TARGET_BASE': options.halyard_artifacts_docker_image_nightly_base,
     })
     logging.info(
-        'Preparing the environment variables for release/all.sh:\n'
+        'Preparing the environment variables for release/promote-all.sh:\n'
         '    PUBLISH_HALYARD_DOCKER_IMAGE_BASE=%s\n'
+        '    PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_SRC_BASE=%s\n'
+        '    PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_TARGET_BASE=%s\n'
         '    PUBLISH_HALYARD_BUCKET_BASE_URL=%s',
         options.halyard_docker_image_base,
+        options.halyard_artifacts_docker_image_nightly_base,
+        options.halyard_artifacts_docker_image_nightly_base,
         options.halyard_bucket_base_url)
 
     logfile = self.get_logfile_path('halyard-publish-to-nightly')
@@ -301,6 +307,14 @@ class BuildHalyardFactory(GradleCommandFactory):
         parser, 'halyard_docker_image_base',
         defaults, None,
         help='Base Docker image name for writing halyard builds.')
+    self.add_argument(
+        parser, 'halyard_artifacts_docker_image_nightly_base',
+        defaults, None,
+        help='Base Artifact Registry Docker image name for writing halyard nightly builds.')
+    self.add_argument(
+        parser, 'halyard_artifacts_docker_image_releases_base',
+        defaults, None,
+        help='Base Artifact Registry Docker image name for writing halyard release builds.')
     self.add_argument(
         parser, 'gcb_project', defaults, None,
         help='The GCP project ID when using the GCP Container Builder.')
@@ -476,7 +490,9 @@ class PublishHalyardCommand(CommandProcessor):
     env = dict(os.environ)
     env.update({
         'PUBLISH_HALYARD_BUCKET_BASE_URL': options.halyard_bucket_base_url,
-        'PUBLISH_HALYARD_DOCKER_IMAGE_BASE': options.halyard_docker_image_base
+        'PUBLISH_HALYARD_DOCKER_IMAGE_BASE': options.halyard_docker_image_base,
+        'PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_SRC_BASE': options.halyard_artifacts_docker_image_nightly_base,
+        'PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_TARGET_BASE': options.halyard_artifacts_docker_image_releases_base,
     })
     check_subprocesses_to_logfile(
         'Promote Halyard', logfile,


### PR DESCRIPTION
Companion PR to https://github.com/spinnaker/halyard/pull/1657

This PR changes Halyard's promotion process (both nighlty and stable releases) to use the new Artifact Registry URLs. This promotion process is handled (somewhat bizarrely) by scripts in the Halyard repo that are called from this tool (see PR linked above for changes there). 

To maintain backwards compatibility with previous release branches, I opted to add `halyard_artifacts_docker_image_[nightly | releases]_base` options, rather than cherry picking GAR changes. We're not _releasing_ Halyard from previous _Spinnaker_ release branches, so I didn't see a good reason to go the cherry pick route.

