### PR TITLE
feat(boms): Add one-off for migrating BOMs to GAR

### DIFF
--- a/one-offs/migrate-boms/migrate-boms.go
+++ b/one-offs/migrate-boms/migrate-boms.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"log"
+	"regexp"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+var (
+	srcBucket   = flag.String("srcBucket", "halconfig", "The GCS bucket name to read from. Must contain a bom/ directory.")
+	destBucket  = flag.String("destBucket", "halconfig2", "The GCS bucket name to write to.")
+	jsonKeyPath = flag.String("jsonKey", "", "Filepath to JSON key with permission to read --srcBucket and write to the --destBucket")
+
+	releaseRegexp = regexp.MustCompile(`1\.[0-9]{1,2}\.[0-9]{1,2}\.yml`)
+)
+
+func main() {
+	flag.Parse()
+
+	ctx := context.Background()
+	var err error
+	storageSvc, err := storage.NewClient(ctx, option.WithCredentialsFile(*jsonKeyPath), option.WithScopes(storage.ScopeFullControl))
+	if err != nil {
+		log.Fatalf("Error generating new storage client: %v", err)
+	}
+
+	iter := storageSvc.Bucket(*srcBucket).Objects(ctx, &storage.Query{Prefix: "bom/"})
+	for obj, err := iter.Next(); err == nil; obj, err = iter.Next() {
+		if releaseRegexp.MatchString(obj.Name) {
+			log.Printf("Reading %v\n", obj.Name)
+			r, err := storageSvc.Bucket(*srcBucket).Object(obj.Name).NewReader(ctx)
+			if err != nil {
+				log.Fatalf("error reading object %v: %v", obj.Name, err)
+			}
+			scanner := bufio.NewScanner(r)
+			w := storageSvc.Bucket(*destBucket).Object(obj.Name).NewWriter(ctx)
+			w.ObjectAttrs.ContentType = "application/x-yaml"
+			for scanner.Scan() {
+				t := scanner.Text()
+				if strings.Contains(t, "gcr.io/spinnaker-marketplace") {
+					t = strings.ReplaceAll(t, "gcr.io/spinnaker-marketplace", "us-docker.pkg.dev/spinnaker-community/releases")
+					log.Printf("Replaced! New line: %v", t)
+				}
+				_, err := w.Write([]byte(t + "\n"))
+				if err != nil {
+					log.Fatalf("error writing output: %v", err)
+				}
+			}
+			if scanner.Err() != nil {
+				log.Fatalf("Error scanning: %v", scanner.Err())
+			}
+			err = w.Close()
+			if err != nil {
+				log.Fatalf("Error closing: %v", err)
+			}
+		}
+	}
+
+	if err != iterator.Done {
+		log.Fatalf("Error iterating: %v", err)
+	}
+}


### PR DESCRIPTION
Here's the last of the migration stuff. This pulls down all released BOMs and replaces `gcr.io/spinnaker-marketplace` with `us-docker.pkg.dev/spinnaker-community/releases`. 

I made a copy of the halconfig bucket (`gsutil -m cp -r gs://halconfig/* gs://bom-migration-1`) and instructed a local halyard (with the bucket overridden) to deploy to GKE and it worked as expected (as in it started pulling from the new GAR registry).

This PR represents option 3 of the following:

1. Just leave all past BOMs alone and pointing to `gcr.io/spinnaker-marketplace` (after all there's no pressure to turn it down)
2. Only migrate currently supported BOMs (BOMs listed as "stable" from https://www.spinnaker.io/community/releases/versions/)
3. Migrate all BOMs.

We never really discussed these options, so here's your chance. Change only here forward, change partially, or change fully?