### PR TITLE
fix(buildtool): Check GCR for existing containers instead of GAR

### DIFF
--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -65,11 +65,9 @@ class BuildContainerCommand(GradleCommandProcessor):
   def __gcb_image_exists(self, image_name, version):
     """Determine if gcb image already exists."""
     options = self.options
-    command = ['gcloud', 'beta',
-               '--account', options.gcb_service_account,
-               'artifacts', 'docker', 'images', 'list',
-               options.artifact_registry + '/' + image_name,
-               '--include-tags',
+    command = ['gcloud', '--account', options.gcb_service_account,
+               'container', 'images', 'list-tags',
+               options.docker_registry + '/' + image_name,
                '--filter="%s"' % version,
                '--format=json']
     got = check_subprocess(' '.join(command), stderr=subprocess.PIPE)


### PR DESCRIPTION
There's a bug in GAR that prevents this from working. Since we're writing to both places at the moment, using either should work.