### PR TITLE
fix(plugins-test): double wrap test params in quotes,

### DIFF
--- a/dev/all_tests.yaml
+++ b/dev/all_tests.yaml
@@ -340,4 +340,4 @@ tests:
     api: gate
     args:
       stage_name: randomWait
-      stage_params: '{ "maxWaitTime": 5 }'
+      stage_params: "'{ \"maxWaitTime\": 5 }'"


### PR DESCRIPTION
since they're unwrapped when passed through a shell to start the test.