### PR TITLE
fix(kubernetes): deploy test Spinnaker using a V2 account

### DIFF
--- a/dev/validate_bom__deploy.py
+++ b/dev/validate_bom__deploy.py
@@ -445,9 +445,25 @@ class KubernetesValidateBomDeployer(BaseValidateBomDeployer):
                           .format(options.injected_deploy_spinnaker_account)))
     options.injected_deploy_spinnaker_account = options.k8s_account_name
 
+  def __wait_for_deployment(self, k8s_namespace, service):
+    options = self.options
+    kubectl_command = 'kubectl {context} wait deployment/spin-{service} --timeout=300s --for=condition=available  --namespace {namespace}'.format(
+        context=('--context {0}'.format(options.k8s_account_context)
+                 if options.k8s_account_context
+                 else ''),
+        service=service,
+        namespace=k8s_namespace)
+    retcode, stdout = run_subprocess(kubectl_command)
+    if retcode != 0:
+      message = 'Timed out waiting for deployment to be available for service "{service}".: {error}'.format(
+        service=service,
+        error=stdout.strip())
+      raise_and_log_error(ExecutionError(message, program='kubectl'))
+
   def __get_pod_name(self, k8s_namespace, service):
     """Determine the pod name for the deployed service."""
     options = self.options
+    self.__wait_for_deployment(k8s_namespace, service)
     flags = ' --namespace {namespace} --logtostderr=false'.format(
         namespace=k8s_namespace)
     label_selector = '-l app.kubernetes.io/name={service}'.format(


### PR DESCRIPTION
This PR cherry-picks the three commits necessary to deploy the test Spinnaker using a Kubernetes V2 account. The end to end tests that exercise deploying to Kubernetes using a Kubernetes V1 account will still run; we are just running those tests on a Spinnaker that was deployed using a V2 account. This allows us to continue running 1.18.x tests using nightly Halyard, which no longer includes support for installing Spinnaker using a V1 account.