### PR TITLE
fix(build): do not tag buildtool or spin-rel

### DIFF
--- a/dev/buildtool/spinnaker_commands.py
+++ b/dev/buildtool/spinnaker_commands.py
@@ -272,20 +272,6 @@ class PublishSpinnakerCommand(CommandProcessor):
           self.__push_branch_and_maybe_tag_repository(
               repository, self.__branch, version, name in names_to_push)
 
-    additional_repositories = list(SPINNAKER_PROCESS_REPOSITORY_NAMES)
-    for name in additional_repositories:
-      if self.__only_repositories and name not in self.__only_repositories:
-        logging.debug('Skipping %s because of --only_repositories', name)
-        continue
-      repository = branch_scm.make_repository_spec(name)
-      branch_scm.ensure_local_repository(repository)
-      git_summary = self.__git.collect_repository_summary(repository.git_dir)
-      version = git_summary.version
-      if self.__branch_and_tag_repository(
-          repository, self.__branch, version):
-        self.__push_branch_and_maybe_tag_repository(
-            repository, self.__branch, version, True)
-
   def __already_have_tag(self, repository, tag):
     """Determine if we already have the tag in the repository."""
     git_dir = repository.git_dir


### PR DESCRIPTION
The buildtool and spin-rel services were manually seeded with tags whose _major_ version matched the Spinnaker _minor_ version to which they corresponded for 1.17, 1.18, and 1.19. For example, the 1.19.x release branch of buildtool corresponded to a `version-19.0.x` tag. However, no logic exists in buildtool to handle incrementing the major version of these two services when a new Spinnaker minor version is released. Because of that, the tag corresponding to the 1.20.x release branches for buildtool was confusingly [`version-19.1.0`](https://github.com/spinnaker/buildtool/tree/version-19.1.0). (I only discovered this because I cherry-picked a commit back to the 1.19.x release branch of buildtool, which caused a tag conflict.)

Since the only client of buildtool and spin-rel are our own Jenkins sever, which I think just use those services at the HEAD of each release branch rather than relying on any particular tagging scheme, @ezimanyi and I think it should be safe to remove this tagging altogether. If we ever do need to version buildtool and spin-rel in the future, it would probably make sense to have their minor versions match the Spinnaker minor version for consistency.