### PR TITLE
feat(gcb): pass the version into the compile container

### DIFF
--- a/dev/buildtool/cloudbuild/containers.yml
+++ b/dev/buildtool/cloudbuild/containers.yml
@@ -7,7 +7,13 @@ steps:
   - id: buildCompileImage
     waitFor: ["restoreCache"]
     name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "compile", "-f", "Dockerfile.compile", "."]
+    args: [
+      "build",
+      "-t", "compile",
+      "-f", "Dockerfile.compile",
+      "--build-arg", "VERSION=$TAG_NAME",
+      "."
+    ]
   - id: compile
     waitFor: ["buildCompileImage"]
     name: compile

--- a/dev/buildtool/cloudbuild/debs.yml
+++ b/dev/buildtool/cloudbuild/debs.yml
@@ -7,7 +7,13 @@ steps:
 - id: buildCompileImage
   waitFor: ["restoreCache"]
   name: gcr.io/cloud-builders/docker
-  args: ["build", "-t", "compile", "-f", "Dockerfile.compile", "."]
+  args: [
+    "build",
+    "-t", "compile",
+    "-f", "Dockerfile.compile",
+    "--build-arg", "VERSION=$_VERSION-$_BUILD_NUMBER",
+    "."
+  ]
 - id: publishDeb
   waitFor: ["buildCompileImage"]
   name: compile

--- a/dev/buildtool/cloudbuild/halyard-tars.yml
+++ b/dev/buildtool/cloudbuild/halyard-tars.yml
@@ -7,7 +7,13 @@ steps:
 - id: buildCompileImage
   waitFor: ["restoreCache"]
   name: gcr.io/cloud-builders/docker
-  args: ["build", "-t", "compile", "-f", "Dockerfile.compile", "."]
+  args: [
+    "build",
+    "-t", "compile",
+    "-f", "Dockerfile.compile",
+    "--build-arg", "VERSION=$TAG_NAME",
+    "."
+  ]
 - id: compile
   waitFor: ["buildCompileImage"]
   name: compile


### PR DESCRIPTION
It gets ignored (with the warning) if the `Dockerfile` doesn't define it as an `ARG`.

This fixes part of spinnaker/spinnaker#5740.