### PR TITLE
fix(citest): do not exceed appengine naming limits

### DIFF
--- a/testing/citest/tests/appengine_gcs_pubsub_test.py
+++ b/testing/citest/tests/appengine_gcs_pubsub_test.py
@@ -454,8 +454,8 @@ class AppengineGcsPubsubTest(st.AgentTestCase):
 
 def main():
   defaults = {
-    'TEST_STACK': 'appenginegcspubsubtest' + AppengineGcsPubsubTestScenario.DEFAULT_TEST_ID,
-    'TEST_APP': 'appenginegcspubsubgaetest' + AppengineGcsPubsubTestScenario.DEFAULT_TEST_ID
+    'TEST_STACK': AppengineGcsPubsubTestScenario.DEFAULT_TEST_ID,
+    'TEST_APP': 'gae2' + AppengineGcsPubsubTestScenario.DEFAULT_TEST_ID
   }
 
   return citest.base.TestRunner.main(

--- a/testing/citest/tests/appengine_smoke_test.py
+++ b/testing/citest/tests/appengine_smoke_test.py
@@ -453,7 +453,7 @@ class AppengineSmokeTest(st.AgentTestCase):
 def main():
   defaults = {
       'TEST_STACK': AppengineSmokeTestScenario.DEFAULT_TEST_ID,
-      'TEST_APP': 'gaesmoketest' + AppengineSmokeTestScenario.DEFAULT_TEST_ID,
+      'TEST_APP': 'gae1' + AppengineSmokeTestScenario.DEFAULT_TEST_ID,
   }
 
   return citest.base.TestRunner.main(


### PR DESCRIPTION
Our GAE end to end tests are failing at HEAD:

```
The total length of your subdomain in the format $VERSION_ID-dot-$SERVICE_ID-dot-$APP_ID should not exceed 63 characters.
```

In our tests:
- $VERSION_ID: gaesmoketestvmgvalx06-gce-v000 (whatever name we supply + 18 chars)
- $SERVICE_ID: gaesmoketestvmgvalx06-gce (whatever name we supply + 13 chars)
- $APP_ID: spinnaker-community (19 chars)

Including the two separators, we should have a budget of about 5 characters per name. Just to be safe, let's only use 4. I named them, , uncreatively, `gae1` and `gae2` (open to suggestions). The alternative here is shortening the `DEFAULT_TEST_ID` which we set in the Jenkins config:

```
CITEST_TEST_ID=${OVERRIDE_CITEST_ID:-${LOCAL_JOB_DECORATOR}valx$(printf "%02d" $(expr $BUILD_NUMBER % 10))}
```

I was afraid to touch that, so went with this approach instead in order to limit the blast radius of the change to only the appengine tests.