### PR TITLE
chore(containers): revert the Artifact Registry changes

### DIFF
--- a/dev/buildtool/bom_commands.py
+++ b/dev/buildtool/bom_commands.py
@@ -171,7 +171,7 @@ class BomBuilder(object):
         name: source
         for name, source in [
             ('debianRepository', debian_repository),
-            ('dockerRegistry', options.artifact_registry),
+            ('dockerRegistry', options.docker_registry),
             ('googleImageProject', options.publish_gce_image_project)
         ]
         if source

--- a/dev/buildtool/cloudbuild/containers.yml
+++ b/dev/buildtool/cloudbuild/containers.yml
@@ -24,8 +24,6 @@ steps:
             "build",
             "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME",
             "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim",
-            "-t", "$_ARTIFACT_REGISTRY/$_IMAGE_NAME:$TAG_NAME",
-            "-t", "$_ARTIFACT_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim",
             "-f", "Dockerfile.slim",
             ".",
           ]
@@ -35,7 +33,6 @@ steps:
     args: [
             "build",
             "-t", "$_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu",
-            "-t", "$_ARTIFACT_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu",
             "-f", "Dockerfile.ubuntu",
             ".",
           ]
@@ -51,10 +48,6 @@ images:
   - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME
   - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim
   - $_DOCKER_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu
-  - $_ARTIFACT_REGISTRY/$_IMAGE_NAME:$TAG_NAME
-  - $_ARTIFACT_REGISTRY/$_IMAGE_NAME:$TAG_NAME-slim
-  - $_ARTIFACT_REGISTRY/$_IMAGE_NAME:$TAG_NAME-ubuntu
-
 tags: ["type_containers", "repo_$_IMAGE_NAME", "branch_$_BRANCH_TAG"]
 timeout: 3600s
 options:
@@ -62,4 +55,3 @@ options:
 substitutions:
   _COMPILE_CACHE_BUCKET: spinnaker-build-cache
   _BRANCH_TAG: unknown
-  _ARTIFACT_REGISTRY: us-docker.pkg.dev/spinnaker-community/nightly

--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -65,12 +65,10 @@ class BuildContainerCommand(GradleCommandProcessor):
   def __gcb_image_exists(self, image_name, version):
     """Determine if gcb image already exists."""
     options = self.options
-    command = ['gcloud', 'beta',
-               '--account', options.gcb_service_account,
-               'artifacts', 'docker', 'images', 'list',
-               options.artifact_registry + '/' + image_name,
-               '--include-tags',
-               '--filter="tags=%s"' % version,
+    command = ['gcloud', '--account', options.gcb_service_account,
+               'container', 'images', 'list-tags',
+               options.docker_registry + '/' + image_name,
+               '--filter="%s"' % version,
                '--format=json']
     got = check_subprocess(' '.join(command), stderr=subprocess.PIPE)
     if got.strip() != '[]':
@@ -88,9 +86,7 @@ class BuildContainerCommand(GradleCommandProcessor):
     substitutions = {'_BRANCH_NAME': options.git_branch,
                      '_BRANCH_TAG': re.sub(r'\W', '_', options.git_branch),
                      '_DOCKER_REGISTRY': options.docker_registry,
-                     '_ARTIFACT_REGISTRY': options.artifact_registry,
                      '_IMAGE_NAME': service_name,
-                     '_COMPILE_CACHE_BUCKET': options.gcb_cache_bucket,
                      'TAG_NAME': build_version}
     # Convert it to the format expected by gcloud: "_FOO=bar,_BAZ=qux"
     substitutions_arg = ','.join('='.join((str(k), str(v))) for k, v in
@@ -125,9 +121,6 @@ class BuildContainerFactory(GradleCommandFactory):
     BuildContainerFactory.add_argument(
         parser, 'docker_registry', defaults, None,
         help='Docker registry to push the container images to.')
-    BuildContainerFactory.add_argument(
-        parser, 'artifact_registry', defaults, None,
-        help='Artifact registry to push the container images to.')
 
   def init_argparser(self, parser, defaults):
     super(BuildContainerFactory, self).init_argparser(parser, defaults)
@@ -141,9 +134,6 @@ class BuildContainerFactory(GradleCommandFactory):
     self.add_argument(
         parser, 'gcb_service_account', defaults, None,
         help='Google Service Account when using the GCP Container Builder.')
-    self.add_argument(
-        parser, 'gcb_cache_bucket', defaults, "spinnaker-build-cache",
-        help='Google Storage Bucket for build caches when using the GCP Container Builder.')
 
 
 def add_bom_parser_args(parser, defaults):

--- a/dev/buildtool/halyard_commands.py
+++ b/dev/buildtool/halyard_commands.py
@@ -161,20 +161,16 @@ class BuildHalyardCommand(GradleCommandProcessor):
                             config_filename='containers.yml',
                             git_dir=git_dir,
                             substitutions={'TAG_NAME': self.__build_version,
-                                           '_DOCKER_REGISTRY': options.docker_registry,
-                                           '_ARTIFACT_REGISTRY': options.artifact_registry,
-                                           '_COMPILE_CACHE_BUCKET': options.gcb_cache_bucket}),
+                                           '_DOCKER_REGISTRY': options.docker_registry}),
         self.gcloud_command(name='halyard-deb-build',
                             config_filename='debs.yml',
                             git_dir=git_dir,
                             substitutions={'_VERSION': summary.version,
-                                           '_BUILD_NUMBER': options.build_number,
-                                           '_COMPILE_CACHE_BUCKET': options.gcb_cache_bucket}),
+                                           '_BUILD_NUMBER': options.build_number}),
         self.gcloud_command(name='halyard-tar-build',
                             config_filename='halyard-tars.yml',
                             git_dir=git_dir,
-                            substitutions={'TAG_NAME': self.__build_version,
-                                           '_COMPILE_CACHE_BUCKET': options.gcb_cache_bucket}),
+                            substitutions={'TAG_NAME': self.__build_version}),
     ]
 
     pool = ThreadPool(len(commands))
@@ -310,12 +306,6 @@ class BuildHalyardFactory(GradleCommandFactory):
     self.add_argument(
         parser, 'docker_registry', defaults, None,
         help='Docker registry to push the container images to.')
-    self.add_argument(
-        parser, 'artifact_registry', defaults, None,
-        help='Artifact registry to push the container images to.')
-    self.add_argument(
-        parser, 'gcb_cache_bucket', defaults, "spinnaker-build-cache",
-        help='Google Storage Bucket for build caches when using the GCP Container Builder.')
 
 
 class PublishHalyardCommandFactory(CommandFactory):
@@ -376,8 +366,8 @@ class PublishHalyardCommandFactory(CommandFactory):
         parser, 'gcb_service_account', defaults, None,
         help='Google Service Account when using the GCP Container Builder.')
     self.add_argument(
-        parser, 'artifact_registry', defaults, None,
-        help='Artifact registry to push the container images to.')
+        parser, 'docker_registry', defaults, None,
+        help='Docker registry to push the container images to.')
 
 
 class PublishHalyardCommand(CommandProcessor):

--- a/dev/buildtool/halyard_commands.py
+++ b/dev/buildtool/halyard_commands.py
@@ -134,19 +134,13 @@ class BuildHalyardCommand(GradleCommandProcessor):
     env = dict(os.environ)
     env.update({
         'PUBLISH_HALYARD_BUCKET_BASE_URL': options.halyard_bucket_base_url,
-        'PUBLISH_HALYARD_DOCKER_IMAGE_BASE': options.halyard_docker_image_base,
-        'PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_SRC_BASE': options.halyard_artifacts_docker_image_nightly_base,
-        'PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_TARGET_BASE': options.halyard_artifacts_docker_image_nightly_base,
+        'PUBLISH_HALYARD_DOCKER_IMAGE_BASE': options.halyard_docker_image_base
     })
     logging.info(
-        'Preparing the environment variables for release/promote-all.sh:\n'
+        'Preparing the environment variables for release/all.sh:\n'
         '    PUBLISH_HALYARD_DOCKER_IMAGE_BASE=%s\n'
-        '    PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_SRC_BASE=%s\n'
-        '    PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_TARGET_BASE=%s\n'
         '    PUBLISH_HALYARD_BUCKET_BASE_URL=%s',
         options.halyard_docker_image_base,
-        options.halyard_artifacts_docker_image_nightly_base,
-        options.halyard_artifacts_docker_image_nightly_base,
         options.halyard_bucket_base_url)
 
     logfile = self.get_logfile_path('halyard-publish-to-nightly')
@@ -307,14 +301,6 @@ class BuildHalyardFactory(GradleCommandFactory):
         parser, 'halyard_docker_image_base',
         defaults, None,
         help='Base Docker image name for writing halyard builds.')
-    self.add_argument(
-        parser, 'halyard_artifacts_docker_image_nightly_base',
-        defaults, None,
-        help='Base Artifact Registry Docker image name for writing halyard nightly builds.')
-    self.add_argument(
-        parser, 'halyard_artifacts_docker_image_releases_base',
-        defaults, None,
-        help='Base Artifact Registry Docker image name for writing halyard release builds.')
     self.add_argument(
         parser, 'gcb_project', defaults, None,
         help='The GCP project ID when using the GCP Container Builder.')
@@ -490,9 +476,7 @@ class PublishHalyardCommand(CommandProcessor):
     env = dict(os.environ)
     env.update({
         'PUBLISH_HALYARD_BUCKET_BASE_URL': options.halyard_bucket_base_url,
-        'PUBLISH_HALYARD_DOCKER_IMAGE_BASE': options.halyard_docker_image_base,
-        'PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_SRC_BASE': options.halyard_artifacts_docker_image_nightly_base,
-        'PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_TARGET_BASE': options.halyard_artifacts_docker_image_releases_base,
+        'PUBLISH_HALYARD_DOCKER_IMAGE_BASE': options.halyard_docker_image_base
     })
     check_subprocesses_to_logfile(
         'Promote Halyard', logfile,

--- a/unittest/buildtool/bom_command_test.py
+++ b/unittest/buildtool/bom_command_test.py
@@ -62,7 +62,7 @@ def make_default_options(options):
   options.build_number = 'OptionBuildNumber'
   options.bintray_org = 'test-bintray-org'
   options.bintray_debian_repository = 'test-debian-repo'
-  options.artifact_registry = 'test-docker-registry'
+  options.docker_registry = 'test-docker-registry'
   options.publish_gce_image_project = 'test-image-project-name'
   options.github_upstream_owner = 'spinnaker'
   return options
@@ -279,7 +279,7 @@ class TestBomBuilder(BaseGitRepoTestFixture):
     golden_bom['artifactSources'] = {
       'debianRepository': 'https://dl.bintray.com/%s/%s' % (
           options.bintray_org, options.bintray_debian_repository),
-      'dockerRegistry': options.artifact_registry,
+      'dockerRegistry': options.docker_registry,
       'googleImageProject': options.publish_gce_image_project,
       'gitPrefix': os.path.dirname(self.repo_commit_map[NORMAL_REPO]['ORIGIN'])
     }
@@ -328,7 +328,7 @@ class TestBomBuilder(BaseGitRepoTestFixture):
     updated_bom['artifactSources'] = {
         'debianRepository': 'https://dl.bintray.com/%s/%s' % (
             options.bintray_org, options.bintray_debian_repository),
-        'dockerRegistry': options.artifact_registry,
+        'dockerRegistry': options.docker_registry,
         'googleImageProject': options.publish_gce_image_project,
         'gitPrefix': self.golden_bom['artifactSources']['gitPrefix']
     }


### PR DESCRIPTION
The build system is going to be redone (one way or another) by the end of the year. Since the Artifact Registry changes were only partly finished, I'd rather deal with it as part of the build system rework.

I think it's likely we'll have the new build system publishing to GAR while the old one publishes to GCR and then do the final cutover as part of turning down the old build system. So I'd rather wait to make this move until then.