### PR TITLE
fix(kubernetes): Fix API group for test deployments

### DIFF
--- a/testing/citest/spinnaker_testing/kubernetes_manifests.py
+++ b/testing/citest/spinnaker_testing/kubernetes_manifests.py
@@ -52,7 +52,7 @@ class KubernetesManifestFactory(object):
 
   def deployment(self, name, image):
     return {
-        'apiVersion': 'apps/v1beta2',
+        'apiVersion': 'apps/v1',
         'kind': 'Deployment',
         'metadata': {
             'name': name,

--- a/testing/citest/tests/kube_v2_data/helm-test/templates/deployment.yaml
+++ b/testing/citest/tests/kube_v2_data/helm-test/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ .Values.name }}"


### PR DESCRIPTION
I upgraded our testing cluster to Kubernetes 1.16, which has deprecated some old API versions. While all currently supported versions of Spinnaker have been updated to handle these changes, there are two places in the tests themselves where we are using an old API version, which is causing the tests to fail. Update these to the new API version.