### PR TITLE
fix(kubernetes): Add apiVersion to V1 tests

### DIFF
--- a/testing/citest/tests/kube_smoke_test.py
+++ b/testing/citest/tests/kube_smoke_test.py
@@ -541,6 +541,7 @@ class KubeSmokeTestScenario(sk.SpinnakerTestScenario):
                           }}
                   ],
                   'kind': 'DaemonSet',
+                  'apiVersion': 'apps/v1',
                   'volumeSources': [],
                   'provider': 'kubernetes',
                   'regions': [self.TEST_NAMESPACE],
@@ -581,6 +582,7 @@ class KubeSmokeTestScenario(sk.SpinnakerTestScenario):
                           }}
                   ],
                   'kind': 'StatefulSet',
+                  'apiVersion': 'apps/v1',
                   'volumeSources': [],
                   'provider': 'kubernetes',
                   'regions': [self.TEST_NAMESPACE],


### PR DESCRIPTION
The V1 tests are failing since upgrading our Kubernetes cluster to 1.16. These tests only exist on 1.20 and earlier, as the V1 provider is deprecated and removed in 1.21.

I think the fix is to just add an apiVersion here, though if this doesn't work I may delete this test as it's not clear the amount of effort that should go into debugging it given that the V1 provider is deprecated (and that given our backport criteria it's unlikely we'll ever change the V1 provider on these branches).