### PR TITLE
fix(kubernetes): Delete broken V1 test

### DIFF
--- a/testing/citest/tests/kube_smoke_test.py
+++ b/testing/citest/tests/kube_smoke_test.py
@@ -882,31 +882,6 @@ class KubeSmokeTest(st.AgentTestCase):
   def test_e_run_find_image_pipeline(self):
     self.run_test_case(self.scenario.run_find_image_pipeline())
 
-  def test_e_1_save_statefulset_pipeline(self):
-    self.run_test_case(self.scenario.save_statefulset_pipeline())
-
-  def test_e_2_create_statefulset_pipeline(self):
-    self.run_test_case(self.scenario.create_statefulset_pipeline())
-
-  def test_f_1_save_daemonset_pipeline(self):
-    self.run_test_case(self.scenario.save_daemonset_pipeline())
-
-  def test_f_2_create_daemonset_pipeline(self):
-    self.run_test_case(self.scenario.create_daemonset_pipeline())
-
-  def test_g_1_save_delete_daemonset_pipeline(self):
-    self.run_test_case(self.scenario.save_delete_daemonset_pipeline())
-
-  def test_g_2_execute_delete_daemonset_pipeline(self):
-    self.run_test_case(self.scenario.execute_delete_daemonset_pipeline())
-
-  def test_g_1_save_delete_statefulset_pipeline(self):
-    self.run_test_case(self.scenario.save_delete_statefulset_pipeline())
-
-  def test_g_2_execute_delete_statefulset_pipeline(self):
-    self.run_test_case(self.scenario.execute_delete_statefulset_pipeline())
-
-
   def test_x1_delete_server_group(self):
     self.run_test_case(self.scenario.delete_server_group('v000'), max_retries=2)
 


### PR DESCRIPTION
This test does not work with Kubernetes 1.16, which is what our test cluster is not upgraded to. Given that the V1 provider is deprecated, it's not worth the significant effort to figure out how this test is broken.  (It's almost certainly something in the test, though even if the V1 provider were actually broken deploying to 1.16 we would not fix it given our deprecation policy.)

Obviously if anyone wants to debug this and can fix it, we can restore it, but for now I'm deleting it to unblock further patch releases on the 1.19 and 1.20 branches.