### PR TITLE
fix(hal install): install Java before installing Halyard

### DIFF
--- a/dev/validate_bom__deploy.py
+++ b/dev/validate_bom__deploy.py
@@ -344,6 +344,7 @@ class BaseValidateBomDeployer(object):
   def add_install_hal_script_statements(self, script):
     """Adds the sequence of Bash statements to fetch and install halyard."""
     options = self.options
+    script.append('sudo apt-get update && sudo apt-get install -y openjdk-11-jre-headless')
     script.append('curl -s -O {url}'.format(url=options.halyard_install_script))
     install_params = ['-y']
     if options.halyard_config_bucket:


### PR DESCRIPTION
See spinnaker/halyard#1762

This needs to be backported to all versions since the buildtool (like all our instructions) uses the version of InstallHalyard.sh from HEAD, not a branch.