### PR TITLE
fix(citest): use relative path in requirements file

### DIFF
--- a/testing/citest/requirements.txt
+++ b/testing/citest/requirements.txt
@@ -3,7 +3,7 @@
 # citest is not currently published through pip
 # You'll need to clone the https://github.com/google/citest repository
 # and run pip install -r requirements.txt on its requirements file
-citest
+../../../citest
 
 # This is to make gsutil compatible with virtualenv
 # it isnt directly used by any tests, only tests that


### PR DESCRIPTION
Since citest isn't published we should probably be using a relative path
to where the package is being installed. Not positive this will fix the
issues we're seeing, but we were able to validate that this works
manually on the Jenkins box itself.