### PR TITLE
revert(citest): use relative path in requirements file (#145)

### DIFF
--- a/testing/citest/requirements.txt
+++ b/testing/citest/requirements.txt
@@ -3,7 +3,7 @@
 # citest is not currently published through pip
 # You'll need to clone the https://github.com/google/citest repository
 # and run pip install -r requirements.txt on its requirements file
-../../../citest
+citest
 
 # This is to make gsutil compatible with virtualenv
 # it isnt directly used by any tests, only tests that


### PR DESCRIPTION
This reverts commit 7f43220ef29ca8902eaf016a9817916970f873d2.

We're doing this because the actual fix is to pin the version of `pip`
being used on the box to 19.0.3. When creating a `virtualenv` in py2 it
looks like the latest `pip` gets installed, which introduced the
regression we're seeing in the build jobs (20.2.1).