### PR TITLE
fix(kubernetes): Fix eventually consistent test

### DIFF
--- a/testing/citest/tests/kube_v2_cache_test.py
+++ b/testing/citest/tests/kube_v2_cache_test.py
@@ -266,6 +266,16 @@ class KubeV2CacheTestScenario(sk.SpinnakerTestScenario):
         NoOpOperation('Has recorded a load balancer'),
         contract=builder.build())
 
+  def check_load_balancers_endpoint_empty(self):
+    builder = HttpContractBuilder(self.agent)
+    (builder.new_clause_builder('Has no load balancer')
+      .get_url_path('/applications/{}/loadBalancers'.format(self.TEST_APP))
+      .EXPECT(ov_factory.value_list_matches([])))
+
+    return st.OperationContract(
+        NoOpOperation('Has no load balancer'),
+        contract=builder.build())
+
   def check_clusters_endpoint(self, kind):
     name = kind + ' ' + self.TEST_APP + '-' + kind
     account = self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']
@@ -392,8 +402,8 @@ class KubeV2CacheTest(st.AgentTestCase):
   def test_b3_delete_service(self):
     self.run_test_case(self.scenario.delete_kind('service'), max_retries=2)
 
-  def test_b4_check_server_groups_endpoint_no_load_balancer(self):
-    self.run_test_case(self.scenario.check_server_groups_endpoint('deployment', 'library/nginx', has_lb=False))
+  def test_b4_check_load_balancers_endpoint_no_load_balancer(self):
+    self.run_test_case(self.scenario.check_load_balancers_endpoint_empty())
 
   def test_b9_delete_deployment(self):
     self.run_test_case(self.scenario.delete_kind('deployment'), max_retries=2)


### PR DESCRIPTION
The recent refactor of caching broke one of the kube v2 cache tests. The particular case this was testing was the following:
(1) Add a service, and a deployment attached to that service
(2) Check that the various clusters/serverGroups/loadBalancers endpoints return the expected results.
(3) Delete the service
(4) Check that when we hit the /serverGroups endpoint, we still see the service but that it no longer has a loadBalancer (as the service is now deleted)

The step that is breaking is (4). The reason is that when we delete an object, we don't wait a full cache refresh cycle; we just purge that entry from the cache. (I learned this today about how force cache refresh works.) So even once force cache refresh has completed there might still be objects with relationships pointing to the deleted object, as we don't (as we do with inserts/updates) wait a full cache refresh cycle.

This used to work because when looking up server groups, we
(inefficiently) looked up all load balancers, and then found which ones had a relationship to the server group in question. Now we just take the server group's relationships (which temporarily point to the deleted load balancer until the next cache cycle). This means that even after the load balancer is deleted, we still for some time
(up to a cache cycle) show it in the details on the server group.

This has always been the case (as this test was asserting before relationships were up to date) but the fact that we changed some implementation details now broke the test.  I don't think that this is a use case that is important enough to revert the performance fixes for; there will be some eventual consistency within the clusters tab (as there always was, it's just slightly different now). And in particular for this exact case, deleting a service for an active server group is likely quite rare.

So let's instead replace the test with one that just looks up the load balancers endpoint directly and makes sure there are none.