### PR TITLE
fix(aws): fix usage of the aws '--filters' arg

### DIFF
--- a/dev/validate_bom__deploy.py
+++ b/dev/validate_bom__deploy.py
@@ -831,8 +831,8 @@ class AwsValidateBomDeployer(GenericVmValidateBomDeployer):
       retcode, stdout = run_subprocess(
           'aws ec2 describe-instances'
           ' --profile {region}'
-          ' --filters "Name=tag:Name,Values={name}'
-          ',Name=instance-state-name,Values=running"'
+          ' --filters "Name=tag:Name,Values={name}"'
+          ' "Name=instance-state-name,Values=running"'
           .format(region=options.deploy_aws_region,
                   name=options.deploy_aws_name))
       if retcode != 0:
@@ -882,8 +882,8 @@ class AwsValidateBomDeployer(GenericVmValidateBomDeployer):
         'aws ec2 describe-instances'
         ' --profile {region}'
         ' --output json'
-        ' --filters "Name=tag:Name,Values={name}'
-        ',Name=instance-state-name,Values=running"'
+        ' --filters "Name=tag:Name,Values={name}"'
+        ' "Name=instance-state-name,Values=running"'
         .format(region=options.deploy_aws_region,
                 name=options.deploy_aws_name))
     if retcode != 0:
@@ -1022,8 +1022,8 @@ class AwsValidateBomDeployer(GenericVmValidateBomDeployer):
       lookup_response = check_subprocess(
           'aws ec2 describe-instances'
           ' --profile {region}'
-          ' --filters "Name=tag:Name,Values={name}'
-          ',Name=instance-state-name,Values=running"'
+          ' --filters "Name=tag:Name,Values={name}"'
+          ' "Name=instance-state-name,Values=running"'
           .format(region=options.deploy_aws_region,
                   name=options.deploy_aws_name))
       exists = decode_json(lookup_response).get('Reservations')


### PR DESCRIPTION
We were doing
```
  --filters Name=a,Values=b,Name=c,Values=d
```
Apparently this used to work, but unintentionally. You're supposed to (and now have to) use a space instead of a comma between name/value pairs.