### PR TITLE
fix(audit): Fix a few issues with Admin_AuditBoms

### DIFF
--- a/dev/buildtool/inspection_commands.py
+++ b/dev/buildtool/inspection_commands.py
@@ -1289,8 +1289,9 @@ class AuditArtifactVersions(CommandProcessor):
     if commit_map is None:
       return False
     for _, buildnums in commit_map.items():
-      if buildnum in buildnums:
-        return True
+      for bom_build_num in buildnums:
+        if bom_build_num.startswith(buildnum):
+          return True
     return False
 
   def audit_package_helper(self, package, version, buildnum, which):

--- a/dev/buildtool/inspection_commands.py
+++ b/dev/buildtool/inspection_commands.py
@@ -296,7 +296,7 @@ class CollectBomVersions(CommandProcessor):
 
   def ingest_bom_list(self, bom_list):
     """Ingest each of the boms."""
-    max_threads = 1 if self.options.one_at_a_time else 64
+    max_threads = 1 if self.options.one_at_a_time else 2
     pool = ThreadPool(min(max_threads, len(bom_list)))
     pool.map(self.ingest_bom, bom_list)
     pool.close()

--- a/dev/buildtool/inspection_commands.py
+++ b/dev/buildtool/inspection_commands.py
@@ -1356,7 +1356,7 @@ class AuditArtifactVersions(CommandProcessor):
         for _, buildnums in commits.items():
           for buildnum, info_list in buildnums.items():
             version_buildnum = '%s-%s' % (version, buildnum)
-            if service in ['monitoring-daemon', 'monitoring-third-party']:
+            if service in ['monitoring-daemon', 'monitoring-third-party', 'deck']:
               # Uses debians, but not jars so missing jars is ok.
               jar_ok = True
             else:

--- a/dev/buildtool/inspection_commands.py
+++ b/dev/buildtool/inspection_commands.py
@@ -296,7 +296,7 @@ class CollectBomVersions(CommandProcessor):
 
   def ingest_bom_list(self, bom_list):
     """Ingest each of the boms."""
-    max_threads = 1 if self.options.one_at_a_time else 2
+    max_threads = 1 if self.options.one_at_a_time else 4
     pool = ThreadPool(min(max_threads, len(bom_list)))
     pool.map(self.ingest_bom, bom_list)
     pool.close()


### PR DESCRIPTION
This fixes a few issues with `Admin_AuditBoms`, which ensures that the artifacts (debians, jars, containers) for all published versions of Spinnaker are present.  It also suggests artifacts that are no longer referenced by a BOM to delete.  The container auditing is still broken because it doesn't handle the new `spinnaker-1.20.2` tag format.  I'm just not going to run the container deleting script as I don't think we've run into any issues with GCR being slow because of all these artifacts.

* fix(audit): Remove unused keep_latest_version flag

  We are not using this flag; removing it allows us to remove some unecessary code, some of which is throwing a lot of exceptions that clutter the logs.

* fix(audit): Don't require a jar for deck

  At some point we stopped publishing jars for deck. (I'm not sure what was even in them when we did...)  But we should not report a failure if a released deck version doesn't have a jar.

* fix(audit): Don't remove versions whose prefix matches

  Now that we publish variants of containters with -java8 or
  -slim or -slim-java8 at the end, we should not require the tag to exactly match a version we released, but should just start with such a version.

* fix(audit): Reduce concurrency of gsutil

  It seems like gsutil itself has locking and limits to only one operation running at a time, so trying to run 64 of these at once is not any faster.  We'll still use 2 threads in case we speed things up a tiny bit by letting the next job run while we're parsing the yaml from the prior one.

* fix(audit): Update concurrency to 4

  Actually after running this a few times, up to parallel 4 does speed things up, so let's use that instead of 2.