### PR TITLE
fix(test): fix kube_v2_cache_test

### DIFF
--- a/testing/citest/tests/kube_v2_cache_test.py
+++ b/testing/citest/tests/kube_v2_cache_test.py
@@ -385,25 +385,43 @@ class KubeV2CacheTest(st.AgentTestCase):
     self.run_test_case(self.scenario.check_manifest_endpoint_exists('deployment'))
 
   def test_b2_check_applications_endpoint(self):
-    self.run_test_case(self.scenario.check_applications_endpoint())
+    # Give a total of 2 minutes because it might also need
+    # an internal cache update
+    self.run_test_case(self.scenario.check_applications_endpoint(),
+                       retry_interval_secs=8, max_retries=15)
 
   def test_b2_check_clusters_endpoint(self):
-    self.run_test_case(self.scenario.check_clusters_endpoint('deployment'))
+    # Give a total of 2 minutes because it might also need
+    # an internal cache update
+    self.run_test_case(self.scenario.check_clusters_endpoint('deployment'),
+                       retry_interval_secs=8, max_retries=15)
 
   def test_b2_check_detailed_clusters_endpoint(self):
-    self.run_test_case(self.scenario.check_detailed_clusters_endpoint('deployment'))
+    # Give a total of 2 minutes because it might also need
+    # an internal cache update
+    self.run_test_case(self.scenario.check_detailed_clusters_endpoint('deployment'),
+                       retry_interval_secs=8, max_retries=15)
 
   def test_b2_check_server_groups_endpoint(self):
-    self.run_test_case(self.scenario.check_server_groups_endpoint('deployment', 'library/nginx'))
+    # Give a total of 2 minutes because it might also need
+    # an internal cache update
+    self.run_test_case(self.scenario.check_server_groups_endpoint('deployment', 'library/nginx'),
+                       retry_interval_secs=8, max_retries=15)
 
   def test_b2_check_load_balancers_endpoint(self):
-    self.run_test_case(self.scenario.check_load_balancers_endpoint('service'))
+    # Give a total of 2 minutes because it might also need
+    # an internal cache update
+    self.run_test_case(self.scenario.check_load_balancers_endpoint('service'),
+                       retry_interval_secs=8, max_retries=15)
 
   def test_b3_delete_service(self):
     self.run_test_case(self.scenario.delete_kind('service'), max_retries=2)
 
   def test_b4_check_load_balancers_endpoint_no_load_balancer(self):
-    self.run_test_case(self.scenario.check_load_balancers_endpoint_empty())
+    # Give a total of 2 minutes because it might also need
+    # an internal cache update
+    self.run_test_case(self.scenario.check_load_balancers_endpoint_empty(),
+                       retry_interval_secs=8, max_retries=15)
 
   def test_b9_delete_deployment(self):
     self.run_test_case(self.scenario.delete_kind('deployment'), max_retries=2)


### PR DESCRIPTION
The behavior previously enabled by the `liveManifestCalls` flag is now [enabled by default](https://github.com/spinnaker/spinnaker/issues/5906). We have removed the Force Cache Refresh task from all Kubernetes pipelines stages (these were a no-op with the flag enabled). However, this resulted in the end-to-end tests that expected the cache to be in a consistent state after Kubernetes operations completed to begin failing intermittently.

This commit adds a retry interval of 8 seconds with a max retries of 15, for a total of 2 minutes, to all test cases that expect the cache to reflect the state of the operation being tested. This includes any operation that hits Clouddriver's applications, clusters, server group, and load balancers endpoints. It excludes those, such as `delete_kind`, that instead rely on the citest.kube_testing package. The retry interval and max retries numbers were chosen for consistency with the existing test that relies on a [cache update](https://github.com/spinnaker/buildtool/blob/master/testing/citest/tests/kube_v2_cache_test.py#L412).