### PR TITLE
fix(containers): fix checking for existing containers

### DIFF
--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -27,8 +27,8 @@ from buildtool import (
   GradleCommandFactory,
   GradleCommandProcessor,
 
-  check_subprocess,
-  check_subprocesses_to_logfile
+  check_subprocesses_to_logfile,
+  run_subprocess
 )
 
 
@@ -67,15 +67,11 @@ class BuildContainerCommand(GradleCommandProcessor):
     options = self.options
     command = ['gcloud', 'beta',
                '--account', options.gcb_service_account,
-               'artifacts', 'docker', 'images', 'list',
-               options.artifact_registry + '/' + image_name,
-               '--include-tags',
-               '--filter="tags:%s"' % version,
-               '--format=json']
-    got = check_subprocess(' '.join(command), stderr=subprocess.PIPE)
-    if got.strip() != '[]':
-      return True
-    return False
+               'artifacts', 'docker', 'images', 'describe',
+               '%s/%s:%s' % (options.artifact_registry, image_name, version)]
+    exit_code = run_subprocess(' '.join(command), stderr=subprocess.PIPE)[0]
+
+    return exit_code == 0
 
   def __build_with_gcb(self, repository, build_version):
     name = repository.name


### PR DESCRIPTION
Listing images with a filter doesn't seem to work. It seems to only find the image we're looking for if it was uploaded recently. I suspect it just does a client-side filter of the first page of results or something. Since we know exactly what tag we want anyway, let's just look for that specific one.

Right now on old release branches, we end up rebuilding containers that already exist because we don't find them. This should take care of that.