### PR TITLE
Release spin with semver

### DIFF
--- a/dev/buildtool/spin_commands.py
+++ b/dev/buildtool/spin_commands.py
@@ -277,7 +277,7 @@ class PublishSpinCommand(CommandProcessor):
 
     release_branch = 'origin/release-{maj}.{min}.x'.format(
         maj=semver_parts[0], min=semver_parts[1])
-    release_tag = 'version-' + self.__stable_version
+    release_tag = 'v' + self.__stable_version
     logging.info('Pushing branch=%s and tag=%s to %s',
                  release_branch, release_tag, repository.origin)
     git.check_run_sequence(


### PR DESCRIPTION
## Why

Solves [Tag Spin release versions with semver](https://github.com/spinnaker/spinnaker/issues/6189).

In current Spin releases, it has many problems

* To import Spin in Go project, we have to specify the commit sha or the commit datetime because it does not use semver
* We can't use gorelease because it only supports semver. therefore, the spin is distributed with raw source code not the binary making users hard to setup in their environment
* etc