### PR TITLE
Fix the Artifact Registry URLs

### DIFF
--- a/dev/buildtool/ga-defaults.yml
+++ b/dev/buildtool/ga-defaults.yml
@@ -28,7 +28,7 @@ bintray_publish_wait_secs: -1
 # Halyard Commands
 ################################
 halyard_bucket_base_url: gs://spinnaker-artifacts/halyard
-halyard_docker_image_base: gcr.io/spinnaker-community/halyard
+halyard_docker_image_base: us-docker.pkg.dev/spinnaker-community/docker/halyard
 docs_repo_owner: spinnaker
 halyard_bom_bucket: halconfig
 
@@ -43,5 +43,5 @@ spin_build_credentials_path:
 ################################
 # Container Commands
 ################################
-docker_registry: gcr.io/spinnaker-community
+docker_registry: us-docker.pkg.dev/spinnaker-community/docker
 gcb_project: spinnaker-community

--- a/dev/validate-config-template.yml
+++ b/dev/validate-config-template.yml
@@ -72,7 +72,7 @@
 # halyard_config_bucket:    # only set to override
 # halyard_config_bucket_credentials:  # only set if needed by halyard_config_bucket
 # spinnaker_repository: https://dl.bintray.com/spinnaker-releases/debians
-# spinnaker_registry: gcr.io/spinnaker-community
+# spinnaker_registry: us-docker.pkg.dev/spinnaker-community/docker
 # deploy_spinnaker_type: # localdebian or distributed
 # deploy_hal_platform:   # one of gce, ec2, azure
 # deploy_haly_user:      # LOGNAME environment variable


### PR DESCRIPTION
Artifact Registry has multiple regions and allows multiple repositories
in a single project, so the URLs are more complicated.