### PR TITLE
Release Spin with semver

### DIFF
--- a/dev/buildtool/spin_commands.py
+++ b/dev/buildtool/spin_commands.py
@@ -436,7 +436,7 @@ def bump_spin_patch(git, git_dir, gate_version):
     patch = '0'
 
   # SemanticVersion.make() expects a tag, so formulate the input gate version as a tag.
-  spin_semver = SemanticVersion.make('version-{major}.{minor}.{patch}'
+  spin_semver = SemanticVersion.make('v{major}.{minor}.{patch}'
                                      .format(major=gate_semver.major,
                                              minor=gate_semver.minor,
                                              patch=patch))


### PR DESCRIPTION
## Why

Solves [Tag Spin release versions with semver](https://github.com/spinnaker/spinnaker/issues/6189).
Part 2 of https://github.com/spinnaker/buildtool/pull/170, I missed this update.

In current Spin releases, it has many problems

* To import Spin in Go project, we have to specify the commit sha or the commit datetime because it does not use semver
* We can't use gorelease because it only supports semver. therefore, the spin is distributed with raw source code not the binary making users hard to setup in their environment
* etc