### PR TITLE
chore(Revert): revert "feat(keel): add keel to build process (#156)"

### DIFF
--- a/dev/build_google_component_image.sh
+++ b/dev/build_google_component_image.sh
@@ -390,7 +390,6 @@ declare -A COMPONENTS=( ['clouddriver']='clouddriver' \
   ['gate']='gate' \
   ['igor']='igor' \
   ['kayenta']='kayenta' \
-  ['keel']='keel' \
   ['orca']='orca' \
   ['rosco']='rosco' \
   ['consul']='consul-server' \

--- a/dev/build_google_component_images.py
+++ b/dev/build_google_component_images.py
@@ -27,7 +27,7 @@ from build_release import run_shell_and_log, BuildFailure
 
 
 SUBSYSTEM_LIST = ['clouddriver', 'deck', 'echo', 'fiat', 'front50', 'gate',
-                  'igor', 'orca', 'rosco', 'consul', 'redis', 'vault', 'keel']
+                  'igor', 'orca', 'rosco', 'consul', 'redis', 'vault']
 
 
 class ComponentVmBuilder(object):

--- a/dev/buildtool/__init__.py
+++ b/dev/buildtool/__init__.py
@@ -7,8 +7,7 @@ SPINNAKER_RUNNABLE_REPOSITORY_NAMES = [
     'clouddriver',
     'deck',
     'echo', 'fiat', 'front50',
-    'gate', 'igor', 'kayenta',
-    'orca', 'rosco', 'keel']
+    'gate', 'igor', 'kayenta', 'orca', 'rosco']
 
 # For building and validating a release
 SPINNAKER_PROCESS_REPOSITORY_NAMES = ['buildtool', 'spinrel']

--- a/unittest/buildtool/bom_command_test.py
+++ b/unittest/buildtool/bom_command_test.py
@@ -171,7 +171,7 @@ class TestBuildBomCommand(BaseGitRepoTestFixture):
             origin='https://%s/TestOwner/%s' % (options.github_hostname, name),
             upstream='https://github.com/spinnaker/' + name)
         for name in sorted(['clouddriver', 'deck', 'echo', 'fiat', 'front50',
-                            'gate', 'igor', 'kayenta', 'orca', 'rosco', 'keel',
+                            'gate', 'igor', 'kayenta', 'orca', 'rosco',
                             'spinnaker-monitoring'])
     ]
     mock_filter.assert_called_once_with(bom_repo_list)


### PR DESCRIPTION
Reverts spinnaker/buildtool#171

Keel seems to be blocking the 1.26 release, removing it from the build for now. Facing issues with the gradle task, keel-sql:liquibaseUpdate