### PR TITLE
fix(build): stop publishing debians

### DIFF
--- a/dev/buildtool/halyard_commands.py
+++ b/dev/buildtool/halyard_commands.py
@@ -608,7 +608,8 @@ class PublishHalyardCommand(CommandProcessor):
   def _do_command(self):
     """Implements CommandProcessor interface."""
     repository = self._prepare_repository()
-    self._build_release(repository)
+    # Removing debian publishing, until we have a new place to push them to.
+    #self._build_release(repository)
     self._promote_halyard(repository)
     build_halyard_docs(self, repository)
     self.push_docs(repository)


### PR DESCRIPTION
cloudbuild is still publishing debs for halyard, commenting it out for now
https://console.cloud.google.com/cloud-build/builds;region=global/7807ec36-e957-403c-9887-9d5b150267f4?project=spinnaker-community