### PR TITLE
chore(ci): Add Flake8 linting

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,7 @@ jobs:
         run: python --version
       - name: Install dependencies with pip
         run: |
+          pip install flake8
           pip install -r dev/requirements.txt
           pip install -r dev/buildtool/requirements.txt
       - name: Setup for tests
@@ -25,3 +26,10 @@ jobs:
           git config --global user.email "sig-platform@spinnaker.io"
           git config --global user.name "Spinnaker GHA"
       - run: ./unittest/run_tests.sh
+      # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#using-the-python-starter-workflow
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/dev/build_google_component_images.py
+++ b/dev/build_google_component_images.py
@@ -26,87 +26,107 @@ import sys
 from build_release import run_shell_and_log, BuildFailure
 
 
-SUBSYSTEM_LIST = ['clouddriver', 'deck', 'echo', 'fiat', 'front50', 'gate',
-                  'igor', 'orca', 'rosco', 'consul', 'redis', 'vault']
+SUBSYSTEM_LIST = [
+    "clouddriver",
+    "deck",
+    "echo",
+    "fiat",
+    "front50",
+    "gate",
+    "igor",
+    "orca",
+    "rosco",
+    "consul",
+    "redis",
+    "vault",
+]
 
 
 class ComponentVmBuilder(object):
-  def __init__(self, options):
-    self.__account = options.account
-    self.__build_failures = []
-    self.__build_project = options.build_project
-    self.__install_script = options.install_script
-    self.__publish_project = options.publish_project
-    self.__publish_script = options.publish_script
-    self.__version = options.version
-    self.__zone = options.zone
+    def __init__(self, options):
+        self.__account = options.account
+        self.__build_failures = []
+        self.__build_project = options.build_project
+        self.__install_script = options.install_script
+        self.__publish_project = options.publish_project
+        self.__publish_script = options.publish_script
+        self.__version = options.version
+        self.__zone = options.zone
 
-  def __do_build(self, artifact):
-    cmds = [
-      './build_google_component_image.sh --artifact {artifact} --account {account} '
-      '--build_project {build_project} --install_script {install_script} '
-      '--publish_project {publish_project} --publish_script {publish_script} '
-      '--version {version} --zone {zone}'.format(
-        artifact=artifact,
-        account=self.__account,
-        build_project=self.__build_project,
-        install_script=self.__install_script,
-        publish_project=self.__publish_project,
-        publish_script=self.__publish_script,
-        version=self.__version,
-        zone=self.__zone
-      )
-    ]
-    try:
-      logfile = '{artifact}-vm-build.log'.format(artifact=artifact)
-      run_shell_and_log(cmds, logfile, cwd=os.path.abspath(os.path.dirname(__file__)))
-    except Exception as ex:
-      self.__build_failures.append(BuildFailure(artifact, ex))
+    def __do_build(self, artifact):
+        cmds = [
+            "./build_google_component_image.sh --artifact {artifact} --account {account} "
+            "--build_project {build_project} --install_script {install_script} "
+            "--publish_project {publish_project} --publish_script {publish_script} "
+            "--version {version} --zone {zone}".format(
+                artifact=artifact,
+                account=self.__account,
+                build_project=self.__build_project,
+                install_script=self.__install_script,
+                publish_project=self.__publish_project,
+                publish_script=self.__publish_script,
+                version=self.__version,
+                zone=self.__zone,
+            )
+        ]
+        try:
+            logfile = "{artifact}-vm-build.log".format(artifact=artifact)
+            run_shell_and_log(
+                cmds, logfile, cwd=os.path.abspath(os.path.dirname(__file__))
+            )
+        except Exception as ex:
+            self.__build_failures.append(BuildFailure(artifact, ex))
 
-  def __check_build_failures(self):
-    if self.__build_failures:
-      msg_lines = ['Builds failed:\n']
-      should_exit = False
-      for failure in self.__build_failures:
-        if failure.component in SUBSYSTEM_LIST:
-          should_exit = True
-          msg_lines.append('Building component {} failed with exception:'
-                           '\n{}\n'.format(failure.component, failure.exception))
-      if should_exit:
-        msg = '\n'.join(msg_lines)
-        raise RuntimeError(msg)
+    def __check_build_failures(self):
+        if self.__build_failures:
+            msg_lines = ["Builds failed:\n"]
+            should_exit = False
+            for failure in self.__build_failures:
+                if failure.component in SUBSYSTEM_LIST:
+                    should_exit = True
+                    msg_lines.append(
+                        "Building component {} failed with exception:"
+                        "\n{}\n".format(failure.component, failure.exception)
+                    )
+            if should_exit:
+                msg = "\n".join(msg_lines)
+                raise RuntimeError(msg)
 
-  def build_component_images(self):
-    pool = multiprocessing.pool.ThreadPool(processes=5) # Probably should be an argument.
-    pool.map(self.__do_build, SUBSYSTEM_LIST)
-    self.__check_build_failures()
+    def build_component_images(self):
+        pool = multiprocessing.pool.ThreadPool(
+            processes=5
+        )  # Probably should be an argument.
+        pool.map(self.__do_build, SUBSYSTEM_LIST)
+        self.__check_build_failures()
 
-  @classmethod
-  def init_argument_parser(cls, parser):
-    parser.add_argument('--account',
-                        help='GCP service account to use.')
-    parser.add_argument('--build_project',
-                        help='GCP project to build the component images in.')
-    parser.add_argument('--install_script',
-                        help='Path to the install script to run when building'
-                        'the component image.')
-    parser.add_argument('--publish_project',
-                        help='GCP project to publish the component images to.')
-    parser.add_argument('--publish_script',
-                        help='Script to use to publish the component images.')
-    parser.add_argument('--version',
-                        help='Spinnaker release version to use.')
-    parser.add_argument('--zone',
-                        help='GCP zone to use when creating the images.')
+    @classmethod
+    def init_argument_parser(cls, parser):
+        parser.add_argument("--account", help="GCP service account to use.")
+        parser.add_argument(
+            "--build_project", help="GCP project to build the component images in."
+        )
+        parser.add_argument(
+            "--install_script",
+            help="Path to the install script to run when building"
+            "the component image.",
+        )
+        parser.add_argument(
+            "--publish_project", help="GCP project to publish the component images to."
+        )
+        parser.add_argument(
+            "--publish_script", help="Script to use to publish the component images."
+        )
+        parser.add_argument("--version", help="Spinnaker release version to use.")
+        parser.add_argument("--zone", help="GCP zone to use when creating the images.")
 
-  @classmethod
-  def main(cls):
-    parser = argparse.ArgumentParser()
-    cls.init_argument_parser(parser)
-    options = parser.parse_args()
-    vm_image_builder = cls(options)
-    vm_image_builder.build_component_images()
+    @classmethod
+    def main(cls):
+        parser = argparse.ArgumentParser()
+        cls.init_argument_parser(parser)
+        options = parser.parse_args()
+        vm_image_builder = cls(options)
+        vm_image_builder.build_component_images()
 
 
-if __name__ == '__main__':
-  sys.exit(ComponentVmBuilder.main())
+if __name__ == "__main__":
+    sys.exit(ComponentVmBuilder.main())

--- a/dev/buildtool/__init__.py
+++ b/dev/buildtool/__init__.py
@@ -4,40 +4,46 @@
 
 # These would be required if running from source code
 SPINNAKER_RUNNABLE_REPOSITORY_NAMES = [
-    'clouddriver',
-    'deck',
-    'echo', 'fiat', 'front50',
-    'gate', 'igor', 'kayenta', 'orca', 'rosco']
+    "clouddriver",
+    "deck",
+    "echo",
+    "fiat",
+    "front50",
+    "gate",
+    "igor",
+    "kayenta",
+    "orca",
+    "rosco",
+]
 
 # For building and validating a release
-SPINNAKER_PROCESS_REPOSITORY_NAMES = ['buildtool', 'spinrel']
+SPINNAKER_PROCESS_REPOSITORY_NAMES = ["buildtool", "spinrel"]
 
 # Additional tools that accompany a release
-SPIN_REPOSITORY_NAMES = ['spin']
+SPIN_REPOSITORY_NAMES = ["spin"]
 
 # Halyard is independent of spinnaker
-SPINNAKER_HALYARD_REPOSITORY_NAME = 'halyard'
+SPINNAKER_HALYARD_REPOSITORY_NAME = "halyard"
 
 # Documentation is version agnostic
-SPINNAKER_IO_REPOSITORY_NAME = 'spinnaker.io'
+SPINNAKER_IO_REPOSITORY_NAME = "spinnaker.io"
 
 # Artifact sources are per GitHub Action build jobs
-SPINNAKER_DEBIAN_REPOSITORY = 'https://us-apt.pkg.dev/projects/spinnaker-community'
-SPINNAKER_DOCKER_REGISTRY = 'us-docker.pkg.dev/spinnaker-community/docker'
-SPINNAKER_GOOGLE_IMAGE_PROJECT = 'marketplace-spinnaker-release'
+SPINNAKER_DEBIAN_REPOSITORY = "https://us-apt.pkg.dev/projects/spinnaker-community"
+SPINNAKER_DOCKER_REGISTRY = "us-docker.pkg.dev/spinnaker-community/docker"
+SPINNAKER_GOOGLE_IMAGE_PROJECT = "marketplace-spinnaker-release"
 
 
 from buildtool.util import (
     DEFAULT_BUILD_NUMBER,
     add_parser_argument,
     unused_port,
-
     log_timestring,
     timedelta_string,
     log_embedded_output,
-
     ensure_dir_exists,
-    write_to_path)
+    write_to_path,
+)
 
 from buildtool.errors import (
     BuildtoolError,
@@ -46,18 +52,16 @@ from buildtool.errors import (
     ResponseError,
     TimeoutError,
     UnexpectedError,
-
     exception_to_message,
     maybe_log_exception,
     raise_and_log_error,
-
     check_kwargs_empty,
     check_options_set,
     check_path_exists,
-
     # This is very specialized, but here to share
     # between validate_bom__deploy and image_commands
-    scan_logs_for_install_errors)
+    scan_logs_for_install_errors,
+)
 
 from buildtool.subprocess_support import (
     start_subprocess,
@@ -67,42 +71,37 @@ from buildtool.subprocess_support import (
     check_subprocess_sequence,
     run_subprocess_sequence,
     check_subprocesses_to_logfile,
-    determine_subprocess_outcome_labels)
+    determine_subprocess_outcome_labels,
+)
 
 from buildtool.git_support import (
     GitRepositorySpec,
     GitRunner,
-
     CommitMessage,
     CommitTag,
     RepositorySummary,
-    SemanticVersion)
+    SemanticVersion,
+)
 
-from buildtool.hal_support import (
-    HalRunner)
+from buildtool.hal_support import HalRunner
 
-from buildtool.scm import (
-    SourceInfo,
-    SpinnakerSourceCodeManager)
+from buildtool.scm import SourceInfo, SpinnakerSourceCodeManager
 
-from buildtool.bom_scm import (
-    SPINNAKER_BOM_REPOSITORY_NAMES,
-    BomSourceCodeManager)
+from buildtool.bom_scm import SPINNAKER_BOM_REPOSITORY_NAMES, BomSourceCodeManager
 
-from buildtool.branch_scm import (
-    BranchSourceCodeManager)
+from buildtool.branch_scm import BranchSourceCodeManager
 
-from buildtool.command import (
-    CommandFactory,
-    CommandProcessor)
+from buildtool.command import CommandFactory, CommandProcessor
 
 from buildtool.repository_command import (
     RepositoryCommandProcessor,
-    RepositoryCommandFactory)
+    RepositoryCommandFactory,
+)
 
 from buildtool.gradle_support import (
     GradleCommandFactory,
     GradleCommandProcessor,
-    GradleRunner)
+    GradleRunner,
+)
 
 from buildtool.metrics import MetricsManager

--- a/dev/buildtool/__main__.py
+++ b/dev/buildtool/__main__.py
@@ -33,17 +33,14 @@ import time
 import yaml
 
 from buildtool.metrics import MetricsManager
-from buildtool import (
-    add_parser_argument,
-    maybe_log_exception,
-    GitRunner)
+from buildtool import add_parser_argument, maybe_log_exception, GitRunner
 
 
 STANDARD_LOG_LEVELS = {
-    'debug': logging.DEBUG,
-    'info': logging.INFO,
-    'warning': logging.WARNING,
-    'error': logging.ERROR
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
 }
 
 # This is so tests can disable it
@@ -51,265 +48,304 @@ CHECK_HOME_FOR_CONFIG = True
 
 
 def add_standard_parser_args(parser, defaults):
-  """Init argparser with command-independent options.
+    """Init argparser with command-independent options.
 
-  Args:
-    parser: [argparse.Parser]
-    defaults: [dict]  Default value overrides keyed by option name.
-  """
-  parser.add_argument(
-      'components', nargs='*', default=defaults.get('components', None),
-      help='Restrict commands to these components or repository names')
+    Args:
+      parser: [argparse.Parser]
+      defaults: [dict]  Default value overrides keyed by option name.
+    """
+    parser.add_argument(
+        "components",
+        nargs="*",
+        default=defaults.get("components", None),
+        help="Restrict commands to these components or repository names",
+    )
 
-  add_parser_argument(
-      parser, 'default_args_file', defaults, None,
-      help='Path to YAML file containing command-line option overrides.'
-           ' The default is $HOME/.spinnaker/buildtool.yml if present.'
-           ' This parameter will overload the defaults. Embedded'
-           ' default_args_file will also be read at a lower precedence than'
-           ' the containing file.')
+    add_parser_argument(
+        parser,
+        "default_args_file",
+        defaults,
+        None,
+        help="Path to YAML file containing command-line option overrides."
+        " The default is $HOME/.spinnaker/buildtool.yml if present."
+        " This parameter will overload the defaults. Embedded"
+        " default_args_file will also be read at a lower precedence than"
+        " the containing file.",
+    )
 
-  add_parser_argument(
-      parser, 'log_level', defaults, 'info',
-      choices=STANDARD_LOG_LEVELS.keys(),
-      help='Set the logging level')
-  add_parser_argument(
-      parser, 'output_dir', defaults, 'output',
-      help='Directory to write working files.')
-  add_parser_argument(
-      parser, 'input_dir', defaults, 'source_code',
-      help='Directory to cache input files, such as cloning git repos.')
-  add_parser_argument(
-      parser, 'one_at_a_time', defaults, False, type=bool,
-      help='Do not perform applicable concurrency, for debugging.')
-  add_parser_argument(
-      parser, 'parent_invocation_id', defaults,
-      '{:%y%m%d}.{}'.format(datetime.datetime.utcnow(), os.getpid()),
-      help='For identifying the context of the metrics data to be produced.')
+    add_parser_argument(
+        parser,
+        "log_level",
+        defaults,
+        "info",
+        choices=STANDARD_LOG_LEVELS.keys(),
+        help="Set the logging level",
+    )
+    add_parser_argument(
+        parser,
+        "output_dir",
+        defaults,
+        "output",
+        help="Directory to write working files.",
+    )
+    add_parser_argument(
+        parser,
+        "input_dir",
+        defaults,
+        "source_code",
+        help="Directory to cache input files, such as cloning git repos.",
+    )
+    add_parser_argument(
+        parser,
+        "one_at_a_time",
+        defaults,
+        False,
+        type=bool,
+        help="Do not perform applicable concurrency, for debugging.",
+    )
+    add_parser_argument(
+        parser,
+        "parent_invocation_id",
+        defaults,
+        "{:%y%m%d}.{}".format(datetime.datetime.utcnow(), os.getpid()),
+        help="For identifying the context of the metrics data to be produced.",
+    )
 
 
 def __load_defaults_from_path(path, visited=None):
-  """Helper function for loading defaults from yaml file."""
-  visited = visited or []
-  if path in visited:
-    raise ValueError('Circular "default_args_file" dependency in %s' % path)
-  visited.append(path)
+    """Helper function for loading defaults from yaml file."""
+    visited = visited or []
+    if path in visited:
+        raise ValueError('Circular "default_args_file" dependency in %s' % path)
+    visited.append(path)
 
-  with open(path, 'r') as f:
-    defaults = yaml.safe_load(f)
+    with open(path, "r") as f:
+        defaults = yaml.safe_load(f)
 
-    # Allow these files to be recursive
-    # So that there can be some overall default file
-    # that is then overwridden by another file where
-    # the override file references the default one
-    # and the CLI argument points to the override file.
-    base_defaults_file = defaults.get('default_args_file')
+        # Allow these files to be recursive
+        # So that there can be some overall default file
+        # that is then overwridden by another file where
+        # the override file references the default one
+        # and the CLI argument points to the override file.
+        base_defaults_file = defaults.get("default_args_file")
 
-    if base_defaults_file:
-      base_defaults = __load_defaults_from_path(base_defaults_file)
-      base_defaults.update(defaults)  # base is lower precedence.
-      defaults = base_defaults        # defaults is what we want to return.
+        if base_defaults_file:
+            base_defaults = __load_defaults_from_path(base_defaults_file)
+            base_defaults.update(defaults)  # base is lower precedence.
+            defaults = base_defaults  # defaults is what we want to return.
 
-  return defaults
+    return defaults
 
 
-def preprocess_args(args, default_home_path_filename='buildtool.yml'):
-  """Preprocess the args to determine the defaults to use.
+def preprocess_args(args, default_home_path_filename="buildtool.yml"):
+    """Preprocess the args to determine the defaults to use.
 
-  This recognizes the --default_args_file override and, if present loads them.
+    This recognizes the --default_args_file override and, if present loads them.
 
-  Returns:
-    args, defaults
-    Where:
-      args are remaining arguments (with--default_args_file removed
-      defaults are overriden defaults from the default_args_file, if present.
-  """
-  parser = argparse.ArgumentParser(add_help=False)
-  parser.add_argument('--default_args_file', default=None)
+    Returns:
+      args, defaults
+      Where:
+        args are remaining arguments (with--default_args_file removed
+        defaults are overriden defaults from the default_args_file, if present.
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--default_args_file", default=None)
 
-  options, args = parser.parse_known_args(args)
+    options, args = parser.parse_known_args(args)
 
-  home_path = os.path.join(os.environ['HOME'], '.spinnaker',
-                           default_home_path_filename)
-  if CHECK_HOME_FOR_CONFIG and os.path.exists(home_path):
-    defaults = __load_defaults_from_path(home_path)
-    defaults['default_args_file'] = home_path
-  else:
-    defaults = {}
+    home_path = os.path.join(
+        os.environ["HOME"], ".spinnaker", default_home_path_filename
+    )
+    if CHECK_HOME_FOR_CONFIG and os.path.exists(home_path):
+        defaults = __load_defaults_from_path(home_path)
+        defaults["default_args_file"] = home_path
+    else:
+        defaults = {}
 
-  if options.default_args_file:
-    override_defaults = __load_defaults_from_path(options.default_args_file)
-    override_defaults['default_args_file'] = options.default_args_file
-    defaults.update(override_defaults)
+    if options.default_args_file:
+        override_defaults = __load_defaults_from_path(options.default_args_file)
+        override_defaults["default_args_file"] = options.default_args_file
+        defaults.update(override_defaults)
 
-  return args, defaults
+    return args, defaults
 
 
 def make_registry(command_modules, parser, defaults):
-  """Creates a command registry, adding command arguments to the parser.
+    """Creates a command registry, adding command arguments to the parser.
 
-  Args:
-    command_modules: [list of modules]  The modules that have commands
-      to register. Each module should have a function
-          register_commands(registry, subparsers, defaults)
-      that will register CommandFactory instances into the registry.
-    parser: [ArgumentParser] The parser to add commands to
-       This adds a 'command' subparser to capture the requested command choice.
-    defaults: [dict] Default values to specify when adding arguments.
-  """
-  registry = {}
+    Args:
+      command_modules: [list of modules]  The modules that have commands
+        to register. Each module should have a function
+            register_commands(registry, subparsers, defaults)
+        that will register CommandFactory instances into the registry.
+      parser: [ArgumentParser] The parser to add commands to
+         This adds a 'command' subparser to capture the requested command choice.
+      defaults: [dict] Default values to specify when adding arguments.
+    """
+    registry = {}
 
-  subparsers = parser.add_subparsers(title='command', dest='command')
-  for module in command_modules:
-    module.register_commands(registry, subparsers, defaults)
-  return registry
+    subparsers = parser.add_subparsers(title="command", dest="command")
+    for module in command_modules:
+        module.register_commands(registry, subparsers, defaults)
+    return registry
 
 
 def add_monitoring_context_labels(options):
-  option_dict = vars(options)
-  version_name = option_dict.get('git_branch', None)
-  if not version_name:
-    bom_name = option_dict.get('bom_version') or option_dict.get('bom_path')
-    if bom_name:
-      if bom_name.find('-unbuilt') > 0:
-        version_name = bom_name[:bom_name.find('-unbuilt')]
-      elif bom_name.find('-latest') > 0:
-        version_name = bom_name[:bom_name.find('-latest')]
-      else:
-        version_name = bom_name[:bom_name.rfind('-')]
+    option_dict = vars(options)
+    version_name = option_dict.get("git_branch", None)
+    if not version_name:
+        bom_name = option_dict.get("bom_version") or option_dict.get("bom_path")
+        if bom_name:
+            if bom_name.find("-unbuilt") > 0:
+                version_name = bom_name[: bom_name.find("-unbuilt")]
+            elif bom_name.find("-latest") > 0:
+                version_name = bom_name[: bom_name.find("-latest")]
+            else:
+                version_name = bom_name[: bom_name.rfind("-")]
 
-  if version_name:
-    context_labels = ['version=' + version_name]
-    if (version_name == 'master'
-        or version_name.startswith('release-')
-        or version_name.startswith('master-latest-')):
-      context_labels.append('official_version='+version_name)
-    if options.monitoring_context_labels:
-      context_labels.append(options.monitoring_context_labels)
-    options.monitoring_context_labels = ','.join(context_labels)
+    if version_name:
+        context_labels = ["version=" + version_name]
+        if (
+            version_name == "master"
+            or version_name.startswith("release-")
+            or version_name.startswith("master-latest-")
+        ):
+            context_labels.append("official_version=" + version_name)
+        if options.monitoring_context_labels:
+            context_labels.append(options.monitoring_context_labels)
+        options.monitoring_context_labels = ",".join(context_labels)
 
 
 def init_options_and_registry(args, command_modules):
-  """Register command modules and determine options from commandline.
+    """Register command modules and determine options from commandline.
 
-  These are coupled together for implementation simplicity. Conceptually
-  they are unrelated but they share implementation details that can be
-  encapsulated by combining them this way.
+    These are coupled together for implementation simplicity. Conceptually
+    they are unrelated but they share implementation details that can be
+    encapsulated by combining them this way.
 
-  Args:
-    args: [list of command-line arguments]
-    command_modules: See make_registry.
+    Args:
+      args: [list of command-line arguments]
+      command_modules: See make_registry.
 
-  Returns:
-    options, registry
+    Returns:
+      options, registry
 
-    Where:
-      options: [Namespace] From parsed args.
-      registry: [dict] of (<command-name>: <CommandFactory>)
-  """
-  args, defaults = preprocess_args(args)
+      Where:
+        options: [Namespace] From parsed args.
+        registry: [dict] of (<command-name>: <CommandFactory>)
+    """
+    args, defaults = preprocess_args(args)
 
-  parser = argparse.ArgumentParser(prog='buildtool.sh')
-  add_standard_parser_args(parser, defaults)
-  MetricsManager.init_argument_parser(parser, defaults)
+    parser = argparse.ArgumentParser(prog="buildtool.sh")
+    add_standard_parser_args(parser, defaults)
+    MetricsManager.init_argument_parser(parser, defaults)
 
-  registry = make_registry(command_modules, parser, defaults)
-  options = parser.parse_args(args)
-  options.program = 'buildtool'
+    registry = make_registry(command_modules, parser, defaults)
+    options = parser.parse_args(args)
+    options.program = "buildtool"
 
-  # Determine the version for monitoring purposes.
-  # Depending on the options defined, this is either the branch or bom prefix.
-  add_monitoring_context_labels(options)
+    # Determine the version for monitoring purposes.
+    # Depending on the options defined, this is either the branch or bom prefix.
+    add_monitoring_context_labels(options)
 
-  return options, registry
+    return options, registry
 
 
 def main():
-  """The main command dispatcher."""
+    """The main command dispatcher."""
 
-  start_time = time.time()
+    start_time = time.time()
 
-  from importlib import import_module
-  command_modules = [
-      import_module(name + '_commands') for name in [
-          'apidocs',
-          'bom',
-          'changelog',
-          'halyard',
-          'image',
-          'source',
-          'spinnaker',
-          'inspection',
-      ]]
+    from importlib import import_module
 
-  GitRunner.stash_and_clear_auth_env_vars()
-  options, command_registry = init_options_and_registry(
-      sys.argv[1:], command_modules)
+    command_modules = [
+        import_module(name + "_commands")
+        for name in [
+            "apidocs",
+            "bom",
+            "changelog",
+            "halyard",
+            "image",
+            "source",
+            "spinnaker",
+            "inspection",
+        ]
+    ]
 
-  logging.basicConfig(
-      format='%(levelname).1s %(asctime)s.%(msecs)03d'
-             ' [%(threadName)s.%(process)d] %(message)s',
-      datefmt='%H:%M:%S',
-      level=STANDARD_LOG_LEVELS[options.log_level])
+    GitRunner.stash_and_clear_auth_env_vars()
+    options, command_registry = init_options_and_registry(sys.argv[1:], command_modules)
 
-  logging.debug(
-      'Running with options:\n   %s',
-      '\n   '.join(yaml.safe_dump(vars(options), default_flow_style=False)
-                   .split('\n')))
+    logging.basicConfig(
+        format="%(levelname).1s %(asctime)s.%(msecs)03d"
+        " [%(threadName)s.%(process)d] %(message)s",
+        datefmt="%H:%M:%S",
+        level=STANDARD_LOG_LEVELS[options.log_level],
+    )
 
-  factory = command_registry.get(options.command)
-  if not factory:
-    logging.error('Unknown command "%s"', options.command)
-    return -1
+    logging.debug(
+        "Running with options:\n   %s",
+        "\n   ".join(
+            yaml.safe_dump(vars(options), default_flow_style=False).split("\n")
+        ),
+    )
 
-  MetricsManager.startup_metrics(options)
-  labels = {'command': options.command}
-  success = False
-  try:
-    command = factory.make_command(options)
-    command()
-    success = True
-  finally:
-    labels['success'] = success
-    MetricsManager.singleton().observe_timer(
-        'BuildTool_Outcome', labels,
-        time.time() - start_time)
-    MetricsManager.shutdown_metrics()
+    factory = command_registry.get(options.command)
+    if not factory:
+        logging.error('Unknown command "%s"', options.command)
+        return -1
 
-  return 0
+    MetricsManager.startup_metrics(options)
+    labels = {"command": options.command}
+    success = False
+    try:
+        command = factory.make_command(options)
+        command()
+        success = True
+    finally:
+        labels["success"] = success
+        MetricsManager.singleton().observe_timer(
+            "BuildTool_Outcome", labels, time.time() - start_time
+        )
+        MetricsManager.shutdown_metrics()
+
+    return 0
 
 
 def dump_threads():
-  """Dump current threads to facilitate debugging possible deadlock.
+    """Dump current threads to facilitate debugging possible deadlock.
 
-  A process did not exit when log file suggested it was. Maybe there was
-  a background thread it was joining on. If so, this might give a clue
-  should it happen again.
-  """
-  import threading
-  threads = []
-  for thread in threading.enumerate():
-    threads.append('  name={name} daemon={d} id={id}'.format(
-        name=thread.name, d=thread.daemon, id=thread.ident))
+    A process did not exit when log file suggested it was. Maybe there was
+    a background thread it was joining on. If so, this might give a clue
+    should it happen again.
+    """
+    import threading
 
-  if len(threads) > 1:
-    logging.info('The following threads still running:\n%s', '\n'.join(threads))
+    threads = []
+    for thread in threading.enumerate():
+        threads.append(
+            "  name={name} daemon={d} id={id}".format(
+                name=thread.name, d=thread.daemon, id=thread.ident
+            )
+        )
+
+    if len(threads) > 1:
+        logging.info("The following threads still running:\n%s", "\n".join(threads))
 
 
 def wrapped_main():
-  """Run main and dump outstanding threads when done."""
-  # pylint: disable=broad-except
-  try:
-    retcode = main()
-  except Exception as ex:
-    sys.stdout.flush()
-    maybe_log_exception('main()', ex, action_msg='Terminating')
-    logging.error("FAILED")
-    retcode = -1
+    """Run main and dump outstanding threads when done."""
+    # pylint: disable=broad-except
+    try:
+        retcode = main()
+    except Exception as ex:
+        sys.stdout.flush()
+        maybe_log_exception("main()", ex, action_msg="Terminating")
+        logging.error("FAILED")
+        retcode = -1
 
-  dump_threads()
-  return retcode
+    dump_threads()
+    return retcode
 
 
-if __name__ == '__main__':
-  sys.exit(wrapped_main())
+if __name__ == "__main__":
+    sys.exit(wrapped_main())

--- a/dev/buildtool/apidocs_commands.py
+++ b/dev/buildtool/apidocs_commands.py
@@ -21,24 +21,21 @@ import shutil
 import time
 
 try:
-  from urllib2 import urlopen
-  from urllib2 import URLError
+    from urllib2 import urlopen
+    from urllib2 import URLError
 except ImportError:
-  from urllib.request import urlopen
-  from urllib.error import URLError
+    from urllib.request import urlopen
+    from urllib.error import URLError
 
 from buildtool import (
     SPINNAKER_IO_REPOSITORY_NAME,
-
     RepositoryCommandFactory,
     RepositoryCommandProcessor,
     CommandFactory,
     CommandProcessor,
-
     BomSourceCodeManager,
     BranchSourceCodeManager,
     GitRunner,
-
     check_options_set,
     check_path_exists,
     check_subprocess,
@@ -52,330 +49,388 @@ from buildtool import (
     ensure_dir_exists,
     raise_and_log_error,
     TimeoutError,
-    UnexpectedError)
+    UnexpectedError,
+)
 
 
-SWAGGER_URL_PATHS = {
-    'gate': 'v2/api-docs'
-}
+SWAGGER_URL_PATHS = {"gate": "v2/api-docs"}
 
-BUILD_DOCS_COMMAND = 'build_apidocs'
+BUILD_DOCS_COMMAND = "build_apidocs"
 
 
 def make_options_with_fallback(options):
-  """A hack for now, using git_fallback_branch to support spinnaker.io
+    """A hack for now, using git_fallback_branch to support spinnaker.io
 
-  That repo does not use the release branches, rather master.
-  So if creating a release, it will fallback to master for that repo.
-  """
-  options_copy = copy.copy(options)
-  options_copy.git_fallback_branch = 'master'
-  return options_copy
+    That repo does not use the release branches, rather master.
+    So if creating a release, it will fallback to master for that repo.
+    """
+    options_copy = copy.copy(options)
+    options_copy.git_fallback_branch = "master"
+    return options_copy
 
 
 class BuildApiDocsCommand(RepositoryCommandProcessor):
-  """Implements build_api_docs command."""
+    """Implements build_api_docs command."""
 
-  def __init__(self, factory, options, **kwargs):
-    super(BuildApiDocsCommand, self).__init__(
-        factory, options, source_repository_names=['gate'], **kwargs)
-    self._check_args()
-    self.__templates_directory = None
+    def __init__(self, factory, options, **kwargs):
+        super(BuildApiDocsCommand, self).__init__(
+            factory, options, source_repository_names=["gate"], **kwargs
+        )
+        self._check_args()
+        self.__templates_directory = None
 
-  def _check_args(self):
-    options = self.options
-    check_options_set(options, ['swagger_codegen_cli_jar_path'])
-    check_path_exists(options.swagger_codegen_cli_jar_path,
-                      why='options.swagger_codegen_cli_jar_path')
+    def _check_args(self):
+        options = self.options
+        check_options_set(options, ["swagger_codegen_cli_jar_path"])
+        check_path_exists(
+            options.swagger_codegen_cli_jar_path,
+            why="options.swagger_codegen_cli_jar_path",
+        )
 
-  def _ensure_templates_directory(self):
-    """Initialize the templates_directory, pulling the repo if needed."""
-    scm = BranchSourceCodeManager(
-        make_options_with_fallback(self.options),
-        self.get_input_dir())
-    repository = scm.make_repository_spec(SPINNAKER_IO_REPOSITORY_NAME)
+    def _ensure_templates_directory(self):
+        """Initialize the templates_directory, pulling the repo if needed."""
+        scm = BranchSourceCodeManager(
+            make_options_with_fallback(self.options), self.get_input_dir()
+        )
+        repository = scm.make_repository_spec(SPINNAKER_IO_REPOSITORY_NAME)
 
-    # These documents arent tied to version control, especially since they are
-    # published to a different repository.
-    scm.ensure_git_path(repository)
+        # These documents arent tied to version control, especially since they are
+        # published to a different repository.
+        scm.ensure_git_path(repository)
 
-    self.__templates_directory = os.path.join(
-        repository.git_dir, '_api_templates')
+        self.__templates_directory = os.path.join(repository.git_dir, "_api_templates")
 
-  def _do_command(self):
-    """Wraps base method so we can start/stop redis if needed."""
-    self._ensure_templates_directory()
-    redis_name = 'redis-server'
-    start_redis = run_subprocess('sudo service %s start' % redis_name)[0] != 0
-    logging.debug('redis-server %s running.',
-                  'IS NOT' if start_redis else 'IS')
+    def _do_command(self):
+        """Wraps base method so we can start/stop redis if needed."""
+        self._ensure_templates_directory()
+        redis_name = "redis-server"
+        start_redis = run_subprocess("sudo service %s start" % redis_name)[0] != 0
+        logging.debug("redis-server %s running.", "IS NOT" if start_redis else "IS")
 
-    try:
-      if start_redis:
-        check_subprocess('sudo service %s start' % redis_name)
-      super(BuildApiDocsCommand, self)._do_command()
-    finally:
-      if start_redis:
+        try:
+            if start_redis:
+                check_subprocess("sudo service %s start" % redis_name)
+            super(BuildApiDocsCommand, self)._do_command()
+        finally:
+            if start_redis:
+                # pylint: disable=broad-except
+                try:
+                    check_subprocess("sudo service %s stop" % redis_name)
+                except Exception as ex:
+                    maybe_log_exception(
+                        self.name,
+                        ex,
+                        "Ignoring exception while stopping temporary " + redis_name,
+                    )
+
+    def wait_for_url(self, url, timeout_secs):
+        """Wait for url to be ready or timeout."""
+        logging.info("Waiting for %s", url)
+        for _ in range(timeout_secs):
+            try:
+                code = urlopen(url).getcode()
+                if code >= 200 and code < 300:
+                    logging.info("%s is ready", url)
+                    return
+            except URLError:
+                time.sleep(1)
+
+        raise_and_log_error(
+            TimeoutError("%s not ready" % url),
+            "%s not ready after %s secs" % (url, timeout_secs),
+        )
+
+    def __generate_json_from_url(self, repository, server_url, output_path):
+        """Build the swagger json from the swagger endpoint."""
+        ensure_dir_exists(os.path.dirname(output_path))
+        logging.info("Generating swagger docs for %s", repository.name)
+        check_subprocess(
+            "curl -s {url} -o {output_path}".format(
+                url=server_url, output_path=output_path
+            )
+        )
+
+    def build_swagger_docs(self, repository, json_path):
+        """Build the API from the swagger endpoint."""
+        if repository.name != "gate":
+            raise_and_log_error(
+                UnexpectedError('Repo "%s" != "gate"' % repository.name)
+            )
+
+        docs_dir = os.path.dirname(json_path)
+        check_subprocess(
+            "java -jar {jar_path} generate -i {json_path} -l html2"
+            " -o {output_dir} -t {templates_directory}".format(
+                jar_path=self.options.swagger_codegen_cli_jar_path,
+                json_path=json_path,
+                output_dir=docs_dir,
+                templates_directory=self.__templates_directory,
+            )
+        )
+        logging.info("Writing docs to directory %s", docs_dir)
+
+    def _do_repository(self, repository):
+        generate_path = self.options.generate_swagger_path
+        if not generate_path:
+            self.__build_from_live_server(repository)
+            return
+
+        swagger_dir = os.path.dirname(generate_path)
+        generate_logfile = self.get_logfile_path(repository.name + "-generate_swagger")
+        check_subprocesses_to_logfile(
+            "Extracting API to JSON",
+            generate_logfile,
+            [generate_path],
+            cwd=repository.git_dir,
+        )
+
+        docs_dir = self.get_output_dir()
+        ensure_dir_exists(docs_dir)
+        json_path = os.path.join(docs_dir, "docs.json")
+        swagger_output_path = os.path.join(
+            repository.git_dir, swagger_dir, "swagger.json"
+        )
+        with open(swagger_output_path, "r") as stream:
+            content = stream.read()
+        with open(json_path, "w") as stream:
+            stream.write(content)
+        self.build_swagger_docs(repository, json_path)
+
+    def __build_from_live_server(self, repository):
+        """Implements CommandProcessor interface."""
+        docs_url_path = SWAGGER_URL_PATHS[repository.name]
+        env = dict(os.environ)
+        port = unused_port()
+        env["SERVER_PORT"] = str(port)
+        base_url = "http://localhost:" + str(port)
+
+        gate_logfile = self.get_logfile_path(repository.name + "-apidocs-server")
+        logging.info(
+            "Starting up prototype %s so we can extract docs from it."
+            " We will log this instance to %s",
+            repository.name,
+            gate_logfile,
+        )
+        boot_run_cmd = "./gradlew"  # default will run
+        ensure_dir_exists(os.path.dirname(gate_logfile))
+        gate_logstream = open(gate_logfile, "w")
+        process = start_subprocess(
+            boot_run_cmd,
+            stream=gate_logstream,
+            stdout=gate_logstream,
+            cwd=repository.git_dir,
+            env=env,
+        )
+
+        max_wait_secs = self.options.max_wait_secs_startup
         # pylint: disable=broad-except
         try:
-          check_subprocess('sudo service %s stop' % redis_name)
-        except Exception as ex:
-          maybe_log_exception(
-              self.name, ex,
-              'Ignoring exception while stopping temporary ' + redis_name)
-
-  def wait_for_url(self, url, timeout_secs):
-    """Wait for url to be ready or timeout."""
-    logging.info('Waiting for %s', url)
-    for _ in range(timeout_secs):
-      try:
-        code = urlopen(url).getcode()
-        if code >= 200 and code < 300:
-          logging.info('%s is ready', url)
-          return
-      except URLError:
-        time.sleep(1)
-
-    raise_and_log_error(
-        TimeoutError('%s not ready' % url),
-        '%s not ready after %s secs' % (url, timeout_secs))
-
-  def __generate_json_from_url(
-      self, repository, server_url, output_path):
-    """Build the swagger json from the swagger endpoint."""
-    ensure_dir_exists(os.path.dirname(output_path))
-    logging.info('Generating swagger docs for %s', repository.name)
-    check_subprocess('curl -s {url} -o {output_path}'
-                     .format(url=server_url, output_path=output_path))
-
-  def build_swagger_docs(self, repository, json_path):
-    """Build the API from the swagger endpoint."""
-    if repository.name != 'gate':
-      raise_and_log_error(
-          UnexpectedError('Repo "%s" != "gate"' % repository.name))
-
-    docs_dir = os.path.dirname(json_path)
-    check_subprocess(
-        'java -jar {jar_path} generate -i {json_path} -l html2'
-        ' -o {output_dir} -t {templates_directory}'
-        .format(jar_path=self.options.swagger_codegen_cli_jar_path,
-                json_path=json_path, output_dir=docs_dir,
-                templates_directory=self.__templates_directory))
-    logging.info('Writing docs to directory %s', docs_dir)
-
-  def _do_repository(self, repository):
-    generate_path = self.options.generate_swagger_path
-    if not generate_path:
-      self.__build_from_live_server(repository)
-      return
-
-    swagger_dir = os.path.dirname(generate_path)
-    generate_logfile = self.get_logfile_path(
-        repository.name + '-generate_swagger')
-    check_subprocesses_to_logfile(
-        'Extracting API to JSON', generate_logfile, [generate_path],
-        cwd=repository.git_dir)
-
-    docs_dir = self.get_output_dir()
-    ensure_dir_exists(docs_dir)
-    json_path = os.path.join(docs_dir, 'docs.json')
-    swagger_output_path = os.path.join(
-        repository.git_dir, swagger_dir, 'swagger.json')
-    with open(swagger_output_path, 'r') as stream:
-      content = stream.read()
-    with open(json_path, 'w') as stream:
-      stream.write(content)
-    self.build_swagger_docs(repository, json_path)
-
-  def __build_from_live_server(self, repository):
-    """Implements CommandProcessor interface."""
-    docs_url_path = SWAGGER_URL_PATHS[repository.name]
-    env = dict(os.environ)
-    port = unused_port()
-    env['SERVER_PORT'] = str(port)
-    base_url = 'http://localhost:' + str(port)
-
-    gate_logfile = self.get_logfile_path(repository.name + '-apidocs-server')
-    logging.info('Starting up prototype %s so we can extract docs from it.'
-                 ' We will log this instance to %s',
-                 repository.name, gate_logfile)
-    boot_run_cmd = './gradlew'  # default will run
-    ensure_dir_exists(os.path.dirname(gate_logfile))
-    gate_logstream = open(gate_logfile, 'w')
-    process = start_subprocess(
-        boot_run_cmd, stream=gate_logstream, stdout=gate_logstream,
-        cwd=repository.git_dir, env=env)
-
-    max_wait_secs = self.options.max_wait_secs_startup
-    # pylint: disable=broad-except
-    try:
-      logging.info('Waiting up to %s secs for %s to be ready on port %d',
-                   max_wait_secs, repository.name, port)
-      self.wait_for_url(base_url + '/health', max_wait_secs)
-      json_path = os.path.join(self.get_output_dir(), 'docs.json')
-      self.__generate_json_from_url(
-          repository, base_url + '/' + docs_url_path, json_path)
-      self.build_swagger_docs(repository, json_path)
-    finally:
-      try:
-        gate_logstream.flush()
-        gate_logstream.write(
-            '\n' + log_timestring()
-            + ' ***** buildtool is killing subprocess  *****\n')
-        logging.info('Killing %s subprocess %s now that we are done with it',
-                     repository.name, process.pid)
-        process.kill()
-        wait_subprocess(process)
-        gate_logstream.close()
-      except Exception as ex:
-        maybe_log_exception(
-            self.name, ex,
-            'Ignoring exception while stopping {name} subprocess {pid}.'
-            .format(name=repository.name, pid=process.pid))
+            logging.info(
+                "Waiting up to %s secs for %s to be ready on port %d",
+                max_wait_secs,
+                repository.name,
+                port,
+            )
+            self.wait_for_url(base_url + "/health", max_wait_secs)
+            json_path = os.path.join(self.get_output_dir(), "docs.json")
+            self.__generate_json_from_url(
+                repository, base_url + "/" + docs_url_path, json_path
+            )
+            self.build_swagger_docs(repository, json_path)
+        finally:
+            try:
+                gate_logstream.flush()
+                gate_logstream.write(
+                    "\n"
+                    + log_timestring()
+                    + " ***** buildtool is killing subprocess  *****\n"
+                )
+                logging.info(
+                    "Killing %s subprocess %s now that we are done with it",
+                    repository.name,
+                    process.pid,
+                )
+                process.kill()
+                wait_subprocess(process)
+                gate_logstream.close()
+            except Exception as ex:
+                maybe_log_exception(
+                    self.name,
+                    ex,
+                    "Ignoring exception while stopping {name} subprocess {pid}.".format(
+                        name=repository.name, pid=process.pid
+                    ),
+                )
 
 
 class BuildApiDocsFactory(RepositoryCommandFactory):
-  """Creates instances of BuildApiDocsCommand."""
+    """Creates instances of BuildApiDocsCommand."""
 
-  def __init__(self):
-    super(BuildApiDocsFactory, self).__init__(
-        BUILD_DOCS_COMMAND, BuildApiDocsCommand,
-        'Build the Spinnaker API REST documentation.',
-        BomSourceCodeManager)
+    def __init__(self):
+        super(BuildApiDocsFactory, self).__init__(
+            BUILD_DOCS_COMMAND,
+            BuildApiDocsCommand,
+            "Build the Spinnaker API REST documentation.",
+            BomSourceCodeManager,
+        )
 
-  def init_argparser(self, parser, defaults):
-    """Implements CommandFactory interface."""
-    # For the spinnaker.io repository
-    BranchSourceCodeManager.add_parser_args(parser, defaults)
+    def init_argparser(self, parser, defaults):
+        """Implements CommandFactory interface."""
+        # For the spinnaker.io repository
+        BranchSourceCodeManager.add_parser_args(parser, defaults)
 
-    self.add_argument(
-        parser, 'generate_swagger_path',
-        defaults, 'swagger/generate_swagger.sh',
-        help='Path to standard script (relative to repository) for'
-        ' generating swagger JSON document. If this is empty then'
-        ' spawn a live server to query instead. It is assumed that'
-        ' if present, this will write a "swagger.json" into'
-        ' its directory.')
-    self.add_argument(
-        parser, 'max_wait_secs_startup', defaults, 210, type=int,
-        help='Number of seconds to wait for gate server to startup'
-             ' before giving up and timing out.'
-             ' Used only if generate_swagger_path is not empty.')
-    self.add_argument(
-        parser, 'swagger_codegen_cli_jar_path', defaults, None,
-        help='The location of the swagger-codegen-cli jarfile.'
-        ' The file can be obtained from'
-        ' http://central.maven.org/maven2/io/swagger/swagger-codegen-cli'
-        '/2.2.3/swagger-codegen-cli-2.2.3.jar')
+        self.add_argument(
+            parser,
+            "generate_swagger_path",
+            defaults,
+            "swagger/generate_swagger.sh",
+            help="Path to standard script (relative to repository) for"
+            " generating swagger JSON document. If this is empty then"
+            " spawn a live server to query instead. It is assumed that"
+            ' if present, this will write a "swagger.json" into'
+            " its directory.",
+        )
+        self.add_argument(
+            parser,
+            "max_wait_secs_startup",
+            defaults,
+            210,
+            type=int,
+            help="Number of seconds to wait for gate server to startup"
+            " before giving up and timing out."
+            " Used only if generate_swagger_path is not empty.",
+        )
+        self.add_argument(
+            parser,
+            "swagger_codegen_cli_jar_path",
+            defaults,
+            None,
+            help="The location of the swagger-codegen-cli jarfile."
+            " The file can be obtained from"
+            " http://central.maven.org/maven2/io/swagger/swagger-codegen-cli"
+            "/2.2.3/swagger-codegen-cli-2.2.3.jar",
+        )
 
-    super(BuildApiDocsFactory, self).init_argparser(parser, defaults)
+        super(BuildApiDocsFactory, self).init_argparser(parser, defaults)
 
 
 class PublishApiDocsCommand(CommandProcessor):
-  """Publish built docs back up to the origin repository.
+    """Publish built docs back up to the origin repository.
 
-  This uses git_runner to checkout the SPINNAKER_GITHUB_IO_REPOSITORY
-  that we'll be publishing docs to. It assumes that the documentation has
-  already been built so that it could have been reviewed.
-  """
+    This uses git_runner to checkout the SPINNAKER_GITHUB_IO_REPOSITORY
+    that we'll be publishing docs to. It assumes that the documentation has
+    already been built so that it could have been reviewed.
+    """
 
-  def __init__(self, factory, options, **kwargs):
-    super(PublishApiDocsCommand, self).__init__(
-        factory, options, **kwargs)
-    docs_dir = self.get_output_dir(command=BUILD_DOCS_COMMAND)
-    self.__html_path = os.path.join(os.path.abspath(docs_dir), 'index.html')
-    self._check_args()
+    def __init__(self, factory, options, **kwargs):
+        super(PublishApiDocsCommand, self).__init__(factory, options, **kwargs)
+        docs_dir = self.get_output_dir(command=BUILD_DOCS_COMMAND)
+        self.__html_path = os.path.join(os.path.abspath(docs_dir), "index.html")
+        self._check_args()
 
-    self.__scm = BranchSourceCodeManager(
-        make_options_with_fallback(self.options),
-        self.get_input_dir())
+        self.__scm = BranchSourceCodeManager(
+            make_options_with_fallback(self.options), self.get_input_dir()
+        )
 
-    self.__docs_repository = self.__scm.make_repository_spec(
-        SPINNAKER_IO_REPOSITORY_NAME)
+        self.__docs_repository = self.__scm.make_repository_spec(
+            SPINNAKER_IO_REPOSITORY_NAME
+        )
 
-  def _check_args(self):
-    check_path_exists(self.__html_path,
-                      why='output from running "build_apidocs"')
-    check_options_set(self.options, ['spinnaker_version'])
+    def _check_args(self):
+        check_path_exists(self.__html_path, why='output from running "build_apidocs"')
+        check_options_set(self.options, ["spinnaker_version"])
 
-  def _do_command(self):
-    """Implements CommandProcessor interface."""
-    self.__scm.ensure_git_path(self.__docs_repository, branch='master')
-    base_branch = 'master'
-    version = self.options.spinnaker_version
-    if self.options.git_allow_publish_master_branch:
-      head_branch = 'master'
-      branch_flag = ''
-    else:
-      head_branch = version + '-apidocs'
-      branch_flag = '-b'
+    def _do_command(self):
+        """Implements CommandProcessor interface."""
+        self.__scm.ensure_git_path(self.__docs_repository, branch="master")
+        base_branch = "master"
+        version = self.options.spinnaker_version
+        if self.options.git_allow_publish_master_branch:
+            head_branch = "master"
+            branch_flag = ""
+        else:
+            head_branch = version + "-apidocs"
+            branch_flag = "-b"
 
-    files_added = self._prepare_local_repository_files()
-    git_dir = self.__docs_repository.git_dir
-    message = 'docs(api): API Documentation for Spinnaker ' + version
-    local_git_commands = [
-        # These commands are accomodating to a branch already existing
-        # because the branch is on the version, not build. A rejected
-        # build for some reason that is re-tried will have the same version
-        # so the branch may already exist from the earlier attempt.
-        'checkout ' + base_branch,
-        'checkout {flag} {branch}'.format(
-            flag=branch_flag, branch=head_branch),
-        'add ' + ' '.join([os.path.abspath(path) for path in files_added]),
-    ]
-    logging.debug('Commiting changes into local repository "%s" branch=%s',
-                  self.__docs_repository.git_dir, head_branch)
-    git = self.__scm.git
-    git.check_run_sequence(git_dir, local_git_commands)
-    git.check_commit_or_no_changes(git_dir, '-m "{msg}"'.format(msg=message))
+        files_added = self._prepare_local_repository_files()
+        git_dir = self.__docs_repository.git_dir
+        message = "docs(api): API Documentation for Spinnaker " + version
+        local_git_commands = [
+            # These commands are accomodating to a branch already existing
+            # because the branch is on the version, not build. A rejected
+            # build for some reason that is re-tried will have the same version
+            # so the branch may already exist from the earlier attempt.
+            "checkout " + base_branch,
+            "checkout {flag} {branch}".format(flag=branch_flag, branch=head_branch),
+            "add " + " ".join([os.path.abspath(path) for path in files_added]),
+        ]
+        logging.debug(
+            'Commiting changes into local repository "%s" branch=%s',
+            self.__docs_repository.git_dir,
+            head_branch,
+        )
+        git = self.__scm.git
+        git.check_run_sequence(git_dir, local_git_commands)
+        git.check_commit_or_no_changes(git_dir, '-m "{msg}"'.format(msg=message))
 
-    logging.info('Pushing branch="%s" into "%s"',
-                 head_branch, self.__docs_repository.origin)
-    git.push_branch_to_origin(git_dir, branch=head_branch, force=True)
+        logging.info(
+            'Pushing branch="%s" into "%s"', head_branch, self.__docs_repository.origin
+        )
+        git.push_branch_to_origin(git_dir, branch=head_branch, force=True)
 
-  def _prepare_local_repository_files(self):
-    """Implements CommandProcessor interface."""
+    def _prepare_local_repository_files(self):
+        """Implements CommandProcessor interface."""
 
-    # And putting them into the SPINNAKER_IO_REPOSITORY_NAME
-    #
-    # NOTE(ewiseblatt): 20171218
-    # This is the current scheme, however I think this should read
-    # os.path.join(git_dir, spinnaker_minor_branch, docs_path_in_repo)
-    # where "spinnaker_minor_branch" is the version with the <PATCH>
-    # replaced with 'x'
-    target_path = os.path.join(
-        self.__docs_repository.git_dir, 'reference', 'api', 'docs.html')
+        # And putting them into the SPINNAKER_IO_REPOSITORY_NAME
+        #
+        # NOTE(ewiseblatt): 20171218
+        # This is the current scheme, however I think this should read
+        # os.path.join(git_dir, spinnaker_minor_branch, docs_path_in_repo)
+        # where "spinnaker_minor_branch" is the version with the <PATCH>
+        # replaced with 'x'
+        target_path = os.path.join(
+            self.__docs_repository.git_dir, "reference", "api", "docs.html"
+        )
 
-    logging.debug('Copying %s to %s', self.__html_path, target_path)
-    shutil.copy2(self.__html_path, target_path)
+        logging.debug("Copying %s to %s", self.__html_path, target_path)
+        shutil.copy2(self.__html_path, target_path)
 
-    return [target_path]
+        return [target_path]
 
 
 class PublishApiDocsFactory(CommandFactory):
-  """Factory for PublishApidDocCommand"""
+    """Factory for PublishApidDocCommand"""
 
-  def __init__(self, **kwargs):
-    super(PublishApiDocsFactory, self).__init__(
-        'publish_apidocs', PublishApiDocsCommand,
-        'Publish Spinnaker REST API documentation to spinnaker.io.',
-        **kwargs)
+    def __init__(self, **kwargs):
+        super(PublishApiDocsFactory, self).__init__(
+            "publish_apidocs",
+            PublishApiDocsCommand,
+            "Publish Spinnaker REST API documentation to spinnaker.io.",
+            **kwargs
+        )
 
-  def init_argparser(self, parser, defaults):
-    """Adds command-specific arguments."""
-    super(PublishApiDocsFactory, self).init_argparser(
-        parser, defaults)
-    GitRunner.add_parser_args(parser, defaults)
-    GitRunner.add_publishing_parser_args(parser, defaults)
-    self.add_argument(
-        parser, 'git_branch', defaults, None,
-        help='The branch to checkout in ' + SPINNAKER_IO_REPOSITORY_NAME)
-    self.add_argument(
-        parser, 'spinnaker_version', defaults, None,
-        help='The version of spinnaker this documentation is for.')
+    def init_argparser(self, parser, defaults):
+        """Adds command-specific arguments."""
+        super(PublishApiDocsFactory, self).init_argparser(parser, defaults)
+        GitRunner.add_parser_args(parser, defaults)
+        GitRunner.add_publishing_parser_args(parser, defaults)
+        self.add_argument(
+            parser,
+            "git_branch",
+            defaults,
+            None,
+            help="The branch to checkout in " + SPINNAKER_IO_REPOSITORY_NAME,
+        )
+        self.add_argument(
+            parser,
+            "spinnaker_version",
+            defaults,
+            None,
+            help="The version of spinnaker this documentation is for.",
+        )
 
 
 def register_commands(registry, subparsers, defaults):
-  """Registers all the commands for this module."""
-  BuildApiDocsFactory().register(registry, subparsers, defaults)
-  PublishApiDocsFactory().register(registry, subparsers, defaults)
+    """Registers all the commands for this module."""
+    BuildApiDocsFactory().register(registry, subparsers, defaults)
+    PublishApiDocsFactory().register(registry, subparsers, defaults)

--- a/dev/buildtool/base_metrics.py
+++ b/dev/buildtool/base_metrics.py
@@ -23,449 +23,461 @@ import time
 
 
 class Metric(object):
-  """A metric with unique combination of name and bindings."""
+    """A metric with unique combination of name and bindings."""
 
-  @property
-  def family(self):
-    """The metric family this instance belongs to.
+    @property
+    def family(self):
+        """The metric family this instance belongs to.
 
-    Members of a family share the same name but different label bindings.
-    """
-    return self.__family
+        Members of a family share the same name but different label bindings.
+        """
+        return self.__family
 
-  @property
-  def name(self):
-    return self.__family.name
+    @property
+    def name(self):
+        return self.__family.name
 
-  @property
-  def labels(self):
-    return self.__labels
+    @property
+    def labels(self):
+        return self.__labels
 
-  @property
-  def last_modified(self):
-    """In real seconds."""
-    return self.__last_modified
+    @property
+    def last_modified(self):
+        """In real seconds."""
+        return self.__last_modified
 
-  @property
-  def mutex(self):
-    return self.__mutex
+    @property
+    def mutex(self):
+        return self.__mutex
 
-  def __init__(self, family, labels):
-    self.__mutex = threading.Lock()
-    self.__name = family.name
-    self.__last_modified = None
-    self.__family = family
-    self.__labels = labels
+    def __init__(self, family, labels):
+        self.__mutex = threading.Lock()
+        self.__name = family.name
+        self.__last_modified = None
+        self.__family = family
+        self.__labels = labels
 
-  def touch(self, utc=None):
-    """Update last modified time"""
-    self.__last_modified = utc or datetime.datetime.utcnow()
-    self.__family.registry.queue_update(self)
+    def touch(self, utc=None):
+        """Update last modified time"""
+        self.__last_modified = utc or datetime.datetime.utcnow()
+        self.__family.registry.queue_update(self)
 
 
 class Counter(Metric):
+    @property
+    def count(self):
+        """Returns the current [local] counter value."""
+        return self.__count
 
-  @property
-  def count(self):
-    """Returns the current [local] counter value."""
-    return self.__count
+    def __init__(self, family, labels):
+        super(Counter, self).__init__(family, labels)
+        self.__count = 0
 
-  def __init__(self, family, labels):
-    super(Counter, self).__init__(family, labels)
-    self.__count = 0
-
-  def inc(self, amount=1, utc=None):
-    with self.mutex:
-      self.__count += amount
-      self.touch(utc=utc)
+    def inc(self, amount=1, utc=None):
+        with self.mutex:
+            self.__count += amount
+            self.touch(utc=utc)
 
 
 class Gauge(Metric):
-  @property
-  def value(self):
-    return self.__compute()
+    @property
+    def value(self):
+        return self.__compute()
 
-  def __init__(self, family, labels, compute=None):
-    super(Gauge, self).__init__(family, labels)
-    func = lambda: self.__value
-    self.__value = 0
-    self.__compute = compute or func
+    def __init__(self, family, labels, compute=None):
+        super(Gauge, self).__init__(family, labels)
+        func = lambda: self.__value
+        self.__value = 0
+        self.__compute = compute or func
 
-  def track(self, func, *pos_args, **kwargs):
-    """Add to gauge while function call is in progress."""
-    try:
-      self.inc()
-      return func(*pos_args, **kwargs)
-    finally:
-      self.dec()
+    def track(self, func, *pos_args, **kwargs):
+        """Add to gauge while function call is in progress."""
+        try:
+            self.inc()
+            return func(*pos_args, **kwargs)
+        finally:
+            self.dec()
 
-  def set(self, value, utc=None):
-    """Set the gauge to an absolute value."""
-    with self.mutex:
-      self.__value = value
-      self.touch(utc=utc)
+    def set(self, value, utc=None):
+        """Set the gauge to an absolute value."""
+        with self.mutex:
+            self.__value = value
+            self.touch(utc=utc)
 
-  def inc(self, amount=1, utc=None):
-    """Increment the gauge by an amount."""
-    with self.mutex:
-      self.__value += amount
-      self.touch(utc=utc)
+    def inc(self, amount=1, utc=None):
+        """Increment the gauge by an amount."""
+        with self.mutex:
+            self.__value += amount
+            self.touch(utc=utc)
 
-  def dec(self, amount=1, utc=None):
-    """Decrement the gauge by an amount."""
-    with self.mutex:
-      self.__value -= amount
-      self.touch(utc=utc)
+    def dec(self, amount=1, utc=None):
+        """Decrement the gauge by an amount."""
+        with self.mutex:
+            self.__value -= amount
+            self.touch(utc=utc)
 
 
 class Timer(Metric):
-  """Observes how long functions take to execute."""
+    """Observes how long functions take to execute."""
 
-  @property
-  def count(self):
-    """The number of timings captured."""
-    return self.__count
+    @property
+    def count(self):
+        """The number of timings captured."""
+        return self.__count
 
-  @property
-  def total_seconds(self):
-    """The total time across all the captured timings."""
-    return self.__total
+    @property
+    def total_seconds(self):
+        """The total time across all the captured timings."""
+        return self.__total
 
-  def __init__(self, family, labels):
-    super(Timer, self).__init__(family, labels)
-    self.__count = 0
-    self.__total = 0
+    def __init__(self, family, labels):
+        super(Timer, self).__init__(family, labels)
+        self.__count = 0
+        self.__total = 0
 
-  def observe(self, seconds, utc=None):
-    """Capture a timing observation."""
-    with self.mutex:
-      self.__count += 1
-      self.__total += seconds
-      self.touch(utc=utc)
+    def observe(self, seconds, utc=None):
+        """Capture a timing observation."""
+        with self.mutex:
+            self.__count += 1
+            self.__total += seconds
+            self.touch(utc=utc)
 
 
 class MetricFamily(object):
-  """A Factory for a counter or Gauge metric with specifically bound labels."""
+    """A Factory for a counter or Gauge metric with specifically bound labels."""
 
-  GAUGE = 'GAUGE'
-  COUNTER = 'COUNTER'
-  TIMER = 'TIMER'
+    GAUGE = "GAUGE"
+    COUNTER = "COUNTER"
+    TIMER = "TIMER"
 
-  @property
-  def start_time(self):
-    """The start time values are relative to."""
-    return self.__registry.start_time
+    @property
+    def start_time(self):
+        """The start time values are relative to."""
+        return self.__registry.start_time
 
-  @property
-  def name(self):
-    """The name for this family will be the name of its Metric instances."""
-    return self.__name
+    @property
+    def name(self):
+        """The name for this family will be the name of its Metric instances."""
+        return self.__name
 
-  @property
-  def registry(self):
-    """The MetricsRegistry containing this family."""
-    return self.__registry
+    @property
+    def registry(self):
+        """The MetricsRegistry containing this family."""
+        return self.__registry
 
-  @property
-  def family_type(self):
-    """Returns the type of metrics in this family (GAUGE, COUNTER, TIMER)."""
-    return self.__family_type
+    @property
+    def family_type(self):
+        """Returns the type of metrics in this family (GAUGE, COUNTER, TIMER)."""
+        return self.__family_type
 
-  @property
-  def mutex(self):
-    """Returns lock for this family."""
-    return self.__mutex
+    @property
+    def mutex(self):
+        """Returns lock for this family."""
+        return self.__mutex
 
-  @property
-  def instance_list(self):
-    """Return all the label binding metric variations within this family."""
-    return self.__instances.values()
+    @property
+    def instance_list(self):
+        """Return all the label binding metric variations within this family."""
+        return self.__instances.values()
 
-  def __init__(self, registry, name, factory, family_type):
-    self.__mutex = threading.Lock()
-    self.__name = name
-    self.__factory = factory
-    self.__instances = {}
-    self.__registry = registry
-    self.__family_type = family_type
+    def __init__(self, registry, name, factory, family_type):
+        self.__mutex = threading.Lock()
+        self.__name = name
+        self.__factory = factory
+        self.__instances = {}
+        self.__registry = registry
+        self.__family_type = family_type
 
-  def get(self, labels):
-    """Returns a metric instance with bound labels."""
-    key = ''.join('{0}={1}'.format(key, value) for key, value in labels.items())
-    with self.__mutex:
-      got = self.__instances.get(key)
-      if got is None:
-        got = self.__factory(self, labels)
-        self.__instances[key] = got
-      return got
+    def get(self, labels):
+        """Returns a metric instance with bound labels."""
+        key = "".join("{0}={1}".format(key, value) for key, value in labels.items())
+        with self.__mutex:
+            got = self.__instances.get(key)
+            if got is None:
+                got = self.__factory(self, labels)
+                self.__instances[key] = got
+            return got
 
 
 class BaseMetricsRegistry(object):
-  """Provides base class interface for metrics management.
+    """Provides base class interface for metrics management.
 
-  Specific metric stores would subclass this to specialize to push
-  into their own systems.
+    Specific metric stores would subclass this to specialize to push
+    into their own systems.
 
-  While having this registry be abstract is overkill, it is for what feels
-  like practical reasons where there is no easy to use system for our use
-  case of short lived batch jobs so there's going to be a lot of maintainence
-  here and trials of different systems making this investment more appealing.
-  """
-  # pylint: disable=too-many-public-methods
-
-  @staticmethod
-  def default_determine_outcome_labels(result, base_labels):
-    """Return the outcome labels for a set of tracking labels."""
-    ex_type, _, _ = sys.exc_info()
-    labels = dict(base_labels)
-    labels.update({
-        'success': ex_type is None,
-        'exception_type': '' if ex_type is None else ex_type.__name__
-    })
-    return labels
-
-  @staticmethod
-  def determine_outcome_labels_from_error_result(result, base_labels):
-    if result is None:
-      # Call itself threw an exception before it could return the error
-      _, result, _ = sys.exc_info()
-
-    labels = dict(base_labels)
-    labels.update({
-        'success': result is None,
-        'exception_type': '' if result is None else result.__class__.__name__
-    })
-    return labels
-
-  @property
-  def options(self):
-    """Configured options."""
-    return self.__options
-
-  @property
-  def start_time(self):
-    """When the registry started -- values are relative to this utc time."""
-    return self.__start_time
-
-  @property
-  def metric_family_list(self):
-    """Return all the metric families."""
-    return self.__metric_families.values()
-
-  @staticmethod
-  def __make_context_labels(options):
-    if not hasattr(options, 'monitoring_context_labels'):
-      return {}
-
-    labels = {}
-    matcher = re.compile(r'(\w+)=(.*)')
-    for binding in (options.monitoring_context_labels or '').split(','):
-      if not binding:
-        continue
-      try:
-        match = matcher.match(binding)
-        labels[match.group(1)] = match.group(2)
-      except Exception as ex:
-        raise ValueError(
-            'Invalid monitoring_context_labels binding "%s": %s' % (
-                binding, ex))
-    return labels
-
-  def __init__(self, options):
-    """Constructs registry with options from init_argument_parser."""
-    self.__start_time = datetime.datetime.utcnow()
-    self.__options = options
-    self.__pusher_thread = None
-    self.__pusher_thread_event = threading.Event()
-    self.__metric_families = {}
-    self.__family_mutex = threading.Lock()
-    self.__updated_metrics = set([])
-    self.__update_mutex = threading.Lock()
-    self.__inject_labels = self.__make_context_labels(options)
-    if self.__inject_labels:
-      logging.debug('Injecting additional metric labels %s',
-                    self.__inject_labels)
-
-  def _do_make_family(self, family_type, name, label_names):
-    """Creates new metric-system specific gauge family.
-
-    Args:
-      family_type: MetricFamily.COUNTER, GUAGE, or TIMER
-      name: [string] Metric name.
-      label_names: [list of string] The labels used to distinguish instances.
-
-    Returns:
-      specialized MetricFamily for the given type and registry implementation.
+    While having this registry be abstract is overkill, it is for what feels
+    like practical reasons where there is no easy to use system for our use
+    case of short lived batch jobs so there's going to be a lot of maintainence
+    here and trials of different systems making this investment more appealing.
     """
-    raise NotImplementedError()
 
-  def queue_update(self, metric):
-    """Add metric to list of metrics to push out."""
-    with self.__update_mutex:
-      self.__updated_metrics.add(metric)
+    # pylint: disable=too-many-public-methods
 
-  def inc_counter(self, name, labels, **kwargs):
-    """Track number of completed calls to the given function."""
-    counter = self.get_metric(MetricFamily.COUNTER, name, labels)
-    counter.inc(**kwargs)
-    return counter
+    @staticmethod
+    def default_determine_outcome_labels(result, base_labels):
+        """Return the outcome labels for a set of tracking labels."""
+        ex_type, _, _ = sys.exc_info()
+        labels = dict(base_labels)
+        labels.update(
+            {
+                "success": ex_type is None,
+                "exception_type": "" if ex_type is None else ex_type.__name__,
+            }
+        )
+        return labels
 
-  def count_call(self, name, labels, func, *pos_args, **kwargs):
-    """Track number of completed calls to the given function."""
-    labels = dict(labels)
-    success = False
-    try:
-      result = func(*pos_args, **kwargs)
-      success = True
-      return result
-    finally:
-      labels['success'] = success
-      self.inc_counter(name, labels, **kwargs)
+    @staticmethod
+    def determine_outcome_labels_from_error_result(result, base_labels):
+        if result is None:
+            # Call itself threw an exception before it could return the error
+            _, result, _ = sys.exc_info()
 
-  def set(self, name, labels, value):
-    """Sets the implied gauge with the specified value."""
-    gauge = self.get_metric(MetricFamily.GAUGE, name, labels)
-    gauge.set(value)
-    return gauge
+        labels = dict(base_labels)
+        labels.update(
+            {
+                "success": result is None,
+                "exception_type": "" if result is None else result.__class__.__name__,
+            }
+        )
+        return labels
 
-  def track_call(self, name, labels, func, *pos_args, **kwargs):
-    """Track number of active calls to the given function."""
-    gauge = self.get_metric(MetricFamily.GAUGE, name, labels)
-    return gauge.track(func, *pos_args, **kwargs)
+    @property
+    def options(self):
+        """Configured options."""
+        return self.__options
 
-  def observe_timer(self, name, labels, seconds):
-    """Add an observation to the specified timer."""
-    timer = self.get_metric(MetricFamily.TIMER, name, labels)
-    timer.observe(seconds)
-    return timer
+    @property
+    def start_time(self):
+        """When the registry started -- values are relative to this utc time."""
+        return self.__start_time
 
-  def time_call(self, name, labels, label_func,
-                time_func, *pos_args, **kwargs):
-    """Track number of completed calls to the given function."""
-    try:
-      start_time = time.time()
-      result = time_func(*pos_args, **kwargs)
-      outcome_labels = label_func(result, labels)
-      return result
-    except:
-      try:
-        outcome_labels = label_func(None, labels)
-      except Exception as ex:
-        logging.exception('label_func failed with %s', str(ex))
-        raise ex
-      raise
-    finally:
-      timer = self.get_metric(MetricFamily.TIMER, name, outcome_labels)
-      timer.observe(time.time() - start_time)
+    @property
+    def metric_family_list(self):
+        """Return all the metric families."""
+        return self.__metric_families.values()
 
-  def lookup_family_or_none(self, name):
-    return self.__metric_families.get(name)
+    @staticmethod
+    def __make_context_labels(options):
+        if not hasattr(options, "monitoring_context_labels"):
+            return {}
 
-  def __normalize_labels(self, labels):
-    result = dict(self.__inject_labels)
-    result.update(labels)
-    return result
+        labels = {}
+        matcher = re.compile(r"(\w+)=(.*)")
+        for binding in (options.monitoring_context_labels or "").split(","):
+            if not binding:
+                continue
+            try:
+                match = matcher.match(binding)
+                labels[match.group(1)] = match.group(2)
+            except Exception as ex:
+                raise ValueError(
+                    'Invalid monitoring_context_labels binding "%s": %s' % (binding, ex)
+                )
+        return labels
 
-  def get_metric(self, family_type, name, labels):
-    """Return instance in family with given name and labels.
+    def __init__(self, options):
+        """Constructs registry with options from init_argument_parser."""
+        self.__start_time = datetime.datetime.utcnow()
+        self.__options = options
+        self.__pusher_thread = None
+        self.__pusher_thread_event = threading.Event()
+        self.__metric_families = {}
+        self.__family_mutex = threading.Lock()
+        self.__updated_metrics = set([])
+        self.__update_mutex = threading.Lock()
+        self.__inject_labels = self.__make_context_labels(options)
+        if self.__inject_labels:
+            logging.debug("Injecting additional metric labels %s", self.__inject_labels)
 
-    Returns the existing instance if present, otherwise makes a new one.
-    """
-    labels = self.__normalize_labels(labels)
-    family = self.__metric_families.get(name)
-    if family:
-      if family.family_type != family_type:
-        raise TypeError('{have} is not a {want}'.format(
-            have=family, want=family_type))
-      return family.get(labels)
+    def _do_make_family(self, family_type, name, label_names):
+        """Creates new metric-system specific gauge family.
 
-    family = self._do_make_family(family_type, name, labels.keys())
-    with self.__family_mutex:
-      if name not in self.__metric_families:
-        self.__metric_families[name] = family
-    return family.get(labels)
+        Args:
+          family_type: MetricFamily.COUNTER, GUAGE, or TIMER
+          name: [string] Metric name.
+          label_names: [list of string] The labels used to distinguish instances.
 
-  def track_and_time_call(
-      self, name, labels, outcome_labels_func,
-      result_func, *pos_args, **kwargs):
-    """Call the function with the given arguments while instrumenting it.
+        Returns:
+          specialized MetricFamily for the given type and registry implementation.
+        """
+        raise NotImplementedError()
 
-    This will instrument both tracking of call counts in progress
-    as well as the final outcomes in terms of performance and outcome.
-    """
-    tracking_name = name + '_InProgress'
-    outcome_name = name + '_Outcome'
+    def queue_update(self, metric):
+        """Add metric to list of metrics to push out."""
+        with self.__update_mutex:
+            self.__updated_metrics.add(metric)
 
-    return self.track_call(
-        tracking_name, labels,
-        self.time_call,
-        outcome_name, labels, outcome_labels_func,
-        result_func, *pos_args, **kwargs)
+    def inc_counter(self, name, labels, **kwargs):
+        """Track number of completed calls to the given function."""
+        counter = self.get_metric(MetricFamily.COUNTER, name, labels)
+        counter.inc(**kwargs)
+        return counter
 
-  def start_pusher_thread(self):
-    """Starts thread for pushing metrics."""
-    def delay_func():
-      """Helper function for push thread"""
-      # pylint: disable=broad-except
-      try:
-        if self.__pusher_thread:
-          self.__pusher_thread_event.wait(
-              self.options.monitoring_flush_frequency)
-        return self.__pusher_thread is not None
-      except Exception as ex:
-        logging.error('Pusher thread delay func caught %s', ex)
-        return False
+    def count_call(self, name, labels, func, *pos_args, **kwargs):
+        """Track number of completed calls to the given function."""
+        labels = dict(labels)
+        success = False
+        try:
+            result = func(*pos_args, **kwargs)
+            success = True
+            return result
+        finally:
+            labels["success"] = success
+            self.inc_counter(name, labels, **kwargs)
 
-    self.__pusher_thread = threading.Thread(
-        name='MetricsManager', target=self.flush_every_loop, args=[delay_func])
-    self.__pusher_thread.start()
-    return True
+    def set(self, name, labels, value):
+        """Sets the implied gauge with the specified value."""
+        gauge = self.get_metric(MetricFamily.GAUGE, name, labels)
+        gauge.set(value)
+        return gauge
 
-  def stop_pusher_thread(self):
-    """Stop thread for pushing metrics."""
-    logging.debug('Signaling pusher thread %s', self.__pusher_thread)
-    pusher_thread = self.__pusher_thread
-    self.__pusher_thread = None
-    self.__pusher_thread_event.set()
+    def track_call(self, name, labels, func, *pos_args, **kwargs):
+        """Track number of active calls to the given function."""
+        gauge = self.get_metric(MetricFamily.GAUGE, name, labels)
+        return gauge.track(func, *pos_args, **kwargs)
 
-    # Give a chance for the thread to self-terminate before we continue.
-    # It's ok if this times out, but logging is cleaner to give it a chance.
-    if pusher_thread is not None:
-      pusher_thread.join(2)
+    def observe_timer(self, name, labels, seconds):
+        """Add an observation to the specified timer."""
+        timer = self.get_metric(MetricFamily.TIMER, name, labels)
+        timer.observe(seconds)
+        return timer
 
-  def flush_every_loop(self, ready_func):
-    """Start a loop that pushes while the ready_func is true."""
-    logging.debug('Starting loop to push metrics...')
-    while ready_func():
-      self.flush_updated_metrics()
-    logging.debug('Ending loop to push metrics...')
+    def time_call(self, name, labels, label_func, time_func, *pos_args, **kwargs):
+        """Track number of completed calls to the given function."""
+        try:
+            start_time = time.time()
+            result = time_func(*pos_args, **kwargs)
+            outcome_labels = label_func(result, labels)
+            return result
+        except:
+            try:
+                outcome_labels = label_func(None, labels)
+            except Exception as ex:
+                logging.exception("label_func failed with %s", str(ex))
+                raise ex
+            raise
+        finally:
+            timer = self.get_metric(MetricFamily.TIMER, name, outcome_labels)
+            timer.observe(time.time() - start_time)
 
-  def _do_flush_updated_metrics(self, updated_metrics):
-    """Writes metrics to the server."""
-    raise NotImplementedError()
+    def lookup_family_or_none(self, name):
+        return self.__metric_families.get(name)
 
-  def _do_flush_final_metrics(self):
-    """Notifies that we're doing updating and it is safe to push final metrics.
+    def __normalize_labels(self, labels):
+        result = dict(self.__inject_labels)
+        result.update(labels)
+        return result
 
-    This is only informative for implementations that are not incremental.
-    """
-    pass
+    def get_metric(self, family_type, name, labels):
+        """Return instance in family with given name and labels.
 
-  def flush_final_metrics(self):
-    """Push the final metrics to the metrics server."""
-    if not self.options.monitoring_enabled:
-      logging.warning('Monitoring disabled -- dont push final metrics.')
-      return
+        Returns the existing instance if present, otherwise makes a new one.
+        """
+        labels = self.__normalize_labels(labels)
+        family = self.__metric_families.get(name)
+        if family:
+            if family.family_type != family_type:
+                raise TypeError(
+                    "{have} is not a {want}".format(have=family, want=family_type)
+                )
+            return family.get(labels)
 
-    self._do_flush_final_metrics()
+        family = self._do_make_family(family_type, name, labels.keys())
+        with self.__family_mutex:
+            if name not in self.__metric_families:
+                self.__metric_families[name] = family
+        return family.get(labels)
 
-  def flush_updated_metrics(self):
-    """Push incremental metrics to the metrics server."""
-    if not self.options.monitoring_enabled:
-      logging.warning('Monitoring disabled -- dont push incremental metrics.')
-      return
+    def track_and_time_call(
+        self, name, labels, outcome_labels_func, result_func, *pos_args, **kwargs
+    ):
+        """Call the function with the given arguments while instrumenting it.
 
-    with self.__update_mutex:
-      updated_metrics = self.__updated_metrics
-      self.__updated_metrics = set([])
-    self._do_flush_updated_metrics(updated_metrics)
+        This will instrument both tracking of call counts in progress
+        as well as the final outcomes in terms of performance and outcome.
+        """
+        tracking_name = name + "_InProgress"
+        outcome_name = name + "_Outcome"
+
+        return self.track_call(
+            tracking_name,
+            labels,
+            self.time_call,
+            outcome_name,
+            labels,
+            outcome_labels_func,
+            result_func,
+            *pos_args,
+            **kwargs
+        )
+
+    def start_pusher_thread(self):
+        """Starts thread for pushing metrics."""
+
+        def delay_func():
+            """Helper function for push thread"""
+            # pylint: disable=broad-except
+            try:
+                if self.__pusher_thread:
+                    self.__pusher_thread_event.wait(
+                        self.options.monitoring_flush_frequency
+                    )
+                return self.__pusher_thread is not None
+            except Exception as ex:
+                logging.error("Pusher thread delay func caught %s", ex)
+                return False
+
+        self.__pusher_thread = threading.Thread(
+            name="MetricsManager", target=self.flush_every_loop, args=[delay_func]
+        )
+        self.__pusher_thread.start()
+        return True
+
+    def stop_pusher_thread(self):
+        """Stop thread for pushing metrics."""
+        logging.debug("Signaling pusher thread %s", self.__pusher_thread)
+        pusher_thread = self.__pusher_thread
+        self.__pusher_thread = None
+        self.__pusher_thread_event.set()
+
+        # Give a chance for the thread to self-terminate before we continue.
+        # It's ok if this times out, but logging is cleaner to give it a chance.
+        if pusher_thread is not None:
+            pusher_thread.join(2)
+
+    def flush_every_loop(self, ready_func):
+        """Start a loop that pushes while the ready_func is true."""
+        logging.debug("Starting loop to push metrics...")
+        while ready_func():
+            self.flush_updated_metrics()
+        logging.debug("Ending loop to push metrics...")
+
+    def _do_flush_updated_metrics(self, updated_metrics):
+        """Writes metrics to the server."""
+        raise NotImplementedError()
+
+    def _do_flush_final_metrics(self):
+        """Notifies that we're doing updating and it is safe to push final metrics.
+
+        This is only informative for implementations that are not incremental.
+        """
+        pass
+
+    def flush_final_metrics(self):
+        """Push the final metrics to the metrics server."""
+        if not self.options.monitoring_enabled:
+            logging.warning("Monitoring disabled -- dont push final metrics.")
+            return
+
+        self._do_flush_final_metrics()
+
+    def flush_updated_metrics(self):
+        """Push incremental metrics to the metrics server."""
+        if not self.options.monitoring_enabled:
+            logging.warning("Monitoring disabled -- dont push incremental metrics.")
+            return
+
+        with self.__update_mutex:
+            updated_metrics = self.__updated_metrics
+            self.__updated_metrics = set([])
+        self._do_flush_updated_metrics(updated_metrics)

--- a/dev/buildtool/bom_scm.py
+++ b/dev/buildtool/bom_scm.py
@@ -145,7 +145,7 @@ class BomSourceCodeManager(SpinnakerSourceCodeManager):
         """Make sure repository path is consistent with BOM."""
         check_kwargs_empty(kwargs)
         service_name = self.repository_name_to_service_name(repository.name)
-        if not service_name in self.__bom["services"].keys():
+        if service_name not in self.__bom["services"].keys():
             raise_and_log_error(
                 UnexpectedError('"%s" is not a BOM repo' % service_name)
             )
@@ -161,7 +161,7 @@ class BomSourceCodeManager(SpinnakerSourceCodeManager):
 
     def determine_build_number(self, repository):
         service_name = self.repository_name_to_service_name(repository.name)
-        if not service_name in self.__bom["services"].keys():
+        if service_name not in self.__bom["services"].keys():
             raise_and_log_error(
                 UnexpectedError('"%s" is not a BOM repo' % service_name)
             )
@@ -172,7 +172,7 @@ class BomSourceCodeManager(SpinnakerSourceCodeManager):
 
     def determine_repository_version(self, repository):
         service_name = self.repository_name_to_service_name(repository.name)
-        if not service_name in self.__bom["services"].keys():
+        if service_name not in self.__bom["services"].keys():
             raise_and_log_error(
                 UnexpectedError('"%s" is not a BOM repo' % service_name)
             )

--- a/dev/buildtool/bom_scm.py
+++ b/dev/buildtool/bom_scm.py
@@ -20,195 +20,206 @@ import yaml
 
 from buildtool import (
     SPINNAKER_RUNNABLE_REPOSITORY_NAMES,
-
     HalRunner,
     SpinnakerSourceCodeManager,
-
     add_parser_argument,
     check_kwargs_empty,
     check_path_exists,
     raise_and_log_error,
     ConfigError,
-    UnexpectedError)
+    UnexpectedError,
+)
 
 
 SPINNAKER_BOM_REPOSITORY_NAMES = list(SPINNAKER_RUNNABLE_REPOSITORY_NAMES)
-SPINNAKER_BOM_REPOSITORY_NAMES.extend(['spinnaker-monitoring'])
+SPINNAKER_BOM_REPOSITORY_NAMES.extend(["spinnaker-monitoring"])
 
 
 def check_bom_service(bom, service_name):
-  services = bom.get('services', {})
-  entry = services.get(service_name)
-  if entry is None:
-    raise_and_log_error(
-        ConfigError('BOM does not contain service "%s"' % service_name,
-                    cause='BadBom'),
-        'BOM missing "%s": %s' % (service_name, services.keys()))
-  return entry
+    services = bom.get("services", {})
+    entry = services.get(service_name)
+    if entry is None:
+        raise_and_log_error(
+            ConfigError(
+                'BOM does not contain service "%s"' % service_name, cause="BadBom"
+            ),
+            'BOM missing "%s": %s' % (service_name, services.keys()),
+        )
+    return entry
 
 
 class BomSourceCodeManager(SpinnakerSourceCodeManager):
-  """Manages source code specified in a BOM."""
+    """Manages source code specified in a BOM."""
 
-  @staticmethod
-  def add_parser_args(parser, defaults):
-    """Add standard parser arguments used by SourceCodeManager."""
-    if hasattr(parser, 'added_bom_scm'):
-      return
-    parser.added_bom_scm = True
-    SpinnakerSourceCodeManager.add_parser_args(parser, defaults)
-    HalRunner.add_parser_args(parser, defaults)
-    add_parser_argument(
-        parser, 'bom_path', defaults, None,
-        help='Use the sources specified in the BOM path.')
-    add_parser_argument(
-        parser, 'bom_version', defaults, None,
-        help='Use the sources specified in the BOM version.')
+    @staticmethod
+    def add_parser_args(parser, defaults):
+        """Add standard parser arguments used by SourceCodeManager."""
+        if hasattr(parser, "added_bom_scm"):
+            return
+        parser.added_bom_scm = True
+        SpinnakerSourceCodeManager.add_parser_args(parser, defaults)
+        HalRunner.add_parser_args(parser, defaults)
+        add_parser_argument(
+            parser,
+            "bom_path",
+            defaults,
+            None,
+            help="Use the sources specified in the BOM path.",
+        )
+        add_parser_argument(
+            parser,
+            "bom_version",
+            defaults,
+            None,
+            help="Use the sources specified in the BOM version.",
+        )
 
-  @staticmethod
-  def bom_from_path(path):
-    """Load a BOM from a file."""
-    logging.debug('Loading bom from %s', path)
-    with open(path, 'r') as f:
-      bom_yaml_string = f.read()
-    return yaml.safe_load(bom_yaml_string)
+    @staticmethod
+    def bom_from_path(path):
+        """Load a BOM from a file."""
+        logging.debug("Loading bom from %s", path)
+        with open(path, "r") as f:
+            bom_yaml_string = f.read()
+        return yaml.safe_load(bom_yaml_string)
 
-  @staticmethod
-  def load_bom(options):
-    """Helper function for initializing the BOM if one was specified."""
-    bom_path = options.bom_path if hasattr(options, 'bom_path') else None
-    bom_version = (options.bom_version
-                   if hasattr(options, 'bom_version')
-                   else None)
+    @staticmethod
+    def load_bom(options):
+        """Helper function for initializing the BOM if one was specified."""
+        bom_path = options.bom_path if hasattr(options, "bom_path") else None
+        bom_version = options.bom_version if hasattr(options, "bom_version") else None
 
-    have_bom_path = 1 if bom_path else 0
-    have_bom_version = 1 if bom_version else 0
-    if have_bom_path + have_bom_version != 1:
-      raise_and_log_error(
-          ConfigError('Expected exactly one of: "bom_path", or "bom_version"'))
+        have_bom_path = 1 if bom_path else 0
+        have_bom_version = 1 if bom_version else 0
+        if have_bom_path + have_bom_version != 1:
+            raise_and_log_error(
+                ConfigError('Expected exactly one of: "bom_path", or "bom_version"')
+            )
 
-    if bom_path:
-      check_path_exists(bom_path, why='options.bom_path')
-      return BomSourceCodeManager.bom_from_path(bom_path)
+        if bom_path:
+            check_path_exists(bom_path, why="options.bom_path")
+            return BomSourceCodeManager.bom_from_path(bom_path)
 
-    if not bom_version:
-      raise_and_log_error(
-          UnexpectedError('Not reachable', cause='NotReachable'))
+        if not bom_version:
+            raise_and_log_error(UnexpectedError("Not reachable", cause="NotReachable"))
 
-    logging.debug('Retrieving bom version %s', bom_version)
-    return HalRunner(options).retrieve_bom_version(bom_version)
+        logging.debug("Retrieving bom version %s", bom_version)
+        return HalRunner(options).retrieve_bom_version(bom_version)
 
+    @property
+    def bom(self):
+        """Returns the bom being used, if any."""
+        return self.__bom
 
-  @property
-  def bom(self):
-    """Returns the bom being used, if any."""
-    return self.__bom
+    def __init__(self, options, *pos_args, **kwargs):
+        self.__bom = kwargs.pop("bom", None) or self.load_bom(options)
+        super(BomSourceCodeManager, self).__init__(options, *pos_args, **kwargs)
 
-  def __init__(self, options, *pos_args, **kwargs):
-    self.__bom = kwargs.pop('bom', None) or self.load_bom(options)
-    super(BomSourceCodeManager, self).__init__(options, *pos_args, **kwargs)
+    def get_repository_service_build_version(self, repository):
+        if not self.__bom:
+            raise_and_log_error(UnexpectedError("Missing bom", cause="NotReachable"))
 
-  def get_repository_service_build_version(self, repository):
-    if not self.__bom:
-      raise_and_log_error(UnexpectedError('Missing bom', cause='NotReachable'))
+        service_name = self.repository_name_to_service_name(repository.name)
+        service_entry = self.__bom.get("services", {}).get(service_name, {})
+        if not service_entry:
+            raise_and_log_error(ConfigError("BOM missing service %s" % service_name))
+        return service_entry["version"]
 
-    service_name = self.repository_name_to_service_name(repository.name)
-    service_entry = self.__bom.get('services', {}).get(service_name, {})
-    if not service_entry:
-      raise_and_log_error(ConfigError('BOM missing service %s' % service_name))
-    return service_entry['version']
+    def determine_bom_version(self):
+        """Determine version of bound bom."""
+        if self.__bom:
+            return self.__bom["version"]
+        if self.__options.bom_version:
+            return self.__options.bom_version
+        return None
 
-  def determine_bom_version(self):
-    """Determine version of bound bom."""
-    if self.__bom:
-      return self.__bom['version']
-    if self.__options.bom_version:
-      return self.__options.bom_version
-    return None
+    def determine_origin(self, name):
+        service_name = self.repository_name_to_service_name(name)
+        service = check_bom_service(self.__bom, service_name)
+        if service.get("gitPrefix"):
+            prefix = service["gitPrefix"]
+        else:
+            prefix = self.__bom["artifactSources"]["gitPrefix"]
+        return prefix + "/" + name
 
-  def determine_origin(self, name):
-    service_name = self.repository_name_to_service_name(name)
-    service = check_bom_service(self.__bom, service_name)
-    if service.get('gitPrefix'):
-      prefix = service['gitPrefix']
-    else:
-      prefix = self.__bom['artifactSources']['gitPrefix']
-    return prefix + '/' + name
+    def ensure_git_path(self, repository, **kwargs):
+        """Make sure repository path is consistent with BOM."""
+        check_kwargs_empty(kwargs)
+        service_name = self.repository_name_to_service_name(repository.name)
+        if not service_name in self.__bom["services"].keys():
+            raise_and_log_error(
+                UnexpectedError('"%s" is not a BOM repo' % service_name)
+            )
 
-  def ensure_git_path(self, repository, **kwargs):
-    """Make sure repository path is consistent with BOM."""
-    check_kwargs_empty(kwargs)
-    service_name = self.repository_name_to_service_name(repository.name)
-    if not service_name in self.__bom['services'].keys():
-      raise_and_log_error(
-          UnexpectedError('"%s" is not a BOM repo' % service_name))
+        git_dir = repository.git_dir
+        have_git_dir = os.path.exists(git_dir)
 
-    git_dir = repository.git_dir
-    have_git_dir = os.path.exists(git_dir)
+        service = check_bom_service(self.__bom, service_name)
+        commit_id = service["commit"]
 
-    service = check_bom_service(self.__bom, service_name)
-    commit_id = service['commit']
+        if not have_git_dir:
+            self.git.clone_repository_to_path(repository, commit=commit_id)
 
-    if not have_git_dir:
-      self.git.clone_repository_to_path(repository, commit=commit_id)
+    def determine_build_number(self, repository):
+        service_name = self.repository_name_to_service_name(repository.name)
+        if not service_name in self.__bom["services"].keys():
+            raise_and_log_error(
+                UnexpectedError('"%s" is not a BOM repo' % service_name)
+            )
 
-  def determine_build_number(self, repository):
-    service_name = self.repository_name_to_service_name(repository.name)
-    if not service_name in self.__bom['services'].keys():
-      raise_and_log_error(
-          UnexpectedError('"%s" is not a BOM repo' % service_name))
+        service = check_bom_service(self.__bom, service_name)
+        build_number = service["version"][service["version"].find("-") + 1 :]
+        return build_number
 
-    service = check_bom_service(self.__bom, service_name)
-    build_number = service['version'][service['version'].find('-') + 1:]
-    return build_number
+    def determine_repository_version(self, repository):
+        service_name = self.repository_name_to_service_name(repository.name)
+        if not service_name in self.__bom["services"].keys():
+            raise_and_log_error(
+                UnexpectedError('"%s" is not a BOM repo' % service_name)
+            )
 
-  def determine_repository_version(self, repository):
-    service_name = self.repository_name_to_service_name(repository.name)
-    if not service_name in self.__bom['services'].keys():
-      raise_and_log_error(
-          UnexpectedError('"%s" is not a BOM repo' % service_name))
+        service = check_bom_service(self.__bom, service_name)
+        version = service["version"][: service["version"].find("-")]
+        return version
 
-    service = check_bom_service(self.__bom, service_name)
-    version = service['version'][:service['version'].find('-')]
-    return version
+    def ensure_repository(self, repository):
+        git_dir = repository.git_dir
+        service_name = self.repository_name_to_service_name(repository.name)
+        self.git.refresh_local_repository(git_dir, "origin")
+        bom_commit = check_bom_service(self.__bom, service_name)["commit"]
+        self.git.checkout(repository, bom_commit)
+        return
 
-  def ensure_repository(self, repository):
-    git_dir = repository.git_dir
-    service_name = self.repository_name_to_service_name(repository.name)
-    self.git.refresh_local_repository(git_dir, 'origin')
-    bom_commit = check_bom_service(self.__bom, service_name)['commit']
-    self.git.checkout(repository, bom_commit)
-    return
+    def check_repository_is_current(self, repository):
+        git_dir = repository.git_dir
+        service_name = self.repository_name_to_service_name(repository.name)
+        have_commit = self.git.query_local_repository_commit_id(git_dir)
+        bom_commit = check_bom_service(self.__bom, service_name)["commit"]
+        if have_commit != bom_commit:
+            raise_and_log_error(
+                UnexpectedError(
+                    '"%s" is at the wrong commit "%s"' % (git_dir, bom_commit)
+                )
+            )
+        return True
 
-  def check_repository_is_current(self, repository):
-    git_dir = repository.git_dir
-    service_name = self.repository_name_to_service_name(repository.name)
-    have_commit = self.git.query_local_repository_commit_id(git_dir)
-    bom_commit = check_bom_service(self.__bom, service_name)['commit']
-    if have_commit != bom_commit:
-      raise_and_log_error(
-          UnexpectedError(
-              '"%s" is at the wrong commit "%s"' % (git_dir, bom_commit)))
-    return True
+    def determine_upstream_url(self, name):
+        # Disable upstream on BOM urls since we wont be pushing back.
+        return None
 
-  def determine_upstream_url(self, name):
-    # Disable upstream on BOM urls since we wont be pushing back.
-    return None
+    def determine_source_repositories(self):
+        """Implements SpinnakerSourceCodeManger interface."""
+        bom = self.__bom
+        git_prefix = bom["artifactSources"]["gitPrefix"]
+        repositories = []
+        for service_name, spec in bom["services"].items():
+            if spec is None:
+                logging.warning("Skipping %s because it was null", service_name)
+                continue
+            if service_name in ["monitoring-third-party", "defaultArtifact"]:
+                continue
+            repo_name = self.service_name_to_repository_name(service_name)
 
-  def determine_source_repositories(self):
-    """Implements SpinnakerSourceCodeManger interface."""
-    bom = self.__bom
-    git_prefix = bom['artifactSources']['gitPrefix']
-    repositories = []
-    for service_name, spec in bom['services'].items():
-      if spec is None:
-        logging.warning('Skipping %s because it was null', service_name)
-        continue
-      if service_name in ['monitoring-third-party', 'defaultArtifact']:
-        continue
-      repo_name = self.service_name_to_repository_name(service_name)
-
-      prefix = spec['gitPrefix'] if 'gitPrefix' in spec else git_prefix
-      origin = '%s/%s' % (prefix, repo_name)
-      repositories.append(self.make_repository_spec(repo_name, origin=origin))
-    return repositories
+            prefix = spec["gitPrefix"] if "gitPrefix" in spec else git_prefix
+            origin = "%s/%s" % (prefix, repo_name)
+            repositories.append(self.make_repository_spec(repo_name, origin=origin))
+        return repositories

--- a/dev/buildtool/branch_scm.py
+++ b/dev/buildtool/branch_scm.py
@@ -21,113 +21,129 @@ from buildtool import (
     DEFAULT_BUILD_NUMBER,
     GitRunner,
     SpinnakerSourceCodeManager,
-
     add_parser_argument,
     check_kwargs_empty,
     check_options_set,
     raise_and_log_error,
-    UnexpectedError)
+    UnexpectedError,
+)
 
 
 class BranchSourceCodeManager(SpinnakerSourceCodeManager):
-  """Sources are retrieved from github using branches."""
+    """Sources are retrieved from github using branches."""
 
-  @staticmethod
-  def add_parser_args(parser, defaults):
-    """Add standard parser arguments used by SourceCodeManager."""
-    if hasattr(parser, 'added_branch_scm'):
-      return
-    parser.added_branch_scm = True
+    @staticmethod
+    def add_parser_args(parser, defaults):
+        """Add standard parser arguments used by SourceCodeManager."""
+        if hasattr(parser, "added_branch_scm"):
+            return
+        parser.added_branch_scm = True
 
-    SpinnakerSourceCodeManager.add_parser_args(parser, defaults)
-    GitRunner.add_parser_args(parser, defaults)
-    add_parser_argument(parser, 'git_branch', defaults, None,
-                        help='The git branch to operate on.')
-    add_parser_argument(parser, 'github_hostname', defaults, 'github.com',
-                        help='The hostname of the git server.')
+        SpinnakerSourceCodeManager.add_parser_args(parser, defaults)
+        GitRunner.add_parser_args(parser, defaults)
+        add_parser_argument(
+            parser, "git_branch", defaults, None, help="The git branch to operate on."
+        )
+        add_parser_argument(
+            parser,
+            "github_hostname",
+            defaults,
+            "github.com",
+            help="The hostname of the git server.",
+        )
 
-  def __init__(self, *pos_args, **kwargs):
-    super(BranchSourceCodeManager, self).__init__(*pos_args, **kwargs)
-    options = self.options
-    check_options_set(options,
-                      ['git_branch', 'github_owner', 'github_hostname'])
+    def __init__(self, *pos_args, **kwargs):
+        super(BranchSourceCodeManager, self).__init__(*pos_args, **kwargs)
+        options = self.options
+        check_options_set(options, ["git_branch", "github_owner", "github_hostname"])
 
-    self.__github_owner = (options.github_owner
-                           if hasattr(options, 'github_owner')
-                           else None)
+        self.__github_owner = (
+            options.github_owner if hasattr(options, "github_owner") else None
+        )
 
-  def determine_origin(self, name):
-    """Determine the origin to use for the given repository."""
-    if not self.__github_owner:
-      raise_and_log_error(
-          UnexpectedError('Not reachable', cause='NotReachable'))
-    return self.determine_origin_for_owner(name, self.__github_owner)
+    def determine_origin(self, name):
+        """Determine the origin to use for the given repository."""
+        if not self.__github_owner:
+            raise_and_log_error(UnexpectedError("Not reachable", cause="NotReachable"))
+        return self.determine_origin_for_owner(name, self.__github_owner)
 
-  def determine_origin_for_owner(self, name, github_owner):
-    options = self.options
-    if github_owner in ('upstream', 'default'):
-      github_owner = self.options.github_upstream_owner
+    def determine_origin_for_owner(self, name, github_owner):
+        options = self.options
+        if github_owner in ("upstream", "default"):
+            github_owner = self.options.github_upstream_owner
 
-    if self.options.github_repository_root:
-      return '/'.join([self.options.github_repository_root,
-                       github_owner, name])
+        if self.options.github_repository_root:
+            return "/".join([self.options.github_repository_root, github_owner, name])
 
-    origin_hostname = options.github_hostname
-    if self.options.github_pull_ssh:
-      return self.git.make_ssh_url(origin_hostname, github_owner, name)
-    return self.git.make_https_url(origin_hostname, github_owner, name)
+        origin_hostname = options.github_hostname
+        if self.options.github_pull_ssh:
+            return self.git.make_ssh_url(origin_hostname, github_owner, name)
+        return self.git.make_https_url(origin_hostname, github_owner, name)
 
-  def ensure_git_path(self, repository, **kwargs):
-    branch = kwargs.pop('branch', None)
-    check_kwargs_empty(kwargs)
-    options = self.options
+    def ensure_git_path(self, repository, **kwargs):
+        branch = kwargs.pop("branch", None)
+        check_kwargs_empty(kwargs)
+        options = self.options
 
-    git_dir = repository.git_dir
-    have_git_dir = os.path.exists(git_dir)
-    if not branch:
-      if hasattr(options, 'git_branch'):
-        branch = options.git_branch
-      else:
-        branch = 'master'
-        logging.debug('No git_branch option available.'
-                      ' Assuming "%s" branch is "master"', repository.name)
+        git_dir = repository.git_dir
+        have_git_dir = os.path.exists(git_dir)
+        if not branch:
+            if hasattr(options, "git_branch"):
+                branch = options.git_branch
+            else:
+                branch = "master"
+                logging.debug(
+                    "No git_branch option available."
+                    ' Assuming "%s" branch is "master"',
+                    repository.name,
+                )
 
-    fallback_branch = (options.git_fallback_branch
-                       if hasattr(options, 'git_fallback_branch')
-                       else None)
-    if not have_git_dir:
-      self.git.clone_repository_to_path(
-          repository, branch=branch, default_branch=fallback_branch)
+        fallback_branch = (
+            options.git_fallback_branch
+            if hasattr(options, "git_fallback_branch")
+            else None
+        )
+        if not have_git_dir:
+            self.git.clone_repository_to_path(
+                repository, branch=branch, default_branch=fallback_branch
+            )
 
-  def determine_build_number(self, repository):
-    if hasattr(self.options, 'build_number') and self.options.build_number:
-      build_number = self.options.build_number
-    else:
-      build_number = DEFAULT_BUILD_NUMBER
-      logging.debug('Using default build number "%s" for "%s"',
-                    build_number, repository.name)
-    return build_number
+    def determine_build_number(self, repository):
+        if hasattr(self.options, "build_number") and self.options.build_number:
+            build_number = self.options.build_number
+        else:
+            build_number = DEFAULT_BUILD_NUMBER
+            logging.debug(
+                'Using default build number "%s" for "%s"',
+                build_number,
+                repository.name,
+            )
+        return build_number
 
-  def ensure_repository(self, repository):
-    return
+    def ensure_repository(self, repository):
+        return
 
-  def check_repository_is_current(self, repository):
-    git_dir = repository.git_dir
-    commit = repository.commit_or_none()
-    if commit is not None:
-      have_commit = self.git.query_local_repository_commit_id(git_dir)
-      if have_commit != commit:
-        raise_and_log_error(
-          UnexpectedError(
-             '"%s" is at the wrong commit "%s" vs "%s"' % (
-                 git_dir, have_commit, commit)))
-      return True
+    def check_repository_is_current(self, repository):
+        git_dir = repository.git_dir
+        commit = repository.commit_or_none()
+        if commit is not None:
+            have_commit = self.git.query_local_repository_commit_id(git_dir)
+            if have_commit != commit:
+                raise_and_log_error(
+                    UnexpectedError(
+                        '"%s" is at the wrong commit "%s" vs "%s"'
+                        % (git_dir, have_commit, commit)
+                    )
+                )
+            return True
 
-    branch = self.options.git_branch or 'master'
-    have_branch = self.git.query_local_repository_branch(git_dir)
-    if have_branch != branch:
-      raise_and_log_error(
-          UnexpectedError(
-              '"%s" is at the wrong branch "%s" vs "%s"' % (
-                  git_dir, have_branch, branch)))
-    return True
+        branch = self.options.git_branch or "master"
+        have_branch = self.git.query_local_repository_branch(git_dir)
+        if have_branch != branch:
+            raise_and_log_error(
+                UnexpectedError(
+                    '"%s" is at the wrong branch "%s" vs "%s"'
+                    % (git_dir, have_branch, branch)
+                )
+            )
+        return True

--- a/dev/buildtool/changelog_commands.py
+++ b/dev/buildtool/changelog_commands.py
@@ -26,455 +26,499 @@ import textwrap
 import yaml
 
 try:
-  from urllib2 import urlopen, HTTPError
+    from urllib2 import urlopen, HTTPError
 except ImportError:
-  from urllib.request import urlopen
-  from urllib.error import HTTPError
+    from urllib.request import urlopen
+    from urllib.error import HTTPError
 
 from retrying import retry
 
 from buildtool import (
     SPINNAKER_IO_REPOSITORY_NAME,
-
     CommandFactory,
     CommandProcessor,
     RepositoryCommandFactory,
     RepositoryCommandProcessor,
-
     BomSourceCodeManager,
     BranchSourceCodeManager,
-
     ConfigError,
     UnexpectedError,
     CommitMessage,
     GitRunner,
     HalRunner,
-
     check_kwargs_empty,
     check_options_set,
     check_path_exists,
     ensure_dir_exists,
     raise_and_log_error,
-    write_to_path)
+    write_to_path,
+)
 
 
-BUILD_CHANGELOG_COMMAND = 'build_changelog'
-TITLE_LINE_MATCHER = re.compile(r'\W*\w+\(([^\)]+)\)\s*[:-]?(.*)')
+BUILD_CHANGELOG_COMMAND = "build_changelog"
+TITLE_LINE_MATCHER = re.compile(r"\W*\w+\(([^\)]+)\)\s*[:-]?(.*)")
 
 
 def make_options_with_fallback(options):
-  """A hack for now, using git_fallback_branch to support spinnaker.io
+    """A hack for now, using git_fallback_branch to support spinnaker.io
 
-  That repo does not use the release branches, rather master.
-  So if creating a release, it will fallback to master for that repo.
-  """
-  options_copy = copy.copy(options)
-  options_copy.git_fallback_branch = 'master'
-  return options_copy
+    That repo does not use the release branches, rather master.
+    So if creating a release, it will fallback to master for that repo.
+    """
+    options_copy = copy.copy(options)
+    options_copy.git_fallback_branch = "master"
+    return options_copy
 
 
 class ChangelogRepositoryData(
-    collections.namedtuple('ChangelogRepositoryData',
-                           ['repository', 'summary', 'normalized_messages'])):
-  """Captures the change information for a given repository."""
+    collections.namedtuple(
+        "ChangelogRepositoryData", ["repository", "summary", "normalized_messages"]
+    )
+):
+    """Captures the change information for a given repository."""
 
-  def __cmp__(self, other):
-    return self.repository.name.__cmp__(other.repository.name)
+    def __cmp__(self, other):
+        return self.repository.name.__cmp__(other.repository.name)
 
-  def partition_commits(self, sort=True):
-    """Partition the commit messages by the type of change.
+    def partition_commits(self, sort=True):
+        """Partition the commit messages by the type of change.
 
-    Returns an OrderedDict of the partition ordered by significance.
-    The keys in the dictionary are the type of change.
-    The values are a list of git.CommitMessage.
-    """
-    partition_types = [
-        ('Breaking Changes',
-         re.compile(r'^\s*'
-                    r'(.*?BREAKING CHANGE.*)',
-                    re.MULTILINE)),
-        ('Features',
-         re.compile(r'^\s*'
-                    r'(?:\*\s+)?'
-                    r'((?:feat|feature)[\(:].*)',
-                    re.MULTILINE)),
-        ('Configuration',
-         re.compile(r'^\s*'
-                    r'(?:\*\s+)?'
-                    r'((?:config)[\(:].*)',
-                    re.MULTILINE)),
-        ('Fixes',
-         re.compile(r'^\s*'
-                    r'(?:\*\s+)?'
-                    r'((?:bug|fix)[\(:].*)',
-                    re.MULTILINE)),
-        ('Other',
-         re.compile(r'.*'))
-    ]
-    workspace = {}
-    for msg in self.normalized_messages:
-      text = msg.message
-      match = None
-      for section, regex in partition_types:
-        match = regex.search(text)
-        if match:
-          if section not in workspace:
-            workspace[section] = []
-          workspace[section].append(msg)
-          break
+        Returns an OrderedDict of the partition ordered by significance.
+        The keys in the dictionary are the type of change.
+        The values are a list of git.CommitMessage.
+        """
+        partition_types = [
+            (
+                "Breaking Changes",
+                re.compile(r"^\s*" r"(.*?BREAKING CHANGE.*)", re.MULTILINE),
+            ),
+            (
+                "Features",
+                re.compile(
+                    r"^\s*" r"(?:\*\s+)?" r"((?:feat|feature)[\(:].*)", re.MULTILINE
+                ),
+            ),
+            (
+                "Configuration",
+                re.compile(r"^\s*" r"(?:\*\s+)?" r"((?:config)[\(:].*)", re.MULTILINE),
+            ),
+            (
+                "Fixes",
+                re.compile(r"^\s*" r"(?:\*\s+)?" r"((?:bug|fix)[\(:].*)", re.MULTILINE),
+            ),
+            ("Other", re.compile(r".*")),
+        ]
+        workspace = {}
+        for msg in self.normalized_messages:
+            text = msg.message
+            match = None
+            for section, regex in partition_types:
+                match = regex.search(text)
+                if match:
+                    if section not in workspace:
+                        workspace[section] = []
+                    workspace[section].append(msg)
+                    break
 
-    result = collections.OrderedDict()
-    for spec in partition_types:
-      key = spec[0]
-      if key in workspace:
-        result[key] = (self._sort_partition(workspace[key])
-                       if sort
-                       else workspace[key])
-    return result
+        result = collections.OrderedDict()
+        for spec in partition_types:
+            key = spec[0]
+            if key in workspace:
+                result[key] = (
+                    self._sort_partition(workspace[key]) if sort else workspace[key]
+                )
+        return result
 
-  @staticmethod
-  def _sort_partition(commit_messages):
-    """sorting key function for CommitMessage.
+    @staticmethod
+    def _sort_partition(commit_messages):
+        """sorting key function for CommitMessage.
 
-    Returns the commit messages sorted by affected component while
-    preserving original ordering with the component. The affected
-    component is the <THING> for titles in the form TYPE(<THING>): <MESSAGE>
-    """
-    thing_dict = {}
-    def get_thing_list(title_line):
-      """Return bucket for title_line, adding new one if needed."""
-      match = TITLE_LINE_MATCHER.match(title_line)
-      thing = match.group(1) if match else ''
-      if not thing in thing_dict:
-        thing_dict[thing] = []
-      return thing_dict[thing]
+        Returns the commit messages sorted by affected component while
+        preserving original ordering with the component. The affected
+        component is the <THING> for titles in the form TYPE(<THING>): <MESSAGE>
+        """
+        thing_dict = {}
 
-    for message in commit_messages:
-      title_line = message.message.split('\n')[0]
-      get_thing_list(title_line).append(message)
+        def get_thing_list(title_line):
+            """Return bucket for title_line, adding new one if needed."""
+            match = TITLE_LINE_MATCHER.match(title_line)
+            thing = match.group(1) if match else ""
+            if not thing in thing_dict:
+                thing_dict[thing] = []
+            return thing_dict[thing]
 
-    result = []
-    for thing in sorted(thing_dict.keys()):
-      result.extend(thing_dict[thing])
-    return result
+        for message in commit_messages:
+            title_line = message.message.split("\n")[0]
+            get_thing_list(title_line).append(message)
+
+        result = []
+        for thing in sorted(thing_dict.keys()):
+            result.extend(thing_dict[thing])
+        return result
 
 
 class ChangelogBuilder(object):
-  """Knows how to create changelogs from git.RepositorySummary."""
+    """Knows how to create changelogs from git.RepositorySummary."""
 
-  STRIP_GITHUB_ID_MATCHER = re.compile(r'^(.*?)\s*\(#\d+\)$')
+    STRIP_GITHUB_ID_MATCHER = re.compile(r"^(.*?)\s*\(#\d+\)$")
 
-  def __init__(self, **kwargs):
-    self.__entries = []
-    self.__with_partition = kwargs.pop('with_partition', True)
-    self.__with_detail = kwargs.pop('with_detail', False)
-    self.__write_category_heading = self.__with_partition and self.__with_detail
-    check_kwargs_empty(kwargs)
-    self.__sort_partitions = True
+    def __init__(self, **kwargs):
+        self.__entries = []
+        self.__with_partition = kwargs.pop("with_partition", True)
+        self.__with_detail = kwargs.pop("with_detail", False)
+        self.__write_category_heading = self.__with_partition and self.__with_detail
+        check_kwargs_empty(kwargs)
+        self.__sort_partitions = True
 
-  def clean_message(self, text):
-    """Remove trailing "(#<id>)" from first line of message titles"""
-    parts = text.split('\n', 1)
-    if len(parts) == 1:
-      first, rest = text, ''
-    else:
-      first, rest = parts
-    match = self.STRIP_GITHUB_ID_MATCHER.match(first)
-    if match:
-      if rest:
-        return '\n'.join([match.group(1), rest])
-      return match.group(1)
-    return text
-
-  def add_repository(self, repository, summary):
-    """Add repository changes into the builder."""
-    message_list = summary.commit_messages
-    normalized_messages = CommitMessage.normalize_message_list(message_list)
-    self.__entries.append(ChangelogRepositoryData(
-        repository, summary, normalized_messages))
-
-  def build(self):
-    """Construct changelog."""
-    report = []
-
-    for entry in sorted(self.__entries):
-      summary = entry.summary
-      repository = entry.repository
-      commit_messages = entry.normalized_messages
-      name = repository.name
-
-      if not commit_messages:
-        continue
-
-      report.append('## [{title}](#{name}) {version}'.format(
-          title=name.capitalize(), name=name,
-          version=summary.version))
-      report.append('')
-
-      if self.__with_partition:
-        report.extend(self.build_commits_by_type(entry))
-      if self.__with_detail:
-        report.extend(self.build_commits_by_sequence(entry))
-
-    return '\n'.join(report)
-
-  def build_commits_by_type(self, entry):
-    """Create a section that enumerates changes by partition type.
-
-    Args:
-      entry: [ChangelogRepositoryData] The repository to report on.
-
-    Returns:
-      list of changelog lines
-    """
-
-    report = []
-    partitioned_commits = entry.partition_commits(sort=self.__sort_partitions)
-    if self.__write_category_heading:
-      report.append('### Changes by Type')
-    if not partitioned_commits:
-      report.append('  No Significant Changes.')
-      return report
-
-    one_liner = TITLE_LINE_MATCHER
-    base_url = entry.repository.origin
-    level_marker = '#' * 4
-    for title, commit_messages in partitioned_commits.items():
-      report.append('{level} {title}'.format(level=level_marker, title=title))
-      report.append('')
-      for msg in commit_messages:
-        first_line = msg.message.split('\n', 1)[0].strip()
-        clean_text = self.clean_message(first_line)
-        match = one_liner.match(clean_text)
-        if match:
-          text = u'**{thing}:**  {message}'.format(
-              thing=match.group(1), message=match.group(2))
+    def clean_message(self, text):
+        """Remove trailing "(#<id>)" from first line of message titles"""
+        parts = text.split("\n", 1)
+        if len(parts) == 1:
+            first, rest = text, ""
         else:
-          text = clean_text
+            first, rest = parts
+        match = self.STRIP_GITHUB_ID_MATCHER.match(first)
+        if match:
+            if rest:
+                return "\n".join([match.group(1), rest])
+            return match.group(1)
+        return text
 
-        link = u'[{short_hash}]({base_url}/commit/{full_hash})'.format(
-            short_hash=msg.commit_id[:8], full_hash=msg.commit_id,
-            base_url=base_url)
-        report.append(u'* {text} ({link})'.format(text=text, link=link))
-      report.append('')
-    return report
+    def add_repository(self, repository, summary):
+        """Add repository changes into the builder."""
+        message_list = summary.commit_messages
+        normalized_messages = CommitMessage.normalize_message_list(message_list)
+        self.__entries.append(
+            ChangelogRepositoryData(repository, summary, normalized_messages)
+        )
 
-  def build_commits_by_sequence(self, entry):
-    """Create a section that enumerates all changes in order.
+    def build(self):
+        """Construct changelog."""
+        report = []
 
-    Args:
-      entry: [ChangelogRepositoryData] The repository to report on.
+        for entry in sorted(self.__entries):
+            summary = entry.summary
+            repository = entry.repository
+            commit_messages = entry.normalized_messages
+            name = repository.name
 
-    Returns:
-      list of changelog lines
-    """
-    level_name = [None, 'MAJOR', 'MINOR', 'PATCH']
+            if not commit_messages:
+                continue
 
-    report = []
-    if self.__write_category_heading:
-      report.append('### Changes by Sequence')
-    base_url = entry.repository.origin
-    for msg in entry.normalized_messages:
-      clean_text = self.clean_message(msg.message)
-      link = u'[{short_hash}]({base_url}/commit/{full_hash})'.format(
-          short_hash=msg.commit_id[:8], full_hash=msg.commit_id,
-          base_url=base_url)
-      level = msg.determine_semver_implication()
-      report.append(u'**{level}** ({link})\n{detail}\n'.format(
-          level=level_name[level], link=link, detail=clean_text))
-    return report
+            report.append(
+                "## [{title}](#{name}) {version}".format(
+                    title=name.capitalize(), name=name, version=summary.version
+                )
+            )
+            report.append("")
+
+            if self.__with_partition:
+                report.extend(self.build_commits_by_type(entry))
+            if self.__with_detail:
+                report.extend(self.build_commits_by_sequence(entry))
+
+        return "\n".join(report)
+
+    def build_commits_by_type(self, entry):
+        """Create a section that enumerates changes by partition type.
+
+        Args:
+          entry: [ChangelogRepositoryData] The repository to report on.
+
+        Returns:
+          list of changelog lines
+        """
+
+        report = []
+        partitioned_commits = entry.partition_commits(sort=self.__sort_partitions)
+        if self.__write_category_heading:
+            report.append("### Changes by Type")
+        if not partitioned_commits:
+            report.append("  No Significant Changes.")
+            return report
+
+        one_liner = TITLE_LINE_MATCHER
+        base_url = entry.repository.origin
+        level_marker = "#" * 4
+        for title, commit_messages in partitioned_commits.items():
+            report.append("{level} {title}".format(level=level_marker, title=title))
+            report.append("")
+            for msg in commit_messages:
+                first_line = msg.message.split("\n", 1)[0].strip()
+                clean_text = self.clean_message(first_line)
+                match = one_liner.match(clean_text)
+                if match:
+                    text = "**{thing}:**  {message}".format(
+                        thing=match.group(1), message=match.group(2)
+                    )
+                else:
+                    text = clean_text
+
+                link = "[{short_hash}]({base_url}/commit/{full_hash})".format(
+                    short_hash=msg.commit_id[:8],
+                    full_hash=msg.commit_id,
+                    base_url=base_url,
+                )
+                report.append("* {text} ({link})".format(text=text, link=link))
+            report.append("")
+        return report
+
+    def build_commits_by_sequence(self, entry):
+        """Create a section that enumerates all changes in order.
+
+        Args:
+          entry: [ChangelogRepositoryData] The repository to report on.
+
+        Returns:
+          list of changelog lines
+        """
+        level_name = [None, "MAJOR", "MINOR", "PATCH"]
+
+        report = []
+        if self.__write_category_heading:
+            report.append("### Changes by Sequence")
+        base_url = entry.repository.origin
+        for msg in entry.normalized_messages:
+            clean_text = self.clean_message(msg.message)
+            link = "[{short_hash}]({base_url}/commit/{full_hash})".format(
+                short_hash=msg.commit_id[:8], full_hash=msg.commit_id, base_url=base_url
+            )
+            level = msg.determine_semver_implication()
+            report.append(
+                "**{level}** ({link})\n{detail}\n".format(
+                    level=level_name[level], link=link, detail=clean_text
+                )
+            )
+        return report
 
 
 class BuildChangelogCommand(RepositoryCommandProcessor):
-  """Implements the build_changelog."""
+    """Implements the build_changelog."""
 
-  def __init__(self, factory, options, **kwargs):
-    # Use own repository to avoid race conditions when commands are
-    # running concurrently.
-    if options.relative_to_bom_path and options.relative_to_bom_version:
-      raise_and_log_error(
-          ConfigError(
-              'Cannot specify both --relative_to_bom_path'
-              ' and --relative_to_bom_version.'))
+    def __init__(self, factory, options, **kwargs):
+        # Use own repository to avoid race conditions when commands are
+        # running concurrently.
+        if options.relative_to_bom_path and options.relative_to_bom_version:
+            raise_and_log_error(
+                ConfigError(
+                    "Cannot specify both --relative_to_bom_path"
+                    " and --relative_to_bom_version."
+                )
+            )
 
-    options_copy = copy.copy(options)
-    options_copy.github_disable_upstream_push = True
+        options_copy = copy.copy(options)
+        options_copy.github_disable_upstream_push = True
 
-    if options.relative_to_bom_path:
-      with open(options.relative_to_bom_path, 'r') as stream:
-        self.__relative_bom = yaml.safe_load(stream.read())
-    elif options.relative_to_bom_version:
-      self.__relative_bom = HalRunner(options).retrieve_bom_version(
-          options.relative_to_bom_version)
-    else:
-      self.__relative_bom = None
-    super(BuildChangelogCommand, self).__init__(factory, options_copy, **kwargs)
+        if options.relative_to_bom_path:
+            with open(options.relative_to_bom_path, "r") as stream:
+                self.__relative_bom = yaml.safe_load(stream.read())
+        elif options.relative_to_bom_version:
+            self.__relative_bom = HalRunner(options).retrieve_bom_version(
+                options.relative_to_bom_version
+            )
+        else:
+            self.__relative_bom = None
+        super(BuildChangelogCommand, self).__init__(factory, options_copy, **kwargs)
 
-  def _do_repository(self, repository):
-    """Collect the summary for the given repository."""
-    if self.__relative_bom:
-      repo_name = self.scm.repository_name_to_service_name(repository.name)
-      bom_commit = self.__relative_bom['services'][repo_name]['commit']
-    else:
-      bom_commit = None
-    return self.git.collect_repository_summary(repository.git_dir,
-                                               start_commit_id=bom_commit)
+    def _do_repository(self, repository):
+        """Collect the summary for the given repository."""
+        if self.__relative_bom:
+            repo_name = self.scm.repository_name_to_service_name(repository.name)
+            bom_commit = self.__relative_bom["services"][repo_name]["commit"]
+        else:
+            bom_commit = None
+        return self.git.collect_repository_summary(
+            repository.git_dir, start_commit_id=bom_commit
+        )
 
-  def _do_postprocess(self, result_dict):
-    """Construct changelog from the collected summary, then write it out."""
-    options = self.options
-    path = os.path.join(self.get_output_dir(), 'changelog.md')
+    def _do_postprocess(self, result_dict):
+        """Construct changelog from the collected summary, then write it out."""
+        options = self.options
+        path = os.path.join(self.get_output_dir(), "changelog.md")
 
-    builder = ChangelogBuilder(with_detail=options.include_changelog_details)
-    repository_map = {repository.name: repository
-                      for repository in self.source_repositories}
-    for name, summary in result_dict.items():
-      builder.add_repository(repository_map[name], summary)
-    changelog_text = builder.build()
-    write_to_path(changelog_text, path)
-    logging.info('Wrote changelog to %s', path)
+        builder = ChangelogBuilder(with_detail=options.include_changelog_details)
+        repository_map = {
+            repository.name: repository for repository in self.source_repositories
+        }
+        for name, summary in result_dict.items():
+            builder.add_repository(repository_map[name], summary)
+        changelog_text = builder.build()
+        write_to_path(changelog_text, path)
+        logging.info("Wrote changelog to %s", path)
 
 
 class BuildChangelogFactory(RepositoryCommandFactory):
-  """Builds changelog files."""
-  def __init__(self, **kwargs):
-    super(BuildChangelogFactory, self).__init__(
-        BUILD_CHANGELOG_COMMAND, BuildChangelogCommand,
-        'Build a git changelog and write it out to a file.',
-        BomSourceCodeManager, **kwargs)
+    """Builds changelog files."""
 
-  def init_argparser(self, parser, defaults):
-    """Adds command-specific arguments."""
-    super(BuildChangelogFactory, self).init_argparser(
-        parser, defaults)
+    def __init__(self, **kwargs):
+        super(BuildChangelogFactory, self).__init__(
+            BUILD_CHANGELOG_COMMAND,
+            BuildChangelogCommand,
+            "Build a git changelog and write it out to a file.",
+            BomSourceCodeManager,
+            **kwargs
+        )
 
-    self.add_argument(
-        parser, 'include_changelog_details', defaults, False,
-        action='store_true',
-        help='Include a "details" section with the full commit messages'
-             ' in time sequence in the changelog.')
+    def init_argparser(self, parser, defaults):
+        """Adds command-specific arguments."""
+        super(BuildChangelogFactory, self).init_argparser(parser, defaults)
 
-    HalRunner.add_parser_args(parser, defaults)
-    self.add_argument(
-        parser, 'relative_to_bom_path', defaults, None,
-        help='If specified then produce the changelog relative to the'
-             ' commits found in the specified bom rather than the previous'
-             ' repository tag.')
-    self.add_argument(
-        parser, 'relative_to_bom_version', defaults, None,
-        help='If specified then produce the changelog relative to the'
-             ' commits found in the specified bom rather than the previous'
-             ' repository tag.')
+        self.add_argument(
+            parser,
+            "include_changelog_details",
+            defaults,
+            False,
+            action="store_true",
+            help='Include a "details" section with the full commit messages'
+            " in time sequence in the changelog.",
+        )
+
+        HalRunner.add_parser_args(parser, defaults)
+        self.add_argument(
+            parser,
+            "relative_to_bom_path",
+            defaults,
+            None,
+            help="If specified then produce the changelog relative to the"
+            " commits found in the specified bom rather than the previous"
+            " repository tag.",
+        )
+        self.add_argument(
+            parser,
+            "relative_to_bom_version",
+            defaults,
+            None,
+            help="If specified then produce the changelog relative to the"
+            " commits found in the specified bom rather than the previous"
+            " repository tag.",
+        )
 
 
 class PublishChangelogFactory(RepositoryCommandFactory):
-  def __init__(self, **kwargs):
-    super(PublishChangelogFactory, self).__init__(
-        'publish_changelog', PublishChangelogCommand,
-        'Publish Spinnaker version Changelog to spinnaker.io.',
-        BranchSourceCodeManager, **kwargs)
+    def __init__(self, **kwargs):
+        super(PublishChangelogFactory, self).__init__(
+            "publish_changelog",
+            PublishChangelogCommand,
+            "Publish Spinnaker version Changelog to spinnaker.io.",
+            BranchSourceCodeManager,
+            **kwargs
+        )
 
-  def init_argparser(self, parser, defaults):
-    super(PublishChangelogFactory, self).init_argparser(
-        parser, defaults)
-    GitRunner.add_parser_args(parser, defaults)
-    GitRunner.add_publishing_parser_args(parser, defaults)
+    def init_argparser(self, parser, defaults):
+        super(PublishChangelogFactory, self).init_argparser(parser, defaults)
+        GitRunner.add_parser_args(parser, defaults)
+        GitRunner.add_publishing_parser_args(parser, defaults)
 
-    self.add_argument(
-        parser, 'spinnaker_version', defaults, None,
-        help='The version of spinnaker this documentation is for.')
-    self.add_argument(
-        parser, 'changelog_gist_url', defaults, None,
-        help='The gist to the existing changelog content being published.')
+        self.add_argument(
+            parser,
+            "spinnaker_version",
+            defaults,
+            None,
+            help="The version of spinnaker this documentation is for.",
+        )
+        self.add_argument(
+            parser,
+            "changelog_gist_url",
+            defaults,
+            None,
+            help="The gist to the existing changelog content being published.",
+        )
 
 
 class PublishChangelogCommand(RepositoryCommandProcessor):
-  """Implements publish_changelog."""
+    """Implements publish_changelog."""
 
-  def __init__(self, factory, options, **kwargs):
-    super(PublishChangelogCommand, self).__init__(
-        factory, make_options_with_fallback(options),
-        source_repository_names=[SPINNAKER_IO_REPOSITORY_NAME],
-        **kwargs)
-    check_options_set(options, ['spinnaker_version', 'changelog_gist_url'])
-    try:
-      logging.debug('Verifying changelog gist exists at "%s"',
-                    options.changelog_gist_url)
-      urlopen(options.changelog_gist_url)
-    except HTTPError as error:
-      raise_and_log_error(
-          ConfigError(
-              u'Changelog gist "{url}": {error}'.format(
-                  url=options.changelog_gist_url,
-                  error=error.message)))
+    def __init__(self, factory, options, **kwargs):
+        super(PublishChangelogCommand, self).__init__(
+            factory,
+            make_options_with_fallback(options),
+            source_repository_names=[SPINNAKER_IO_REPOSITORY_NAME],
+            **kwargs
+        )
+        check_options_set(options, ["spinnaker_version", "changelog_gist_url"])
+        try:
+            logging.debug(
+                'Verifying changelog gist exists at "%s"', options.changelog_gist_url
+            )
+            urlopen(options.changelog_gist_url)
+        except HTTPError as error:
+            raise_and_log_error(
+                ConfigError(
+                    'Changelog gist "{url}": {error}'.format(
+                        url=options.changelog_gist_url, error=error.message
+                    )
+                )
+            )
 
-  def _do_repository(self, repository):
-    if repository.name != SPINNAKER_IO_REPOSITORY_NAME:
-      raise_and_log_error(UnexpectedError('Got "%s"' % repository.name))
+    def _do_repository(self, repository):
+        if repository.name != SPINNAKER_IO_REPOSITORY_NAME:
+            raise_and_log_error(UnexpectedError('Got "%s"' % repository.name))
 
-    base_branch = 'master'
-    self.scm.ensure_git_path(repository, branch=base_branch)
-    version = self.options.spinnaker_version
+        base_branch = "master"
+        self.scm.ensure_git_path(repository, branch=base_branch)
+        version = self.options.spinnaker_version
 
-    if self.options.git_allow_publish_master_branch:
-      branch_flag = ''
-      head_branch = 'master'
-    else:
-      branch_flag = '-B'
-      head_branch = version + '-changelog'
+        if self.options.git_allow_publish_master_branch:
+            branch_flag = ""
+            head_branch = "master"
+        else:
+            branch_flag = "-B"
+            head_branch = version + "-changelog"
 
-    files_added = self.prepare_local_repository_files(repository)
-    git_dir = repository.git_dir
-    message = 'doc(changelog): Spinnaker Version ' + version
+        files_added = self.prepare_local_repository_files(repository)
+        git_dir = repository.git_dir
+        message = "doc(changelog): Spinnaker Version " + version
 
-    local_git_commands = [
-        # These commands are accomodating to a branch already existing
-        # because the branch is on the version, not build. A rejected
-        # build for some reason that is re-tried will have the same version
-        # so the branch may already exist from the earlier attempt.
-        'fetch origin ' + base_branch,
-        'checkout ' + base_branch,
-        'checkout {flag} {branch}'.format(
-            flag=branch_flag, branch=head_branch),
-        'add ' + ' '.join([os.path.abspath(path) for path in files_added]),
-    ]
-    logging.debug('Commiting changes into local repository "%s" branch=%s',
-                  repository.git_dir, head_branch)
-    git = self.git
-    git.check_run_sequence(git_dir, local_git_commands)
-    git.check_commit_or_no_changes(git_dir, '-m "{msg}"'.format(msg=message))
+        local_git_commands = [
+            # These commands are accomodating to a branch already existing
+            # because the branch is on the version, not build. A rejected
+            # build for some reason that is re-tried will have the same version
+            # so the branch may already exist from the earlier attempt.
+            "fetch origin " + base_branch,
+            "checkout " + base_branch,
+            "checkout {flag} {branch}".format(flag=branch_flag, branch=head_branch),
+            "add " + " ".join([os.path.abspath(path) for path in files_added]),
+        ]
+        logging.debug(
+            'Commiting changes into local repository "%s" branch=%s',
+            repository.git_dir,
+            head_branch,
+        )
+        git = self.git
+        git.check_run_sequence(git_dir, local_git_commands)
+        git.check_commit_or_no_changes(git_dir, '-m "{msg}"'.format(msg=message))
 
-    logging.info('Pushing branch="%s" into "%s"',
-                 head_branch, repository.origin)
-    git.push_branch_to_origin(git_dir, branch=head_branch)
+        logging.info('Pushing branch="%s" into "%s"', head_branch, repository.origin)
+        git.push_branch_to_origin(git_dir, branch=head_branch)
 
-  def prepare_local_repository_files(self, repository):
-    if repository.name != SPINNAKER_IO_REPOSITORY_NAME:
-      raise_and_log_error(UnexpectedError('Got "%s"' % repository.name))
+    def prepare_local_repository_files(self, repository):
+        if repository.name != SPINNAKER_IO_REPOSITORY_NAME:
+            raise_and_log_error(UnexpectedError('Got "%s"' % repository.name))
 
-    updated_files = []
-    new_version = self.write_new_version(repository)
-    updated_files.append(new_version)
+        updated_files = []
+        new_version = self.write_new_version(repository)
+        updated_files.append(new_version)
 
-    old_version = self.deprecate_prior_version(repository)
-    if old_version is not None:
-      updated_files.append(old_version)
+        old_version = self.deprecate_prior_version(repository)
+        if old_version is not None:
+            updated_files.append(old_version)
 
-    return updated_files
+        return updated_files
 
-  def write_new_version(self, repository):
-    timestamp = '{:%Y-%m-%d %H:%M:%S +0000}'.format(datetime.datetime.utcnow())
-    version = self.options.spinnaker_version
-    changelog_filename = '{version}-changelog.md'.format(version=version)
-    target_path = os.path.join(repository.git_dir,
-                               'content','en','changelogs', changelog_filename)
-    major, minor, patch = version.split('.')
-    patch = int(patch)
-    logging.debug('Adding changelog file %s', target_path)
-    with open(target_path, 'w') as f:
-      # pylint: disable=trailing-whitespace
-      header = textwrap.dedent(
-          """\
+    def write_new_version(self, repository):
+        timestamp = "{:%Y-%m-%d %H:%M:%S +0000}".format(datetime.datetime.utcnow())
+        version = self.options.spinnaker_version
+        changelog_filename = "{version}-changelog.md".format(version=version)
+        target_path = os.path.join(
+            repository.git_dir, "content", "en", "changelogs", changelog_filename
+        )
+        major, minor, patch = version.split(".")
+        patch = int(patch)
+        logging.debug("Adding changelog file %s", target_path)
+        with open(target_path, "w") as f:
+            # pylint: disable=trailing-whitespace
+            header = textwrap.dedent(
+                """\
           ---
           title: Version {major}.{minor}
           changelog_title: Version {version}
@@ -483,192 +527,250 @@ class PublishChangelogCommand(RepositoryCommandProcessor):
           version: {version}
           ---
           """.format(
-              version=version,
-              timestamp=timestamp,
-              major=major, minor=minor))
-      f.write(header)
-      for i in reversed(range(patch + 1)):
-        patchVersion = '.'.join([major, minor, str(i)])
-        f.write('<script src="{gist_url}.js?file={version}.md"></script>'.format(
-            gist_url=self.options.changelog_gist_url,
-            version=patchVersion))
-        f.write('\n')
+                    version=version, timestamp=timestamp, major=major, minor=minor
+                )
+            )
+            f.write(header)
+            for i in reversed(range(patch + 1)):
+                patchVersion = ".".join([major, minor, str(i)])
+                f.write(
+                    '<script src="{gist_url}.js?file={version}.md"></script>'.format(
+                        gist_url=self.options.changelog_gist_url, version=patchVersion
+                    )
+                )
+                f.write("\n")
 
-    return target_path
+        return target_path
 
-  def get_prior_version(self, version):
-    major, minor, patch = version.split('.')
-    patch = int(patch)
-    if patch == 0:
-      return None
-    return '.'.join([major, minor, str(patch - 1)])
+    def get_prior_version(self, version):
+        major, minor, patch = version.split(".")
+        patch = int(patch)
+        if patch == 0:
+            return None
+        return ".".join([major, minor, str(patch - 1)])
 
-  def deprecate_prior_version(self, repository):
-    priorVersion = self.get_prior_version(self.options.spinnaker_version)
-    if priorVersion is None:
-      return None
+    def deprecate_prior_version(self, repository):
+        priorVersion = self.get_prior_version(self.options.spinnaker_version)
+        if priorVersion is None:
+            return None
 
-    changelog_filename = '{version}-changelog.md'.format(version=priorVersion)
-    target_path = os.path.join(repository.git_dir,
-                               'content','en','changelogs', changelog_filename)
+        changelog_filename = "{version}-changelog.md".format(version=priorVersion)
+        target_path = os.path.join(
+            repository.git_dir, "content", "en", "changelogs", changelog_filename
+        )
 
-    logging.debug('Deprecating prior version %s', target_path)
-    for line in fileinput.input(target_path, inplace=True):
-      line = line.rstrip()
-      if line.startswith('tags: '):
-        line = line + ' deprecated'
-      print(line)
-    return target_path
+        logging.debug("Deprecating prior version %s", target_path)
+        for line in fileinput.input(target_path, inplace=True):
+            line = line.rstrip()
+            if line.startswith("tags: "):
+                line = line + " deprecated"
+            print(line)
+        return target_path
+
 
 class PushChangelogFactory(CommandFactory):
-  def __init__(self, **kwargs):
-    super(PushChangelogFactory, self).__init__(
-        'push_changelog_to_gist', PushChangelogCommand,
-        'Push raw changelog to an existing gist, possibly overwriting what'
-        ' was already there. This is intended for builds only, not publishing.'
-        ' The expectation is that these will be curated then published'
-        ' with the "publish_changelog" command.'
-        '\nThis will add (or overwrite) the changelog with the name'
-        ' "<branch>-raw-changelog.md".', **kwargs)
+    def __init__(self, **kwargs):
+        super(PushChangelogFactory, self).__init__(
+            "push_changelog_to_gist",
+            PushChangelogCommand,
+            "Push raw changelog to an existing gist, possibly overwriting what"
+            " was already there. This is intended for builds only, not publishing."
+            " The expectation is that these will be curated then published"
+            ' with the "publish_changelog" command.'
+            "\nThis will add (or overwrite) the changelog with the name"
+            ' "<branch>-raw-changelog.md".',
+            **kwargs
+        )
 
-  def init_argparser(self, parser, defaults):
-    super(PushChangelogFactory, self).init_argparser(
-        parser, defaults)
-    GitRunner.add_parser_args(parser, defaults)
+    def init_argparser(self, parser, defaults):
+        super(PushChangelogFactory, self).init_argparser(parser, defaults)
+        GitRunner.add_parser_args(parser, defaults)
 
-    self.add_argument(
-        parser, 'changelog_path', defaults, None,
-        help='The path to the changelog to push.')
-    self.add_argument(
-        parser, 'git_branch', defaults, None,
-        help='The branch name that this changelog is for. Note that this does'
-             ' not actually *use* any branches, rather the branch name is used'
-             ' to decorates the changelog filename.')
-    self.add_argument(
-        parser, 'build_changelog_gist_url', defaults, None,
-        help='The gist to push the changelog into.')
+        self.add_argument(
+            parser,
+            "changelog_path",
+            defaults,
+            None,
+            help="The path to the changelog to push.",
+        )
+        self.add_argument(
+            parser,
+            "git_branch",
+            defaults,
+            None,
+            help="The branch name that this changelog is for. Note that this does"
+            " not actually *use* any branches, rather the branch name is used"
+            " to decorates the changelog filename.",
+        )
+        self.add_argument(
+            parser,
+            "build_changelog_gist_url",
+            defaults,
+            None,
+            help="The gist to push the changelog into.",
+        )
+
 
 class CreateReleaseChangelogFactory(CommandFactory):
-  def __init__(self, **kwargs):
-    super(CreateReleaseChangelogFactory, self).__init__(
-        'create_release_changelog', CreateReleaseChangelogCommand,
-        'Push a patch release changelog to the gist holding the changelogs for'
-        ' that minor version.\nThis will add (or overwrite) the changelog with'
-        ' the name 1.x.y.md in the supplied release changelog gist.', **kwargs)
+    def __init__(self, **kwargs):
+        super(CreateReleaseChangelogFactory, self).__init__(
+            "create_release_changelog",
+            CreateReleaseChangelogCommand,
+            "Push a patch release changelog to the gist holding the changelogs for"
+            " that minor version.\nThis will add (or overwrite) the changelog with"
+            " the name 1.x.y.md in the supplied release changelog gist.",
+            **kwargs
+        )
 
-  def init_argparser(self, parser, defaults):
-    super(CreateReleaseChangelogFactory, self).init_argparser(
-        parser, defaults)
-    GitRunner.add_parser_args(parser, defaults)
+    def init_argparser(self, parser, defaults):
+        super(CreateReleaseChangelogFactory, self).init_argparser(parser, defaults)
+        GitRunner.add_parser_args(parser, defaults)
 
-    self.add_argument(
-        parser, 'spinnaker_version', defaults, None,
-        help='The Spinnaker version for which we are creating a changelog.')
-    self.add_argument(
-        parser, 'build_changelog_gist_url', defaults, None,
-        help='The gist containing the raw changelog.')
-    self.add_argument(
-        parser, 'changelog_gist_url', defaults, None,
-        help='The gist to which to push the release changelog.')
+        self.add_argument(
+            parser,
+            "spinnaker_version",
+            defaults,
+            None,
+            help="The Spinnaker version for which we are creating a changelog.",
+        )
+        self.add_argument(
+            parser,
+            "build_changelog_gist_url",
+            defaults,
+            None,
+            help="The gist containing the raw changelog.",
+        )
+        self.add_argument(
+            parser,
+            "changelog_gist_url",
+            defaults,
+            None,
+            help="The gist to which to push the release changelog.",
+        )
+
 
 class CreateReleaseChangelogCommand(CommandProcessor):
-  def __init__(self, factory, options, **kwargs):
-    super(CreateReleaseChangelogCommand, self).__init__(factory, options, **kwargs)
-    check_options_set(
-        options, ['build_changelog_gist_url', 'changelog_gist_url', 'spinnaker_version'])
-    self.__git = GitRunner(options)
+    def __init__(self, factory, options, **kwargs):
+        super(CreateReleaseChangelogCommand, self).__init__(factory, options, **kwargs)
+        check_options_set(
+            options,
+            ["build_changelog_gist_url", "changelog_gist_url", "spinnaker_version"],
+        )
+        self.__git = GitRunner(options)
 
-  def _do_command(self):
-    options = self.options
-    version = options.spinnaker_version
-    raw_gist_path = ensure_gist_repo(self.__git, self.get_input_dir(), options.build_changelog_gist_url)
-    release_gist_path = ensure_gist_repo(self.__git, self.get_input_dir(), options.changelog_gist_url)
+    def _do_command(self):
+        options = self.options
+        version = options.spinnaker_version
+        raw_gist_path = ensure_gist_repo(
+            self.__git, self.get_input_dir(), options.build_changelog_gist_url
+        )
+        release_gist_path = ensure_gist_repo(
+            self.__git, self.get_input_dir(), options.changelog_gist_url
+        )
 
-    major, minor, patch = version.split('.')
-    if int(patch) == 0:
-      logging.debug('Not automatically creating release notes for non-patch release {version}'.format(version=version))
-      return
+        major, minor, patch = version.split(".")
+        if int(patch) == 0:
+            logging.debug(
+                "Not automatically creating release notes for non-patch release {version}".format(
+                    version=version
+                )
+            )
+            return
 
-    branch = 'release-{major}.{minor}.x'.format(major=major, minor=minor)
+        branch = "release-{major}.{minor}.x".format(major=major, minor=minor)
 
-    raw_changelog = os.path.join(
-        raw_gist_path, '{branch}-raw-changelog.md'.format(branch=branch))
-    release_changelog = os.path.join(
-        release_gist_path, '{version}.md'.format(version=version))
+        raw_changelog = os.path.join(
+            raw_gist_path, "{branch}-raw-changelog.md".format(branch=branch)
+        )
+        release_changelog = os.path.join(
+            release_gist_path, "{version}.md".format(version=version)
+        )
 
-    with open(release_changelog, 'w') as output:
-      output.write('# Spinnaker Release {version}\n\n'.format(version=version))
-      with open(raw_changelog, 'r') as input:
-        for line in input:
-          output.write(line)
+        with open(release_changelog, "w") as output:
+            output.write("# Spinnaker Release {version}\n\n".format(version=version))
+            with open(raw_changelog, "r") as input:
+                for line in input:
+                    output.write(line)
 
-    git_run_with_retries(self.__git, release_gist_path, 'add ' + os.path.basename(release_changelog))
-    self.__git.check_commit_or_no_changes(
-        release_gist_path, '-a -m "Updated {file}"'.format(file=os.path.basename(release_changelog)))
+        git_run_with_retries(
+            self.__git, release_gist_path, "add " + os.path.basename(release_changelog)
+        )
+        self.__git.check_commit_or_no_changes(
+            release_gist_path,
+            '-a -m "Updated {file}"'.format(file=os.path.basename(release_changelog)),
+        )
 
-    logging.debug('Pushing back gist')
-    git_run_with_retries(self.__git, release_gist_path, 'push origin main')
+        logging.debug("Pushing back gist")
+        git_run_with_retries(self.__git, release_gist_path, "push origin main")
+
 
 class PushChangelogCommand(CommandProcessor):
-  """Implements push_changelog_to_gist."""
+    """Implements push_changelog_to_gist."""
 
-  def __init__(self, factory, options, **kwargs):
-    super(PushChangelogCommand, self).__init__(factory, options, **kwargs)
-    check_options_set(
-        options, ['build_changelog_gist_url', 'git_branch'])
+    def __init__(self, factory, options, **kwargs):
+        super(PushChangelogCommand, self).__init__(factory, options, **kwargs)
+        check_options_set(options, ["build_changelog_gist_url", "git_branch"])
 
-    if not options.changelog_path:
-      options.changelog_path = os.path.join(
-          self.get_output_dir(command=BUILD_CHANGELOG_COMMAND), 'changelog.md')
-    check_path_exists(options.changelog_path, why='changelog_path')
+        if not options.changelog_path:
+            options.changelog_path = os.path.join(
+                self.get_output_dir(command=BUILD_CHANGELOG_COMMAND), "changelog.md"
+            )
+        check_path_exists(options.changelog_path, why="changelog_path")
 
-    self.__git = GitRunner(options)
+        self.__git = GitRunner(options)
 
-  def _do_command(self):
-    options = self.options
-    git_dir = ensure_gist_repo(self.__git, self.get_input_dir(), options.build_changelog_gist_url)
+    def _do_command(self):
+        options = self.options
+        git_dir = ensure_gist_repo(
+            self.__git, self.get_input_dir(), options.build_changelog_gist_url
+        )
 
-    dest_path = os.path.join(
-        git_dir, '%s-raw-changelog.md' % options.git_branch)
-    logging.debug('Copying "%s" to "%s"', options.changelog_path, dest_path)
-    shutil.copyfile(options.changelog_path, dest_path)
+        dest_path = os.path.join(git_dir, "%s-raw-changelog.md" % options.git_branch)
+        logging.debug('Copying "%s" to "%s"', options.changelog_path, dest_path)
+        shutil.copyfile(options.changelog_path, dest_path)
 
-    git_run_with_retries(self.__git, git_dir, 'add ' + os.path.basename(dest_path))
-    self.__git.check_commit_or_no_changes(
-        git_dir, '-a -m "Updated %s"' % os.path.basename(dest_path))
+        git_run_with_retries(self.__git, git_dir, "add " + os.path.basename(dest_path))
+        self.__git.check_commit_or_no_changes(
+            git_dir, '-a -m "Updated %s"' % os.path.basename(dest_path)
+        )
 
-    logging.debug('Pushing back gist')
-    git_run_with_retries(self.__git, git_dir, 'push origin main')
+        logging.debug("Pushing back gist")
+        git_run_with_retries(self.__git, git_dir, "push origin main")
+
 
 def ensure_gist_repo(git, input_dir, gist_url):
-  index = gist_url.rfind('/')
-  if index < 0:
-    index = gist_url.rfind(':')  # ssh gist
-  gist_id = gist_url[index + 1:]
+    index = gist_url.rfind("/")
+    if index < 0:
+        index = gist_url.rfind(":")  # ssh gist
+    gist_id = gist_url[index + 1 :]
 
-  git_dir = os.path.join(input_dir, gist_id)
-  if not os.path.exists(git_dir):
-    logging.debug('Cloning gist from %s', gist_url)
-    ensure_dir_exists(os.path.dirname(git_dir))
-    git_run_with_retries(git, os.path.dirname(git_dir), 'clone ' + gist_url)
-  else:
-    logging.debug('Updating gist in "%s"', git_dir)
-    git_run_with_retries(git, git_dir, 'fetch origin main')
-    git_run_with_retries(git, git_dir, 'checkout main')
-    git_run_with_retries(git, git_dir, 'reset --hard origin/main')
-  return git_dir
+    git_dir = os.path.join(input_dir, gist_id)
+    if not os.path.exists(git_dir):
+        logging.debug("Cloning gist from %s", gist_url)
+        ensure_dir_exists(os.path.dirname(git_dir))
+        git_run_with_retries(git, os.path.dirname(git_dir), "clone " + gist_url)
+    else:
+        logging.debug('Updating gist in "%s"', git_dir)
+        git_run_with_retries(git, git_dir, "fetch origin main")
+        git_run_with_retries(git, git_dir, "checkout main")
+        git_run_with_retries(git, git_dir, "reset --hard origin/main")
+    return git_dir
+
 
 # For some reason gist.github.com seems to have a lot of connection timeout
 # errors, which we don't really see with normal github. I'm not sure why, but
 # let's just retry and see if that helps.
 # Retry every 2^n seconds (with a maximum of 16 seconds), giving up after 2 minutes.
-@retry(stop_max_delay=120000, wait_exponential_multiplier=1000, wait_exponential_max=16000)
+@retry(
+    stop_max_delay=120000, wait_exponential_multiplier=1000, wait_exponential_max=16000
+)
 def git_run_with_retries(git, git_dir, command, **kwargs):
-  git.check_run(git_dir, command, **kwargs)
+    git.check_run(git_dir, command, **kwargs)
+
 
 def register_commands(registry, subparsers, defaults):
-  """Registers all the commands for this module."""
-  BuildChangelogFactory().register(registry, subparsers, defaults)
-  PushChangelogFactory().register(registry, subparsers, defaults)
-  PublishChangelogFactory().register(registry, subparsers, defaults)
-  CreateReleaseChangelogFactory().register(registry, subparsers, defaults)
+    """Registers all the commands for this module."""
+    BuildChangelogFactory().register(registry, subparsers, defaults)
+    PushChangelogFactory().register(registry, subparsers, defaults)
+    PublishChangelogFactory().register(registry, subparsers, defaults)
+    CreateReleaseChangelogFactory().register(registry, subparsers, defaults)

--- a/dev/buildtool/changelog_commands.py
+++ b/dev/buildtool/changelog_commands.py
@@ -143,7 +143,7 @@ class ChangelogRepositoryData(
             """Return bucket for title_line, adding new one if needed."""
             match = TITLE_LINE_MATCHER.match(title_line)
             thing = match.group(1) if match else ""
-            if not thing in thing_dict:
+            if thing not in thing_dict:
                 thing_dict[thing] = []
             return thing_dict[thing]
 

--- a/dev/buildtool/command.py
+++ b/dev/buildtool/command.py
@@ -24,150 +24,164 @@ from buildtool import (
     ensure_dir_exists,
     maybe_log_exception,
     raise_and_log_error,
-    UnexpectedError)
+    UnexpectedError,
+)
 
 
 class CommandFactory(object):
-  """Abstract base class for CLI command injection."""
+    """Abstract base class for CLI command injection."""
 
-  @staticmethod
-  def add_argument(parser, name, defaults, default_value, **kwargs):
-    """See buildtool.util.add_argument."""
-    add_parser_argument(parser, name, defaults, default_value, **kwargs)
+    @staticmethod
+    def add_argument(parser, name, defaults, default_value, **kwargs):
+        """See buildtool.util.add_argument."""
+        add_parser_argument(parser, name, defaults, default_value, **kwargs)
 
-  def register(self, registry, subparsers, defaults):
-    """Registers a command factory.
+    def register(self, registry, subparsers, defaults):
+        """Registers a command factory.
 
-    Args:
-      registry: [dict] The registry to add to, keyed by command name.
-      subparsers: [ArgumentParser subparsers] for adding command arguments
-      defaults: [dict] optional default values for command arguments
-    """
-    factory = self
-    name = factory.name
-    if name in registry.keys():
-      raise_and_log_error(
-          UnexpectedError(
-              'CommandFactory "{name}" already exists.'.format(name=name)))
+        Args:
+          registry: [dict] The registry to add to, keyed by command name.
+          subparsers: [ArgumentParser subparsers] for adding command arguments
+          defaults: [dict] optional default values for command arguments
+        """
+        factory = self
+        name = factory.name
+        if name in registry.keys():
+            raise_and_log_error(
+                UnexpectedError(
+                    'CommandFactory "{name}" already exists.'.format(name=name)
+                )
+            )
 
-    factory.add_argparser(subparsers, defaults)
-    registry[name] = factory
+        factory.add_argparser(subparsers, defaults)
+        registry[name] = factory
 
-  @property
-  def name(self):
-    return self.__name
+    @property
+    def name(self):
+        return self.__name
 
-  @property
-  def description(self):
-    return self.__description
+    @property
+    def description(self):
+        return self.__description
 
-  def __init__(self, name, factory_method, description,
-               *factory_method_pos_args,
-               **factory_method_kwargs):
-    self.__called_init_argparser = False
-    self.__name = name
-    self.__description = description
-    self.__factory_method = factory_method
-    self.__factory_method_pos_args = factory_method_pos_args
-    self.__factory_method_kwargs = factory_method_kwargs
+    def __init__(
+        self,
+        name,
+        factory_method,
+        description,
+        *factory_method_pos_args,
+        **factory_method_kwargs
+    ):
+        self.__called_init_argparser = False
+        self.__name = name
+        self.__description = description
+        self.__factory_method = factory_method
+        self.__factory_method_pos_args = factory_method_pos_args
+        self.__factory_method_kwargs = factory_method_kwargs
 
-  def make_command(self, options):
-    """Creates a new command instance with the given options.
+    def make_command(self, options):
+        """Creates a new command instance with the given options.
 
-    Args:
-      options: [Namespace] containing the parser.parse_args().
-    """
-    return self.__factory_method(
-        self, options,
-        *self.__factory_method_pos_args, **self.__factory_method_kwargs)
+        Args:
+          options: [Namespace] containing the parser.parse_args().
+        """
+        return self.__factory_method(
+            self,
+            options,
+            *self.__factory_method_pos_args,
+            **self.__factory_method_kwargs
+        )
 
-  def add_argparser(self, subparsers, defaults):
-    """Add specialized argparser for this command.
+    def add_argparser(self, subparsers, defaults):
+        """Add specialized argparser for this command.
 
-    Args:
-      subparsers: The subparsers from the argparser parser.
+        Args:
+          subparsers: The subparsers from the argparser parser.
 
-    Returns:
-      A new parser to add additional custom parameters for this command.
-    """
-    # pylint: disable=protected-access
-    parser = subparsers.add_parser(self.name, help=self.description)
-    self.init_argparser(parser, defaults)
+        Returns:
+          A new parser to add additional custom parameters for this command.
+        """
+        # pylint: disable=protected-access
+        parser = subparsers.add_parser(self.name, help=self.description)
+        self.init_argparser(parser, defaults)
 
-    # pylint: disable=superfluous-parens
-    # Verify call propagated through class hierarchy.
-    assert(self.__called_init_argparser)
+        # pylint: disable=superfluous-parens
+        # Verify call propagated through class hierarchy.
+        assert self.__called_init_argparser
 
-  def init_argparser(self, parser, defaults):
-    """Hook for derived classes to override to add their specific arguments."""
-    # pylint: disable=unused-argument
-    self.__called_init_argparser = True
+    def init_argparser(self, parser, defaults):
+        """Hook for derived classes to override to add their specific arguments."""
+        # pylint: disable=unused-argument
+        self.__called_init_argparser = True
 
 
 class CommandProcessor(object):
-  """Abstract base class for CLI command implementations."""
+    """Abstract base class for CLI command implementations."""
 
-  @property
-  def name(self):
-    return self.__factory.name
+    @property
+    def name(self):
+        return self.__factory.name
 
-  @property
-  def factory(self):
-    return self.__factory
+    @property
+    def factory(self):
+        return self.__factory
 
-  @property
-  def options(self):
-    return self.__options
+    @property
+    def options(self):
+        return self.__options
 
-  @property
-  def metrics(self):
-    return self.__metrics
+    @property
+    def metrics(self):
+        return self.__metrics
 
-  def determine_metric_labels(self):
-    """Returns the label bindings for the invocation tracking metrics."""
-    return {'command': self.name}
+    def determine_metric_labels(self):
+        """Returns the label bindings for the invocation tracking metrics."""
+        return {"command": self.name}
 
-  def __init__(self, factory, options):
-    self.__factory = factory
-    self.__options = options
-    self.__metrics = MetricsManager.singleton()
+    def __init__(self, factory, options):
+        self.__factory = factory
+        self.__options = options
+        self.__metrics = MetricsManager.singleton()
 
-  def __call__(self):
-    logging.debug('Running command=%s...', self.name)
-    try:
-      metric_labels = self.determine_metric_labels()
-      result = self.metrics.track_and_time_call(
-          'RunCommand',
-          metric_labels, self.metrics.default_determine_outcome_labels,
-          self._do_command)
-      logging.debug('Finished command=%s', self.name)
-      return result
-    except Exception as ex:
-      maybe_log_exception(self.name, ex)
-      raise
+    def __call__(self):
+        logging.debug("Running command=%s...", self.name)
+        try:
+            metric_labels = self.determine_metric_labels()
+            result = self.metrics.track_and_time_call(
+                "RunCommand",
+                metric_labels,
+                self.metrics.default_determine_outcome_labels,
+                self._do_command,
+            )
+            logging.debug("Finished command=%s", self.name)
+            return result
+        except Exception as ex:
+            maybe_log_exception(self.name, ex)
+            raise
 
-  def _do_command(self):
-    """This should be overriden to implement actual behavior."""
-    raise NotImplementedError('{0}._do_command is not implemented'.format(
-        self.__class__.name))
+    def _do_command(self):
+        """This should be overriden to implement actual behavior."""
+        raise NotImplementedError(
+            "{0}._do_command is not implemented".format(self.__class__.name)
+        )
 
-  def get_logfile_path(self, basename):
-    """Return the path to the logfile to write."""
-    logfile = '%s-%d.log' % (basename, os.getpid())
-    return os.path.join(self.get_output_dir(), logfile)
+    def get_logfile_path(self, basename):
+        """Return the path to the logfile to write."""
+        logfile = "%s-%d.log" % (basename, os.getpid())
+        return os.path.join(self.get_output_dir(), logfile)
 
-  def get_output_dir(self, command=None):
-    """Return the output dir for persistent build output from this command."""
-    command = command or self.__options.command
-    output_command_path = os.path.join(self.__options.output_dir, command)
-    # FIXME: We manually ensure the output dir is there if it doesn't exist.
-    # This should be created before the command is run.
-    if not os.path.isdir(output_command_path):
-      logging.debug('making dir %s', output_command_path)
-      ensure_dir_exists(output_command_path)
-    return output_command_path
+    def get_output_dir(self, command=None):
+        """Return the output dir for persistent build output from this command."""
+        command = command or self.__options.command
+        output_command_path = os.path.join(self.__options.output_dir, command)
+        # FIXME: We manually ensure the output dir is there if it doesn't exist.
+        # This should be created before the command is run.
+        if not os.path.isdir(output_command_path):
+            logging.debug("making dir %s", output_command_path)
+            ensure_dir_exists(output_command_path)
+        return output_command_path
 
-  def get_input_dir(self, command=None):
-    """Return the output dir for persistent build output from this command."""
-    command = command or self.__options.command
-    return os.path.join(self.__options.input_dir, command)
+    def get_input_dir(self, command=None):
+        """Return the output dir for persistent build output from this command."""
+        command = command or self.__options.command
+        return os.path.join(self.__options.input_dir, command)

--- a/dev/buildtool/errors.py
+++ b/dev/buildtool/errors.py
@@ -25,117 +25,117 @@ from buildtool.metrics import MetricsManager
 
 
 class BuildtoolError(Exception):
-  RUNTIME = 'runtime'
-  USAGE = 'usage'
-  INTERNAL = 'internal'
+    RUNTIME = "runtime"
+    USAGE = "usage"
+    INTERNAL = "internal"
 
-  def __init__(self, message, classification, cause=None):
-    super(BuildtoolError, self).__init__(message)
-    labels = {
-        'cause': cause,
-        'classification': classification
-    }
-    MetricsManager.singleton().inc_counter('BuildtoolError', labels)
+    def __init__(self, message, classification, cause=None):
+        super(BuildtoolError, self).__init__(message)
+        labels = {"cause": cause, "classification": classification}
+        MetricsManager.singleton().inc_counter("BuildtoolError", labels)
 
 
 class ConfigError(BuildtoolError):
-  def __init__(self, message, cause=None):
-    super(ConfigError, self).__init__(
-        message, self.INTERNAL, cause=cause or 'config')
+    def __init__(self, message, cause=None):
+        super(ConfigError, self).__init__(
+            message, self.INTERNAL, cause=cause or "config"
+        )
+
 
 class TimeoutError(BuildtoolError):
-  def __init__(self, message, cause=None):
-    super(TimeoutError, self).__init__(message, self.RUNTIME, cause=cause)
+    def __init__(self, message, cause=None):
+        super(TimeoutError, self).__init__(message, self.RUNTIME, cause=cause)
+
 
 class ExecutionError(BuildtoolError):
-  def __init__(self, message, program=None):
-    super(ExecutionError, self).__init__(message, self.RUNTIME, cause=program)
+    def __init__(self, message, program=None):
+        super(ExecutionError, self).__init__(message, self.RUNTIME, cause=program)
+
 
 class ResponseError(BuildtoolError):
-  def __init__(self, message, server=None):
-    super(ResponseError, self).__init__(message, self.RUNTIME, cause=server)
+    def __init__(self, message, server=None):
+        super(ResponseError, self).__init__(message, self.RUNTIME, cause=server)
+
 
 class UnexpectedError(BuildtoolError):
-  def __init__(self, message, cause=None):
-    super(UnexpectedError, self).__init__(message, self.INTERNAL,
-                                          cause=cause or 'unexpected')
+    def __init__(self, message, cause=None):
+        super(UnexpectedError, self).__init__(
+            message, self.INTERNAL, cause=cause or "unexpected"
+        )
 
 
 def exception_to_message(ex):
-  """Get the message from an exception."""
-  return ex.args[0] if ex.args else str(ex)
+    """Get the message from an exception."""
+    return ex.args[0] if ex.args else str(ex)
 
 
-def maybe_log_exception(where, ex, action_msg='propagating exception'):
-  """Log the exception and stacktrace if it hasnt been logged already."""
-  if not hasattr(ex, 'loggedit'):
-    text = traceback.format_exc()
-    logging.error('"%s" caught exception\n%s', where, text)
-    ex.loggedit = True
+def maybe_log_exception(where, ex, action_msg="propagating exception"):
+    """Log the exception and stacktrace if it hasnt been logged already."""
+    if not hasattr(ex, "loggedit"):
+        text = traceback.format_exc()
+        logging.error('"%s" caught exception\n%s', where, text)
+        ex.loggedit = True
 
-  logging.error('"%s" %s', where, action_msg)
+    logging.error('"%s" %s', where, action_msg)
 
 
 def raise_and_log_error(error, *pos_args):
-  if len(pos_args) > 1:
-    raise ValueError('Too many positional args: {}'.format(pos_args))
-  message = pos_args[0] if pos_args else exception_to_message(error)
-  logging.debug(''.join(traceback.format_stack()))
-  logging.error('*** ERROR ***: %s', message)
-  error.loggedit = True
-  raise error
+    if len(pos_args) > 1:
+        raise ValueError("Too many positional args: {}".format(pos_args))
+    message = pos_args[0] if pos_args else exception_to_message(error)
+    logging.debug("".join(traceback.format_stack()))
+    logging.error("*** ERROR ***: %s", message)
+    error.loggedit = True
+    raise error
 
 
 def check_options_set(options, name_list, where=None):
-  """Make sure each of the options in the name_list was set."""
-  where = where or options.command
-  option_dict = vars(options)
-  missing_keys = [key for key in name_list if not option_dict.get(key)]
-  if missing_keys:
-    raise_and_log_error(
-        ValueError('Missing options ' + ', '.join(missing_keys)),
-        '{where} requires options that are not set: {keys}'.format(
-            where=where, keys=', '.join(missing_keys)))
+    """Make sure each of the options in the name_list was set."""
+    where = where or options.command
+    option_dict = vars(options)
+    missing_keys = [key for key in name_list if not option_dict.get(key)]
+    if missing_keys:
+        raise_and_log_error(
+            ValueError("Missing options " + ", ".join(missing_keys)),
+            "{where} requires options that are not set: {keys}".format(
+                where=where, keys=", ".join(missing_keys)
+            ),
+        )
 
 
 def check_path_exists(path, why):
-  """Check path exists and if not, log and raise an error with reason for it."""
-  if not os.path.exists(path):
-    error = ConfigError('NotFound: "%s" for %s' % (path, why))
-    raise_and_log_error(error)
+    """Check path exists and if not, log and raise an error with reason for it."""
+    if not os.path.exists(path):
+        error = ConfigError('NotFound: "%s" for %s' % (path, why))
+        raise_and_log_error(error)
 
 
 def check_kwargs_empty(kwargs):
-  if kwargs:
-    raise_and_log_error(
-        UnexpectedError('Unexpected arguments: {}'.format(kwargs.keys())))
+    if kwargs:
+        raise_and_log_error(
+            UnexpectedError("Unexpected arguments: {}".format(kwargs.keys()))
+        )
 
 
 def scan_logs_for_install_errors(path):
-  """Scan logfile at path and count specific errors of interest."""
-  content = io.open(path, 'r', encoding='utf-8').read()
-  match = re.search(
-      "^E:.* Version '([^']+)' for '([^']+)' was not found",
-      content,
-      re.MULTILINE)
-
-  component = ''
-  cause = 'Unknown'
-
-  if match:
-    version = match.group(1)
-    component = match.group(2)
-    cause = 'ComponentNotFound'
-    logging.error('"%s" version "%s" does not exist.',
-                  component, version)
-  if not match:
+    """Scan logfile at path and count specific errors of interest."""
+    content = io.open(path, "r", encoding="utf-8").read()
     match = re.search(
-        '.*: No such file or directory$', content, re.MULTILINE)
-    if match:
-      cause = 'FileNotFound'
+        "^E:.* Version '([^']+)' for '([^']+)' was not found", content, re.MULTILINE
+    )
 
-  labels = {
-      'component': component,
-     'cause': cause
-  }
-  MetricsManager.singleton().inc_counter('InstallSpinnakerError', labels)
+    component = ""
+    cause = "Unknown"
+
+    if match:
+        version = match.group(1)
+        component = match.group(2)
+        cause = "ComponentNotFound"
+        logging.error('"%s" version "%s" does not exist.', component, version)
+    if not match:
+        match = re.search(".*: No such file or directory$", content, re.MULTILINE)
+        if match:
+            cause = "FileNotFound"
+
+    labels = {"component": component, "cause": cause}
+    MetricsManager.singleton().inc_counter("InstallSpinnakerError", labels)

--- a/dev/buildtool/git_support.py
+++ b/dev/buildtool/git_support.py
@@ -1110,7 +1110,7 @@ class GitRunner(object):
         """
         # pylint: disable=too-many-arguments
 
-        if (commit != None) and (branch != None):
+        if (commit is not None) and (branch is not None):
             raise_and_log_error(
                 ConfigError("At most one of commit or branch can be specified.")
             )
@@ -1221,7 +1221,7 @@ class GitRunner(object):
         )
 
         msgs = []
-        if start_commit_id != None:
+        if start_commit_id is not None:
             msgs = self.query_local_repository_commits_between_two_commit_ids(
                 git_dir, start_commit_id, tag_commit_id
             )

--- a/dev/buildtool/git_support.py
+++ b/dev/buildtool/git_support.py
@@ -40,1139 +40,1278 @@ from buildtool import (
     raise_and_log_error,
     ConfigError,
     ExecutionError,
-    UnexpectedError)
+    UnexpectedError,
+)
 
 
 class GitRepositorySpec(object):
-  """A reference to a git repository with local and origin locations.
+    """A reference to a git repository with local and origin locations.
 
-  Attributes:
-    name: [string] The shorthand name of the repository
-    git_dir: [path] The local path the repository was cloned to, if any.
-    origin: [url] The url the local_path was cloned from, if known.
-    upstream: [url] The url the origin is refreshed from, if known.
-  """
-  @property
-  def name(self):
-    """The short name for the repository."""
-    return self.__name
+    Attributes:
+      name: [string] The shorthand name of the repository
+      git_dir: [path] The local path the repository was cloned to, if any.
+      origin: [url] The url the local_path was cloned from, if known.
+      upstream: [url] The url the origin is refreshed from, if known.
+    """
 
-  @property
-  def git_dir(self):
-    """The path to the local repository the origin was cloned to."""
-    if not self.__git_dir:
-      raise_and_log_error(
-          ConfigError('{0} does not specify a git_dir'.format(self)))
-    return self.__git_dir
+    @property
+    def name(self):
+        """The short name for the repository."""
+        return self.__name
 
-  @property
-  def origin(self):
-    """The origin URL."""
-    if not self.__origin:
-      raise_and_log_error(
-          ConfigError('{0} does not specify an origin'.format(self)))
-    return self.__origin
+    @property
+    def git_dir(self):
+        """The path to the local repository the origin was cloned to."""
+        if not self.__git_dir:
+            raise_and_log_error(
+                ConfigError("{0} does not specify a git_dir".format(self))
+            )
+        return self.__git_dir
 
-  @property
-  def upstream(self):
-    """The upstream URL."""
-    if not self.__upstream:
-      raise_and_log_error(
-          ConfigError('{0} does not specify an upstream'.format(self)))
-    return self.__upstream
+    @property
+    def origin(self):
+        """The origin URL."""
+        if not self.__origin:
+            raise_and_log_error(
+                ConfigError("{0} does not specify an origin".format(self))
+            )
+        return self.__origin
 
-  def __init__(self, name, **kwargs):
-    """Create a new instance."""
-    self.__name = name
-    self.__git_dir = kwargs.pop('git_dir', None)
-    self.__origin = kwargs.pop('origin', None)
-    self.__upstream = kwargs.pop('upstream', None)
-    self.__commit = kwargs.pop('commit_id', None)
-    self.__branch = kwargs.pop('branch', None)
-    check_kwargs_empty(kwargs)
+    @property
+    def upstream(self):
+        """The upstream URL."""
+        if not self.__upstream:
+            raise_and_log_error(
+                ConfigError("{0} does not specify an upstream".format(self))
+            )
+        return self.__upstream
 
-  def branch_or_none(self):
-    """Returns specific branch or None."""
-    return self.__branch
+    def __init__(self, name, **kwargs):
+        """Create a new instance."""
+        self.__name = name
+        self.__git_dir = kwargs.pop("git_dir", None)
+        self.__origin = kwargs.pop("origin", None)
+        self.__upstream = kwargs.pop("upstream", None)
+        self.__commit = kwargs.pop("commit_id", None)
+        self.__branch = kwargs.pop("branch", None)
+        check_kwargs_empty(kwargs)
 
-  def commit_or_none(self):
-    """Returns specific commit or None."""
-    return self.__commit
+    def branch_or_none(self):
+        """Returns specific branch or None."""
+        return self.__branch
 
-  def git_dir_or_none(self):
-    """Returns local git_dir path, which might be None."""
-    return self.__git_dir or None
+    def commit_or_none(self):
+        """Returns specific commit or None."""
+        return self.__commit
 
-  def origin_or_none(self):
-    """Returns origin URL, which might be None."""
-    return self.__origin or None
+    def git_dir_or_none(self):
+        """Returns local git_dir path, which might be None."""
+        return self.__git_dir or None
 
-  def upstream_or_none(self):
-    """Returns upstream URL, which might be None."""
-    return self.__upstream or None
+    def origin_or_none(self):
+        """Returns origin URL, which might be None."""
+        return self.__origin or None
 
-  def __str__(self):
-    return self.__repr__()
+    def upstream_or_none(self):
+        """Returns upstream URL, which might be None."""
+        return self.__upstream or None
 
-  def __repr__(self):
-    return 'git_dir={git_dir}  origin={origin}  upstream={upstream}'.format(
-        git_dir=self.__git_dir,
-        origin=self.__origin,
-        upstream=self.__upstream)
+    def __str__(self):
+        return self.__repr__()
 
-  def __lt__(self, other):
-    if self.__name != other.name:
-      return self.__name < other.name
+    def __repr__(self):
+        return "git_dir={git_dir}  origin={origin}  upstream={upstream}".format(
+            git_dir=self.__git_dir, origin=self.__origin, upstream=self.__upstream
+        )
 
-    # a partial ordering would be fine, but we want strict __eq__ for testing
-    self_hash = hash((self.__git_dir, self.__origin, self.__upstream))
-    other_hash = hash((other.git_dir, other.origin, other.upstream))
-    return  self_hash < other_hash
+    def __lt__(self, other):
+        if self.__name != other.name:
+            return self.__name < other.name
 
-  def __le__(self, other):
-    return self.__lt__(other) or self.__eq__(other)
+        # a partial ordering would be fine, but we want strict __eq__ for testing
+        self_hash = hash((self.__git_dir, self.__origin, self.__upstream))
+        other_hash = hash((other.git_dir, other.origin, other.upstream))
+        return self_hash < other_hash
 
-  def __eq__(self, other):
-    return (self.__name == other.name
+    def __le__(self, other):
+        return self.__lt__(other) or self.__eq__(other)
+
+    def __eq__(self, other):
+        return (
+            self.__name == other.name
             and self.__git_dir == other.git_dir_or_none()
             and self.__origin == other.origin_or_none()
-            and self.__upstream == other.upstream_or_none())
+            and self.__upstream == other.upstream_or_none()
+        )
 
-  def __ne__(self, other):
-    return not self.__eq__(other)
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
-  def __ge__(self, other):
-    return self.__gt__(other) or self.__eq__(other)
+    def __ge__(self, other):
+        return self.__gt__(other) or self.__eq__(other)
 
-  def __gt__(self, other):
-    if self.__name != other.name:
-      return self.__name > other.name
+    def __gt__(self, other):
+        if self.__name != other.name:
+            return self.__name > other.name
 
-    # a partial ordering would be fine, but we want strict __eq__ for testing
-    self_hash = hash((self.__git_dir, self.__origin, self.__upstream))
-    other_hash = hash((other.git_dir, other.origin, other.upstream))
-    return  self_hash > other_hash
+        # a partial ordering would be fine, but we want strict __eq__ for testing
+        self_hash = hash((self.__git_dir, self.__origin, self.__upstream))
+        other_hash = hash((other.git_dir, other.origin, other.upstream))
+        return self_hash > other_hash
 
 
 class SemanticVersion(
-    collections.namedtuple('SemanticVersion',
-                           ['series_name', 'major', 'minor', 'patch'])):
-  """Helper class for interacting with semantic version tags."""
+    collections.namedtuple(
+        "SemanticVersion", ["series_name", "major", "minor", "patch"]
+    )
+):
+    """Helper class for interacting with semantic version tags."""
 
-  SEMVER_MATCHER = re.compile(r'(v)(\d+)\.(\d+)\.(\d+)')
-  TAG_INDEX = 0
-  MAJOR_INDEX = 1
-  MINOR_INDEX = 2
-  PATCH_INDEX = 3
+    SEMVER_MATCHER = re.compile(r"(v)(\d+)\.(\d+)\.(\d+)")
+    TAG_INDEX = 0
+    MAJOR_INDEX = 1
+    MINOR_INDEX = 2
+    PATCH_INDEX = 3
 
-  @staticmethod
-  def make(tag):
-    """Create a new SemanticVersion from the given tag instance.
+    @staticmethod
+    def make(tag):
+        """Create a new SemanticVersion from the given tag instance.
 
-    Args:
-      tag: [string] in the form <series_name><major>.<minor>.<patch>
-    """
-    match = SemanticVersion.SEMVER_MATCHER.match(tag)
-    if match is None:
-      raise_and_log_error(UnexpectedError('Malformed tag "%s"' % tag))
+        Args:
+          tag: [string] in the form <series_name><major>.<minor>.<patch>
+        """
+        match = SemanticVersion.SEMVER_MATCHER.match(tag)
+        if match is None:
+            raise_and_log_error(UnexpectedError('Malformed tag "%s"' % tag))
 
-    # Keep first group as a string, but use integers for the component parts
-    return SemanticVersion(match.group(1),
-                           *[int(num) for num in match.groups()[1:]])
+        # Keep first group as a string, but use integers for the component parts
+        return SemanticVersion(
+            match.group(1), *[int(num) for num in match.groups()[1:]]
+        )
 
-  @staticmethod
-  def compare(semver, other):
-    """Compare this to another semver.
+    @staticmethod
+    def compare(semver, other):
+        """Compare this to another semver.
 
-    Returns:
-      < 0 if this is before, 0 if equal, > 0 if this is after.
-    """
-    if semver.series_name != other.series_name:
-      raise ValueError('Cannot compare different SemVer series.')
+        Returns:
+          < 0 if this is before, 0 if equal, > 0 if this is after.
+        """
+        if semver.series_name != other.series_name:
+            raise ValueError("Cannot compare different SemVer series.")
 
-    if semver.major != other.major:
-      return semver.major - other.major
-    if semver.minor != other.minor:
-      return semver.minor - other.minor
-    return semver.patch - other.patch
+        if semver.major != other.major:
+            return semver.major - other.major
+        if semver.minor != other.minor:
+            return semver.minor - other.minor
+        return semver.patch - other.patch
 
-  def __lt__(self, other):
-    """Implements __lt__ for sorted operator comparison."""
-    return self.compare(self, other) < 0
+    def __lt__(self, other):
+        """Implements __lt__ for sorted operator comparison."""
+        return self.compare(self, other) < 0
 
-  def most_significant_diff_index(self, arg):
-    """Returns the *_INDEX for the most sigificant component differnce."""
-    if arg.series_name != self.series_name:
-      return self.TAG_INDEX
-    if arg.major != self.major:
-      return self.MAJOR_INDEX
-    if arg.minor != self.minor:
-      return self.MINOR_INDEX
-    if arg.patch != self.patch:
-      return self.PATCH_INDEX
+    def most_significant_diff_index(self, arg):
+        """Returns the *_INDEX for the most sigificant component differnce."""
+        if arg.series_name != self.series_name:
+            return self.TAG_INDEX
+        if arg.major != self.major:
+            return self.MAJOR_INDEX
+        if arg.minor != self.minor:
+            return self.MINOR_INDEX
+        if arg.patch != self.patch:
+            return self.PATCH_INDEX
 
-    return None
+        return None
 
-  def to_version(self):
-    """Return string encoding of underlying version number."""
-    return '{major}.{minor}.{patch}'.format(
-        major=self.major, minor=self.minor, patch=self.patch)
+    def to_version(self):
+        """Return string encoding of underlying version number."""
+        return "{major}.{minor}.{patch}".format(
+            major=self.major, minor=self.minor, patch=self.patch
+        )
 
-  def to_tag(self):
-    """Return string encoding of SemanticVersion tag."""
-    return '{series}{major}.{minor}.{patch}'.format(
-        series=self.series_name,
-        major=self.major, minor=self.minor, patch=self.patch)
+    def to_tag(self):
+        """Return string encoding of SemanticVersion tag."""
+        return "{series}{major}.{minor}.{patch}".format(
+            series=self.series_name,
+            major=self.major,
+            minor=self.minor,
+            patch=self.patch,
+        )
 
-  def to_release_branch(self):
-    """Return release branch name for this SemanticVersion."""
-    return 'release-{major}.{minor}.x'.format(
-        major=self.major, minor=self.minor)
+    def to_release_branch(self):
+        """Return release branch name for this SemanticVersion."""
+        return "release-{major}.{minor}.x".format(major=self.major, minor=self.minor)
 
-  def next(self, at_index):
-    """Returns the next SemanticVersion from this when bumping up.
+    def next(self, at_index):
+        """Returns the next SemanticVersion from this when bumping up.
 
-    Args:
-       at_index: [int] The component *_INDEX to bump at.
-    """
-    if at_index is None:
-      raise_and_log_error(UnexpectedError('Invalid index={0}'.format(at_index)))
+        Args:
+           at_index: [int] The component *_INDEX to bump at.
+        """
+        if at_index is None:
+            raise_and_log_error(UnexpectedError("Invalid index={0}".format(at_index)))
 
-    major = self.major
-    minor = self.minor
-    patch = self.patch
+        major = self.major
+        minor = self.minor
+        patch = self.patch
 
-    if at_index == self.PATCH_INDEX:
-      patch += 1
-    else:
-      patch = 0
-      if at_index == self.MINOR_INDEX:
-        minor += 1
-      elif at_index == self.MAJOR_INDEX:
-        minor = 0
-        major += 1
-      else:
-        raise_and_log_error(
-            UnexpectedError('Invalid index={0}'.format(at_index)))
+        if at_index == self.PATCH_INDEX:
+            patch += 1
+        else:
+            patch = 0
+            if at_index == self.MINOR_INDEX:
+                minor += 1
+            elif at_index == self.MAJOR_INDEX:
+                minor = 0
+                major += 1
+            else:
+                raise_and_log_error(
+                    UnexpectedError("Invalid index={0}".format(at_index))
+                )
 
-    return SemanticVersion(self.series_name, major, minor, patch)
+        return SemanticVersion(self.series_name, major, minor, patch)
 
 
-class CommitTag(
-    collections.namedtuple('CommitTag', ['commit_id', 'tag', 'version'])):
-  """Denotes an individual result of git show-ref --tags."""
+class CommitTag(collections.namedtuple("CommitTag", ["commit_id", "tag", "version"])):
+    """Denotes an individual result of git show-ref --tags."""
 
-  @staticmethod
-  def make(ref_line):
-    """Create a new instance from a response line.
+    @staticmethod
+    def make(ref_line):
+        """Create a new instance from a response line.
 
-    Args:
-      ref_line: [string] Response from "git show-ref --tags"
-    """
-    # ref_line is in the form "$commit_id refs/tags/$tag"
-    tokens = ref_line.split(' ')
-    line_id = tokens[0]
-    tag_parts = tokens[1].split('/')
-    tag = tag_parts[len(tag_parts) - 1]
-    version = LooseVersion(tag)
-    return CommitTag(line_id, tag, version)
+        Args:
+          ref_line: [string] Response from "git show-ref --tags"
+        """
+        # ref_line is in the form "$commit_id refs/tags/$tag"
+        tokens = ref_line.split(" ")
+        line_id = tokens[0]
+        tag_parts = tokens[1].split("/")
+        tag = tag_parts[len(tag_parts) - 1]
+        version = LooseVersion(tag)
+        return CommitTag(line_id, tag, version)
 
-  # pylint: disable=multiple-statements
-  def __cmp__(self, other): return self.version.__cmp__(other.version)
-  def __lt__(self, other): return self.version < other.version
-  def __le__(self, other): return self.version <= other.version
-  def __eq__(self, other): return self.version == other.version
-  def __ge__(self, other): return self.version >= other.version
-  def __gt__(self, other): return self.version > other.version
-  def __ne__(self, other): return self.version != other.version
+    # pylint: disable=multiple-statements
+    def __cmp__(self, other):
+        return self.version.__cmp__(other.version)
+
+    def __lt__(self, other):
+        return self.version < other.version
+
+    def __le__(self, other):
+        return self.version <= other.version
+
+    def __eq__(self, other):
+        return self.version == other.version
+
+    def __ge__(self, other):
+        return self.version >= other.version
+
+    def __gt__(self, other):
+        return self.version > other.version
+
+    def __ne__(self, other):
+        return self.version != other.version
 
 
 class CommitMessage(
-    collections.namedtuple('CommitMessage',
-                           ['commit_id', 'author', 'date', 'message'])):
-  """Denotes an individual entry in 'git log --pretty'."""
-  _MEDIUM_PRETTY_COMMIT_MATCHER = re.compile(
-      '(.+)\n(?:Merge: .*?\n)?Author: *(.+)\nDate: *(.*)\n', re.MULTILINE)
+    collections.namedtuple("CommitMessage", ["commit_id", "author", "date", "message"])
+):
+    """Denotes an individual entry in 'git log --pretty'."""
 
-  _EMBEDDED_COMMIT_MATCHER = re.compile(
-      r'^( *)commit [a-f0-9]+\n'
-      r'^\s*Author: .+\n'
-      r'^\s*Date:   .+\n',
-      re.MULTILINE)
+    _MEDIUM_PRETTY_COMMIT_MATCHER = re.compile(
+        "(.+)\n(?:Merge: .*?\n)?Author: *(.+)\nDate: *(.*)\n", re.MULTILINE
+    )
 
-  _EMBEDDED_SUMMARY_MATCHER = re.compile(
-      r'^\s*(?:\*\s*)?[a-z]+\(.+?\): .+',
-      re.MULTILINE)
+    _EMBEDDED_COMMIT_MATCHER = re.compile(
+        r"^( *)commit [a-f0-9]+\n" r"^\s*Author: .+\n" r"^\s*Date:   .+\n", re.MULTILINE
+    )
 
-  # The vocabulary in the following list was taken looking at what's
-  # used in practice (right or wrong), for conforming log entries,
-  # using the following command over the various spinnaker repositories:
-  #
-  # git log --pretty=oneline \
-  #   | sed "s/^[a-f0-9]\+ //g" \
-  #   | egrep "^[^ \(]+\(" \
-  #   | sed "s/^\([^\(]\+\).*/\1/g" \
-  #   | sort | uniq
-  DEFAULT_PATCH_REGEXS = [
-      # Some tags indicate only a patch release.
-      re.compile(r'^\s*'
-                 r'(?:\*\s+)?'
-                 r'((?:fix|bug|chore|docs?|perf|refactor|test)\s*[\(:].*)',
-                 re.MULTILINE)
-  ]
-  DEFAULT_MINOR_REGEXS = [
-      # Some tags indicate a minor release.
-      # These are features as well as hints to non-trivial
-      # implementation changes that suggest a higher level of risk.
-      re.compile(r'^\s*'
-                 r'(?:\*\s+)?'
-                 r'((?:feat|feature|config)\s*[\(:].*)',
-                 re.MULTILINE)
-  ]
-  DEFAULT_MAJOR_REGEXS = [
-      # Breaking changes are explicitly marked as such.
-      re.compile(r'^\s*'
-                 r'(.*?BREAKING CHANGE.*)',
-                 re.MULTILINE)
-  ]
+    _EMBEDDED_SUMMARY_MATCHER = re.compile(
+        r"^\s*(?:\*\s*)?[a-z]+\(.+?\): .+", re.MULTILINE
+    )
 
-  @staticmethod
-  def make_list_from_result(response_text):
-    """Returns a list of CommitMessage from the command response.
+    # The vocabulary in the following list was taken looking at what's
+    # used in practice (right or wrong), for conforming log entries,
+    # using the following command over the various spinnaker repositories:
+    #
+    # git log --pretty=oneline \
+    #   | sed "s/^[a-f0-9]\+ //g" \
+    #   | egrep "^[^ \(]+\(" \
+    #   | sed "s/^\([^\(]\+\).*/\1/g" \
+    #   | sort | uniq
+    DEFAULT_PATCH_REGEXS = [
+        # Some tags indicate only a patch release.
+        re.compile(
+            r"^\s*"
+            r"(?:\*\s+)?"
+            r"((?:fix|bug|chore|docs?|perf|refactor|test)\s*[\(:].*)",
+            re.MULTILINE,
+        )
+    ]
+    DEFAULT_MINOR_REGEXS = [
+        # Some tags indicate a minor release.
+        # These are features as well as hints to non-trivial
+        # implementation changes that suggest a higher level of risk.
+        re.compile(
+            r"^\s*" r"(?:\*\s+)?" r"((?:feat|feature|config)\s*[\(:].*)", re.MULTILINE
+        )
+    ]
+    DEFAULT_MAJOR_REGEXS = [
+        # Breaking changes are explicitly marked as such.
+        re.compile(r"^\s*" r"(.*?BREAKING CHANGE.*)", re.MULTILINE)
+    ]
 
-    Args:
-      response_text: [string] result of "git log --pretty=medium"
-    """
-    all_entries = ('\n' + response_text.strip()).split('\ncommit ')[1:]
-    response = []
-    for entry in all_entries:
-      response.append(CommitMessage.make(entry))
-    return response
+    @staticmethod
+    def make_list_from_result(response_text):
+        """Returns a list of CommitMessage from the command response.
 
-  @staticmethod
-  def make(entry):
-    """Create a new CommitMessage from an individual entry"""
-    match = CommitMessage._MEDIUM_PRETTY_COMMIT_MATCHER.match(entry)
-    if match is None:
-      raise_and_log_error(
-          UnexpectedError('Unexpected commit entry {0}'.format(entry)))
+        Args:
+          response_text: [string] result of "git log --pretty=medium"
+        """
+        all_entries = ("\n" + response_text.strip()).split("\ncommit ")[1:]
+        response = []
+        for entry in all_entries:
+            response.append(CommitMessage.make(entry))
+        return response
 
-    text = entry[match.end(3):]
+    @staticmethod
+    def make(entry):
+        """Create a new CommitMessage from an individual entry"""
+        match = CommitMessage._MEDIUM_PRETTY_COMMIT_MATCHER.match(entry)
+        if match is None:
+            raise_and_log_error(
+                UnexpectedError("Unexpected commit entry {0}".format(entry))
+            )
 
-    # strip trailing spaces on each line
-    lines = [line.rstrip() for line in text.split('\n')]
+        text = entry[match.end(3) :]
 
-    # remove blank lines from beginning and end of text
-    while lines and not lines[0]:
-      del lines[0]
-    while lines and not lines[-1]:
-      del lines[-1]
+        # strip trailing spaces on each line
+        lines = [line.rstrip() for line in text.split("\n")]
 
-    # new string may have initial spacing but no leading/trailing blank lines.
-    text = '\n'.join(lines)
+        # remove blank lines from beginning and end of text
+        while lines and not lines[0]:
+            del lines[0]
+        while lines and not lines[-1]:
+            del lines[-1]
 
-    return CommitMessage(match.group(1), match.group(2), match.group(3), text)
+        # new string may have initial spacing but no leading/trailing blank lines.
+        text = "\n".join(lines)
 
-  @staticmethod
-  def normalize_message_list(msg_list):
-    """Transform a series of CommitMessage into one without compound messages.
+        return CommitMessage(match.group(1), match.group(2), match.group(3), text)
 
-    A compound message is a single commit that is a merge of multiple commits
-    as indicated by a message that looks like multiple entires.
-    This will break apart those compound commits into individual ones for
-    the same commit id entry for easier processing.
-    """
-    msg_list = CommitMessage._unpack_embedded_commits(msg_list)
-    return CommitMessage._unpack_embedded_summaries(msg_list)
+    @staticmethod
+    def normalize_message_list(msg_list):
+        """Transform a series of CommitMessage into one without compound messages.
 
-  @staticmethod
-  def _unpack_embedded_commits(msg_list):
-    """Helper function looking for merged commits.
+        A compound message is a single commit that is a merge of multiple commits
+        as indicated by a message that looks like multiple entires.
+        This will break apart those compound commits into individual ones for
+        the same commit id entry for easier processing.
+        """
+        msg_list = CommitMessage._unpack_embedded_commits(msg_list)
+        return CommitMessage._unpack_embedded_summaries(msg_list)
 
-    These are indicated by having an embedded commit within them.
-    If found, unnest the indentation and run through as if these
-    came directly from a git result to turn them into additional commits.
-    """
-    result = []
-    for commit_message in msg_list:
-      text = commit_message.message
-      found = CommitMessage._EMBEDDED_COMMIT_MATCHER.search(text)
-      if not found:
-        result.append(commit_message)
-        continue
+    @staticmethod
+    def _unpack_embedded_commits(msg_list):
+        """Helper function looking for merged commits.
 
-      text_before = text[:found.start(1)]
-      text_lines = text[found.start(1):].split('\n')
-      pruned_lines = []
-      offset = found.end(1) - found.start(1)
-      for line in text_lines:
-        if line.startswith(found.group(1)):
-          pruned_lines.append(line[offset:])
-        elif not line:
-          pruned_lines.append(line)
-        else:
-          logging.warning(
-              '"%s" looks like an composite commit, but not indented by %d.',
-              text, offset)
-          pruned_lines = []
-          result.append(commit_message)
-          break
+        These are indicated by having an embedded commit within them.
+        If found, unnest the indentation and run through as if these
+        came directly from a git result to turn them into additional commits.
+        """
+        result = []
+        for commit_message in msg_list:
+            text = commit_message.message
+            found = CommitMessage._EMBEDDED_COMMIT_MATCHER.search(text)
+            if not found:
+                result.append(commit_message)
+                continue
 
-      if pruned_lines:
-        if text_before.strip():
-          logging.info('Dropping commit message "%s" in favor of "%s"',
-                       text_before, '\n'.join(pruned_lines))
-        result.extend(
-            CommitMessage.make_list_from_result('\n'.join(pruned_lines)))
-    return result
+            text_before = text[: found.start(1)]
+            text_lines = text[found.start(1) :].split("\n")
+            pruned_lines = []
+            offset = found.end(1) - found.start(1)
+            for line in text_lines:
+                if line.startswith(found.group(1)):
+                    pruned_lines.append(line[offset:])
+                elif not line:
+                    pruned_lines.append(line)
+                else:
+                    logging.warning(
+                        '"%s" looks like an composite commit, but not indented by %d.',
+                        text,
+                        offset,
+                    )
+                    pruned_lines = []
+                    result.append(commit_message)
+                    break
 
-  @staticmethod
-  def _unpack_embedded_summaries(msg_list):
-    """Helper function looking for embedded summaries.
+            if pruned_lines:
+                if text_before.strip():
+                    logging.info(
+                        'Dropping commit message "%s" in favor of "%s"',
+                        text_before,
+                        "\n".join(pruned_lines),
+                    )
+                result.extend(
+                    CommitMessage.make_list_from_result("\n".join(pruned_lines))
+                )
+        return result
 
-    An embedded summary is another top-line message block (e.g. fix(...): ...)
-    This is different from a merged commit in that it doesnt have the
-    commit/author/date fields. These types of entries are typically entered
-    manually to convey a single atomic commit contains multiple changes
-    as opposed to multiple commits becomming aggregated after the fact.
+    @staticmethod
+    def _unpack_embedded_summaries(msg_list):
+        """Helper function looking for embedded summaries.
 
-    Note that embedded summaries all originated from an atomic commit, so
-    all the resulting CommitMessages will have the same underlying commit id.
-    """
-    result = []
-    for commit_message in msg_list:
-      commit_id = commit_message.commit_id
-      author = commit_message.author
-      date = commit_message.date
+        An embedded summary is another top-line message block (e.g. fix(...): ...)
+        This is different from a merged commit in that it doesnt have the
+        commit/author/date fields. These types of entries are typically entered
+        manually to convey a single atomic commit contains multiple changes
+        as opposed to multiple commits becomming aggregated after the fact.
 
-      lines = commit_message.message.split('\n')
-      prev = -1
-      for index, line in enumerate(lines):
-        if CommitMessage._EMBEDDED_SUMMARY_MATCHER.match(line):
-          logging.debug('Found embedded commit at line "%s" prev=%d',
-                        line, prev)
-          if prev >= 0:
-            text = '\n'.join(lines[prev:index]).rstrip()
+        Note that embedded summaries all originated from an atomic commit, so
+        all the resulting CommitMessages will have the same underlying commit id.
+        """
+        result = []
+        for commit_message in msg_list:
+            commit_id = commit_message.commit_id
+            author = commit_message.author
+            date = commit_message.date
+
+            lines = commit_message.message.split("\n")
+            prev = -1
+            for index, line in enumerate(lines):
+                if CommitMessage._EMBEDDED_SUMMARY_MATCHER.match(line):
+                    logging.debug(
+                        'Found embedded commit at line "%s" prev=%d', line, prev
+                    )
+                    if prev >= 0:
+                        text = "\n".join(lines[prev:index]).rstrip()
+                        result.append(CommitMessage(commit_id, author, date, text))
+                    prev = index
+            if prev < 0:
+                prev = 0
+            text = "\n".join(lines[prev:]).rstrip()
             result.append(CommitMessage(commit_id, author, date, text))
-          prev = index
-      if prev < 0:
-        prev = 0
-      text = '\n'.join(lines[prev:]).rstrip()
-      result.append(CommitMessage(commit_id, author, date, text))
 
-    return result
+        return result
 
-  def determine_semver_implication(
-      self, major_regexs=None, minor_regexs=None, patch_regexs=None,
-      default_semver_index=SemanticVersion.MINOR_INDEX):
-    """Determine what effect this commit has on future semantic versioning.
+    def determine_semver_implication(
+        self,
+        major_regexs=None,
+        minor_regexs=None,
+        patch_regexs=None,
+        default_semver_index=SemanticVersion.MINOR_INDEX,
+    ):
+        """Determine what effect this commit has on future semantic versioning.
 
-    Args:
-      major_regexs: [list of re] Regexes to look for indicating a MAJOR change
-      minor_regexs: [list of re] Regexes to look for indicating a MINOR change
-      patch_regexs: [list of re] Regexes to look for indicating a PATCH change
-      default_semver_index: SemanticVersion.*_INDEX for default change
+        Args:
+          major_regexs: [list of re] Regexes to look for indicating a MAJOR change
+          minor_regexs: [list of re] Regexes to look for indicating a MINOR change
+          patch_regexs: [list of re] Regexes to look for indicating a PATCH change
+          default_semver_index: SemanticVersion.*_INDEX for default change
 
-    Returns:
-      The SemanticVersion.*_INDEX of the affected idealized version component
-      that will need to be incremented to accomodate this change.
+        Returns:
+          The SemanticVersion.*_INDEX of the affected idealized version component
+          that will need to be incremented to accomodate this change.
+        """
+
+        def is_compliant(spec):
+            """Determine if the commit message satisfies the specification."""
+            if not spec:
+                return None
+            if not isinstance(spec, list):
+                spec = [spec]
+
+            text = self.message.strip()
+            for matcher in spec:
+                match = matcher.search(text)
+                if match:
+                    return match.groups()
+            return None
+
+        if major_regexs is None:
+            major_regexs = CommitMessage.DEFAULT_MAJOR_REGEXS
+        if minor_regexs is None:
+            minor_regexs = CommitMessage.DEFAULT_MINOR_REGEXS
+        if patch_regexs is None:
+            patch_regexs = CommitMessage.DEFAULT_PATCH_REGEXS
+
+        attempts = [
+            ("MAJOR", major_regexs, SemanticVersion.MAJOR_INDEX),
+            ("MINOR", minor_regexs, SemanticVersion.MINOR_INDEX),
+            ("PATCH", patch_regexs, SemanticVersion.PATCH_INDEX),
+        ]
+        for name, regexes, index in attempts:
+            reason = is_compliant(regexes)
+            if reason:
+                logging.debug(
+                    'Commit is considered "%s" because it says "%s"', name, reason
+                )
+                return index
+
+        logging.debug(
+            'Commit is considered #%d by DEFAULT: message was "%s"',
+            default_semver_index,
+            self.message,
+        )
+        return default_semver_index
+
+    def to_yaml(self):
+        """Convert the summary to a yaml string."""
+        data = dict(self._asdict())
+        return yaml.safe_dump(data, default_flow_style=False)
+
+    def _asdict(self):
+        """Override broken method in some Python3
+
+        https://bugs.python.org/issue24931
+        """
+        return collections.OrderedDict(
+            [
+                ("commit_id", self.commit_id),
+                ("author", self.author),
+                ("date", self.date),
+                ("message", self.message),
+            ]
+        )
+
+
+class RepositorySummary(
+    collections.namedtuple(
+        "RepositorySummary", ["commit_id", "tag", "version", "commit_messages"]
+    )
+):
+    """Denotes information about a repository that a build-delta wants.
+
+    Attributes:
+      commit_id: [string] The latest tag commit id
+      tag: [string] The latest tag
+      version: [string] The Major.Minor.Patch version number
+      commit_messages: [list of CommitMessage] The commits since the last tag.
+         If this is empty then the tag and version already exists.
+         Otherwise the tag and version are proposed values.
     """
-    def is_compliant(spec):
-      """Determine if the commit message satisfies the specification."""
-      if not spec:
-        return None
-      if not isinstance(spec, list):
-        spec = [spec]
 
-      text = self.message.strip()
-      for matcher in spec:
-        match = matcher.search(text)
-        if match:
-          return match.groups()
-      return None
+    @staticmethod
+    def from_dict(content):
+        """Construct from yaml dictionary."""
+        data = dict(content)
+        data["commit_messages"] = [
+            CommitMessage(**raw) for raw in data["commit_messages"]
+        ]
+        return RepositorySummary(**data)
 
-    if major_regexs is None:
-      major_regexs = CommitMessage.DEFAULT_MAJOR_REGEXS
-    if minor_regexs is None:
-      minor_regexs = CommitMessage.DEFAULT_MINOR_REGEXS
-    if patch_regexs is None:
-      patch_regexs = CommitMessage.DEFAULT_PATCH_REGEXS
+    def to_yaml(self, with_commit_messages=True):
+        """Convert the summary to a yaml string."""
+        data = dict(self._asdict())
+        if with_commit_messages:
+            data["commit_messages"] = [
+                dict(m._asdict()) for m in data["commit_messages"]
+            ]
+        else:
+            del data["commit_messages"]
 
-    attempts = [('MAJOR', major_regexs, SemanticVersion.MAJOR_INDEX),
-                ('MINOR', minor_regexs, SemanticVersion.MINOR_INDEX),
-                ('PATCH', patch_regexs, SemanticVersion.PATCH_INDEX)]
-    for name, regexes, index in attempts:
-      reason = is_compliant(regexes)
-      if reason:
-        logging.debug('Commit is considered "%s" because it says "%s"',
-                      name, reason)
-        return index
+        return yaml.safe_dump(data, default_flow_style=False)
 
-    logging.debug('Commit is considered #%d by DEFAULT: message was "%s"',
-                  default_semver_index, self.message)
-    return default_semver_index
+    def _asdict(self):
+        """Override broken method in some Python3
 
-  def to_yaml(self):
-    """Convert the summary to a yaml string."""
-    data = dict(self._asdict())
-    return yaml.safe_dump(data, default_flow_style=False)
-
-  def _asdict(self):
-    """Override broken method in some Python3
-
-    https://bugs.python.org/issue24931
-    """
-    return collections.OrderedDict([
-        ('commit_id', self.commit_id),
-        ('author', self.author),
-        ('date', self.date),
-        ('message', self.message)
-    ])
-
-class RepositorySummary(collections.namedtuple(
-    'RepositorySummary',
-    ['commit_id', 'tag', 'version', 'commit_messages'])):
-  """Denotes information about a repository that a build-delta wants.
-
-  Attributes:
-    commit_id: [string] The latest tag commit id
-    tag: [string] The latest tag
-    version: [string] The Major.Minor.Patch version number
-    commit_messages: [list of CommitMessage] The commits since the last tag.
-       If this is empty then the tag and version already exists.
-       Otherwise the tag and version are proposed values.
-  """
-  @staticmethod
-  def from_dict(content):
-    """Construct from yaml dictionary."""
-    data = dict(content)
-    data['commit_messages'] = [CommitMessage(**raw)
-                               for raw in data['commit_messages']]
-    return RepositorySummary(**data)
-
-  def to_yaml(self, with_commit_messages=True):
-    """Convert the summary to a yaml string."""
-    data = dict(self._asdict())
-    if with_commit_messages:
-      data['commit_messages'] = [dict(m._asdict())
-                                 for m in data['commit_messages']]
-    else:
-      del data['commit_messages']
-
-    return yaml.safe_dump(data, default_flow_style=False)
-
-  def _asdict(self):
-    """Override broken method in some Python3
-
-    https://bugs.python.org/issue24931
-    """
-    return collections.OrderedDict([
-        ('commit_id', self.commit_id),
-        ('tag', self.tag),
-        ('version', self.version),
-        ('commit_messages', self.commit_messages)
-    ])
+        https://bugs.python.org/issue24931
+        """
+        return collections.OrderedDict(
+            [
+                ("commit_id", self.commit_id),
+                ("tag", self.tag),
+                ("version", self.version),
+                ("commit_messages", self.commit_messages),
+            ]
+        )
 
 
 class GitRunner(object):
-  """Helper class for interacting with Git"""
+    """Helper class for interacting with Git"""
 
-  __GITHUB_TOKEN = None
+    __GITHUB_TOKEN = None
 
-  @staticmethod
-  def add_parser_args(parser, defaults):
-    """Add standard parser options used by GitRunner."""
-    if hasattr(parser, 'added_git'):
-      return
-    parser.added_git = True
+    @staticmethod
+    def add_parser_args(parser, defaults):
+        """Add standard parser options used by GitRunner."""
+        if hasattr(parser, "added_git"):
+            return
+        parser.added_git = True
 
-    add_parser_argument(
-        parser, 'github_owner', defaults, None,
-        help='Github repository owner whose repositories we should'
-             ' be operating on.')
-    add_parser_argument(
-        parser, 'github_pull_ssh', defaults, False, type=bool,
-        help='If True, github pull origin uses ssh rather than https.'
-             ' Pulls are https by default since the standard repos are public.')
-    add_parser_argument(
-        parser, 'github_repository_root', defaults, None,
-        help='If set, then use this as the base repository for github.'
-             ' This is intended for urls other than https and ssh,'
-             ' such as filesystems for testing.'
-             ' Otherwise, use github_hostname, github_(push|pull)_ssh.')
-    add_parser_argument(
-        parser, 'github_push_ssh', defaults, True, type=bool,
-        help='If False, github push origin uses https rather than ssh.'
-             ' Pushes are ssh by default for enhanced security over https.')
-    add_parser_argument(
-        parser, 'github_disable_upstream_push', defaults, False, type=bool,
-        help='If True then disable upstream git pushes in local repos.'
-             ' This is intended as a safety mechanism for testing.')
-    add_parser_argument(
-        parser, 'git_allow_no_baseline_tag', defaults, True, type=bool,
-        help='If True then do not require a baseline tag when searching back'
-             ' from a commit to the previous version. Normally this would not'
-             ' be allowed.')
+        add_parser_argument(
+            parser,
+            "github_owner",
+            defaults,
+            None,
+            help="Github repository owner whose repositories we should"
+            " be operating on.",
+        )
+        add_parser_argument(
+            parser,
+            "github_pull_ssh",
+            defaults,
+            False,
+            type=bool,
+            help="If True, github pull origin uses ssh rather than https."
+            " Pulls are https by default since the standard repos are public.",
+        )
+        add_parser_argument(
+            parser,
+            "github_repository_root",
+            defaults,
+            None,
+            help="If set, then use this as the base repository for github."
+            " This is intended for urls other than https and ssh,"
+            " such as filesystems for testing."
+            " Otherwise, use github_hostname, github_(push|pull)_ssh.",
+        )
+        add_parser_argument(
+            parser,
+            "github_push_ssh",
+            defaults,
+            True,
+            type=bool,
+            help="If False, github push origin uses https rather than ssh."
+            " Pushes are ssh by default for enhanced security over https.",
+        )
+        add_parser_argument(
+            parser,
+            "github_disable_upstream_push",
+            defaults,
+            False,
+            type=bool,
+            help="If True then disable upstream git pushes in local repos."
+            " This is intended as a safety mechanism for testing.",
+        )
+        add_parser_argument(
+            parser,
+            "git_allow_no_baseline_tag",
+            defaults,
+            True,
+            type=bool,
+            help="If True then do not require a baseline tag when searching back"
+            " from a commit to the previous version. Normally this would not"
+            " be allowed.",
+        )
 
-  @staticmethod
-  def add_publishing_parser_args(parser, defaults):
-    """Add standard parser options used when pushing changes with GitRunner."""
-    if hasattr(parser, 'added_publishing'):
-      return
-    parser.added_publishing = True
+    @staticmethod
+    def add_publishing_parser_args(parser, defaults):
+        """Add standard parser options used when pushing changes with GitRunner."""
+        if hasattr(parser, "added_publishing"):
+            return
+        parser.added_publishing = True
 
-    add_parser_argument(
-        parser, 'git_allow_publish_master_branch', defaults, True, type=bool,
-        help='If false then push to a version-specific branch'
-             ' rather than "master" so it can be reviewed.')
-    add_parser_argument(
-        parser, 'git_never_push', defaults, False, type=bool,
-        help='Disable pushing to git.')
+        add_parser_argument(
+            parser,
+            "git_allow_publish_master_branch",
+            defaults,
+            True,
+            type=bool,
+            help="If false then push to a version-specific branch"
+            ' rather than "master" so it can be reviewed.',
+        )
+        add_parser_argument(
+            parser,
+            "git_never_push",
+            defaults,
+            False,
+            type=bool,
+            help="Disable pushing to git.",
+        )
 
-  @staticmethod
-  def normalize_repo_url(url):
-    """Normalize a repo url for purposes of checking equality.
+    @staticmethod
+    def normalize_repo_url(url):
+        """Normalize a repo url for purposes of checking equality.
 
-    Returns:
-      Either a tuple (HOST, OWNER, PATH) if url is a github-like URL
-         assumed to be in the form <PROTOCOL://HOST/OWNER/PATH> where
-         or ssh@<HOST>:<USER><REPO>
-         in these cases, a '.git' REPO postfix is considered superfluous.
+        Returns:
+          Either a tuple (HOST, OWNER, PATH) if url is a github-like URL
+             assumed to be in the form <PROTOCOL://HOST/OWNER/PATH> where
+             or ssh@<HOST>:<USER><REPO>
+             in these cases, a '.git' REPO postfix is considered superfluous.
 
-      Otherwise a string assuming the url is a local path
-         where the string will be the absolute path.
-    """
-    dot_git = '.git'
-    gitless_url = (url[:-len(dot_git)]
-                   if url.endswith(dot_git)
-                   else url)
+          Otherwise a string assuming the url is a local path
+             where the string will be the absolute path.
+        """
+        dot_git = ".git"
+        gitless_url = url[: -len(dot_git)] if url.endswith(dot_git) else url
 
-    # e.g. http://github.com/USER/REPO
-    match = re.match(r'[a-z0-9]+://([^/]+)/([^/]+)/(.+)', gitless_url)
-    if not match:
-      # e.g. git@github.com:USER/REPO
-      match = re.match(r'git@([^:]+):([^/]+)/(.+)', gitless_url)
-    if match:
-      return match.groups()
+        # e.g. http://github.com/USER/REPO
+        match = re.match(r"[a-z0-9]+://([^/]+)/([^/]+)/(.+)", gitless_url)
+        if not match:
+            # e.g. git@github.com:USER/REPO
+            match = re.match(r"git@([^:]+):([^/]+)/(.+)", gitless_url)
+        if match:
+            return match.groups()
 
-    return os.path.abspath(url)
+        return os.path.abspath(url)
 
-  @staticmethod
-  def is_same_repo(first, second):
-    """Determine if two URLs refer to the same github repo."""
-    normalized_first = GitRunner.normalize_repo_url(first)
-    normalized_second = GitRunner.normalize_repo_url(second)
-    return normalized_first == normalized_second
+    @staticmethod
+    def is_same_repo(first, second):
+        """Determine if two URLs refer to the same github repo."""
+        normalized_first = GitRunner.normalize_repo_url(first)
+        normalized_second = GitRunner.normalize_repo_url(second)
+        return normalized_first == normalized_second
 
-  @staticmethod
-  def stash_and_clear_auth_env_vars():
-    """Remove git auth variables from global environment; keep internally."""
-    if 'GITHUB_TOKEN' in os.environ:
-      GitRunner.__GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
-      del os.environ['GITHUB_TOKEN']
+    @staticmethod
+    def stash_and_clear_auth_env_vars():
+        """Remove git auth variables from global environment; keep internally."""
+        if "GITHUB_TOKEN" in os.environ:
+            GitRunner.__GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+            del os.environ["GITHUB_TOKEN"]
 
-  @staticmethod
-  def make_https_url(host, owner, repo):
-    """Return github https url."""
-    return 'https://{host}/{owner}/{repo}'.format(
-        host=host, owner=owner, repo=repo)
+    @staticmethod
+    def make_https_url(host, owner, repo):
+        """Return github https url."""
+        return "https://{host}/{owner}/{repo}".format(host=host, owner=owner, repo=repo)
 
-  @staticmethod
-  def make_ssh_url(host, owner, repo):
-    """Return github https url."""
-    return 'git@{host}:{owner}/{repo}'.format(
-        host=host, owner=owner, repo=repo)
+    @staticmethod
+    def make_ssh_url(host, owner, repo):
+        """Return github https url."""
+        return "git@{host}:{owner}/{repo}".format(host=host, owner=owner, repo=repo)
 
-  @property
-  def options(self):
-    """Return bound options."""
-    return self.__options
+    @property
+    def options(self):
+        """Return bound options."""
+        return self.__options
 
-  def __init__(self, options):
-    self.__options = options
-    self.__auth_env = {}
-    if GitRunner.__GITHUB_TOKEN:
-      self.__auth_env['GITHUB_TOKEN'] = GitRunner.__GITHUB_TOKEN
+    def __init__(self, options):
+        self.__options = options
+        self.__auth_env = {}
+        if GitRunner.__GITHUB_TOKEN:
+            self.__auth_env["GITHUB_TOKEN"] = GitRunner.__GITHUB_TOKEN
 
-  def __inject_auth(self, keyword_args_to_modify):
-    """Inject the configured git authentication environment variables.
+    def __inject_auth(self, keyword_args_to_modify):
+        """Inject the configured git authentication environment variables.
 
-    Args:
-      keyword_args_to_modify: [dict]
-          The kwargs dictionary that will be passed to the subprocess is
-          modified to inject additional authentication variables,
-          if configured to do so.
-    """
-    if not self.__auth_env:
-      return
-    new_env = dict(keyword_args_to_modify.get('env', os.environ))
-    new_env.update(self.__auth_env)
-    keyword_args_to_modify['env'] = new_env
+        Args:
+          keyword_args_to_modify: [dict]
+              The kwargs dictionary that will be passed to the subprocess is
+              modified to inject additional authentication variables,
+              if configured to do so.
+        """
+        if not self.__auth_env:
+            return
+        new_env = dict(keyword_args_to_modify.get("env", os.environ))
+        new_env.update(self.__auth_env)
+        keyword_args_to_modify["env"] = new_env
 
-  def run_git(self, git_dir, command, **kwargs):
-    """Wrapper around run_subprocess."""
-    self.__inject_auth(kwargs)
-    return run_subprocess(
-        'git -C "{dir}" {command}'.format(dir=git_dir, command=command),
-        **kwargs)
+    def run_git(self, git_dir, command, **kwargs):
+        """Wrapper around run_subprocess."""
+        self.__inject_auth(kwargs)
+        return run_subprocess(
+            'git -C "{dir}" {command}'.format(dir=git_dir, command=command), **kwargs
+        )
 
-  def check_run(self, git_dir, command, **kwargs):
-    """Wrapper around check_subprocess."""
-    self.__inject_auth(kwargs)
-    return check_subprocess(
-        'git -C "{dir}" {command}'.format(dir=git_dir, command=command),
-        **kwargs)
+    def check_run(self, git_dir, command, **kwargs):
+        """Wrapper around check_subprocess."""
+        self.__inject_auth(kwargs)
+        return check_subprocess(
+            'git -C "{dir}" {command}'.format(dir=git_dir, command=command), **kwargs
+        )
 
-  def check_run_sequence(self, git_dir, commands):
-    """Check a sequence of git commands.
+    def check_run_sequence(self, git_dir, commands):
+        """Check a sequence of git commands.
 
-    Args:
-      git_dir: [path] All the commands refer to this lcoal repository.
-      commands: [list of string] To pass to check_run.
-    """
-    for cmd in commands:
-      self.check_run(git_dir, cmd)
+        Args:
+          git_dir: [path] All the commands refer to this lcoal repository.
+          commands: [list of string] To pass to check_run.
+        """
+        for cmd in commands:
+            self.check_run(git_dir, cmd)
 
-  def check_commit_or_no_changes(self, git_dir, commit_commandline_args):
-    """A variant of check_run 'commit' that tolerates 'no changes' errors."""
-    retcode, stdout = self.run_git(
-        git_dir, 'commit ' + commit_commandline_args)
-    if retcode == 1:
-      last_line = stdout.split('\n')[-1]
-      if last_line.lower().find('nothing to commit') >= 0:
-        logging.debug('No changes to commit -- raw changelog is unchanged.')
+    def check_commit_or_no_changes(self, git_dir, commit_commandline_args):
+        """A variant of check_run 'commit' that tolerates 'no changes' errors."""
+        retcode, stdout = self.run_git(git_dir, "commit " + commit_commandline_args)
+        if retcode == 1:
+            last_line = stdout.split("\n")[-1]
+            if last_line.lower().find("nothing to commit") >= 0:
+                logging.debug("No changes to commit -- raw changelog is unchanged.")
+                return stdout
+            log_embedded_output(logging.ERROR, "command output", stdout)
+            raise_and_log_error(ExecutionError("git failed."))
         return stdout
-      log_embedded_output(logging.ERROR, 'command output', stdout)
-      raise_and_log_error(ExecutionError('git failed.'))
-    return stdout
-
-  def find_newest_tag_and_common_commit_from_id(
-      self, git_dir, commit_id):
-    """Returns most recent tag and common commit to a given commit_id.
-
-    So if we have this:
-       <tag 0.1.0>
-         |
-         A - B - C <tag 0.2.0) - ...
-         |
-         X
-         |
-         Y - Z <id>
-    Then we want for <id> to get the tag <0.2.0> and commit A.
-    """
-    # Find the ancestor commit, which is most recent tag in our direct history.
-    # For the example in the function docs, this would be tag 0.1.0
-    retcode, most_recent_ancestor_tag = self.run_git(
-        git_dir, 'describe --abbrev=0 --tags --match v* ' + commit_id)
-    if retcode != 0:
-      tag = 'v0.0.0'
-      logging.warning('No baseline tag for "%s", assuming this is first one.',
-                      git_dir)
-      tag_commit = self.check_run(git_dir, 'rev-list --max-parents=0 HEAD')
-    else:
-      tag = most_recent_ancestor_tag
-      tag_commit = self.check_run(git_dir, 'rev-list -n 1 ' + tag)
-
-    if tag_commit == commit_id:
-      logging.debug(
-          'Commit %s is already tagged with %s', tag_commit, tag)
-    else:
-      logging.warning(
-              '%s HEAD commit of %s is newer than %s tag at %s. Using last tag & its commit',
-              git_dir.split('/')[2], commit_id, tag, tag_commit)
-
-    return tag, tag_commit
-
-  def query_local_repository_commits_between_two_commit_ids(
-      self, git_dir, start_commit_id, end_commit_id):
-    """Returns the list of commit messages to the local repository within the
-       range from start_commit_id to end_commit_id, inclusive.
-
-    Args:
-      start_commit_id [string]: commits including and since this id
-      end_commit_id [string]: commits until and including this id
-    """
-    # pylint: disable=invalid-name
-
-    commit_history = self.check_run(
-        git_dir,
-        'log --pretty=medium {start_commit_id}..{end_commit_id}'.format(
-            start_commit_id=start_commit_id, end_commit_id=end_commit_id))
-    messages = CommitMessage.make_list_from_result(commit_history)
-    return messages
-
-  def query_commit_at_tag(self, git_dir, tag):
-    """Return the commit for the given tag, or None if tag is not known."""
-    retcode, stdout = self.run_git(git_dir, 'show-ref -- ' + tag)
-    if retcode != 0:
-      return None
-    lines = stdout.split('\n')
-    if len(lines) != 1:
-      raise_and_log_error(
-          UnexpectedError('"{tag}" -> "{msg}"'.format(tag=tag, msg=stdout)))
-    return stdout.split(' ')[0]
-
-  def query_local_repository_commit_id(self, git_dir):
-    """Returns the current commit for the repository at git_dir."""
-    result = self.check_run(git_dir, 'rev-parse HEAD')
-    return result
-
-  def query_remote_repository_commit_id(self, url, branch):
-    """Returns the current commit for the remote repository."""
-    args = {}
-    self.__inject_auth(args)
-    result = check_subprocess('git ls-remote %s %s' % (url, branch), **args)
-    return result.split('\t')[0]
-
-  def query_local_repository_branch(self, git_dir):
-    """Returns the branch for the repository at git_dir."""
-    returncode, stdout = self.run_git(git_dir, 'rev-parse --abbrev-ref HEAD')
-    if returncode:
-      raise_and_log_error(
-          ExecutionError('Could detmine branch', program='git'),
-          'Could not determine branch in {dir}: {output}'.format(
-              dir=git_dir, output=stdout))
-    return stdout
-
-  def delete_branch_on_origin(self, git_dir, branch):
-    if self.options.git_never_push:
-      logging.warning(
-          'SKIP deleting branch because --git_never_push=true.'
-          '\nCommand would have been: %s',
-          'git -C "{dir}" push origin --delete {branch}'.format(
-              dir=git_dir, branch=branch))
-      return
-    logging.warning('Deleting origin branch="%s" for %s', branch, git_dir)
-    self.check_run(git_dir, 'push origin --delete ' + branch)
-
-  def push_branch_to_origin(self, git_dir, branch, force=False):
-    """Push the given local repository back up to the origin.
-
-    This has no effect if the repository is not in the given branch.
-    """
-    if self.options.git_never_push:
-      logging.warning(
-          'SKIP pushing branch because --git_never_push=true.'
-          '\nCommand would have been: %s',
-          'git -C "{dir}" push origin {branch}'.format(
-              dir=git_dir, branch=branch))
-      return
-
-    in_branch = self.query_local_repository_branch(git_dir)
-    if in_branch != branch:
-      logging.warning('Skipping push %s "%s" to origin because branch is "%s".',
-                      git_dir, branch, in_branch)
-      return
-
-    force_flag = ' -f' if force else ''
-    self.check_run(git_dir, 'push origin ' + branch + force_flag)
-
-  def push_tag_to_origin(self, git_dir, tag):
-    """Push the given tag back up to the origin."""
-    if self.options.git_never_push:
-      logging.warning(
-          'SKIP pushing tag because --git_never_push=true.'
-          '\nCommand would have been: %s',
-          'git -C "{dir}" push origin {tag}'.format(dir=git_dir, tag=tag))
-      return
-
-    logging.debug('Pushing tag "%s" and pushing to origin in %s', tag, git_dir)
-    self.check_run(git_dir, 'push origin ' + tag)
-
-  def fetch_tags(self, git_dir, remote_name='origin'):
-    """Fetches the tags in the given remote as a list.
-
-    Args:
-      git_dir: [string] Which local repository to update.
-      remote_name: [remote_name] Which remote repository to pull from.
-
-    Returns:
-      A list of tags.
-    """
-    logging.debug('Fetching tags for %s from remote %s', git_dir, remote_name)
-    self.check_run(git_dir, 'fetch --tags')
-    raw_tags = self.check_run(git_dir, 'tag')
-    return [s.strip() for s in raw_tags.split('\n')]
-
-  def refresh_local_repository(self, git_dir, remote_name):
-    """Refreshes the given local repository from the remote one.
-
-    Args:
-      git_dir: [string] Which local repository to update.
-      remote_name: [remote_name] Which remote repository to pull from.
-      branch: [string] Which branch to pull.
-    """
-    repository = self.determine_git_repository_spec(git_dir)
-    if remote_name == 'upstream' and not repository.upstream:
-      logging.warning(
-          'Skipping pull {remote_name} in {repository} because'
-          ' it does not have a remote "{remote_name}"'
-          .format(remote_name=remote_name,
-                  repository=repository.name))
-      return
-
-    logging.debug('Refreshing %s from %s',
-                  git_dir, remote_name)
-    command = 'fetch {remote_name} --tags'.format(
-        remote_name=remote_name)
-    result = self.check_run(git_dir, command)
-    logging.info('%s:\n%s', repository.name, result)
-
-  def __check_clone_branch(self, remote_url, base_dir, clone_command, branches):
-    remaining_branches = list(branches)
-    while True:
-      branch = remaining_branches.pop(0)
-      cmd = '{clone} -b {branch}'.format(clone=clone_command, branch=branch)
-      retcode, stdout = self.run_git(base_dir, cmd)
-      if not retcode:
-        return
-
-      not_found = stdout.find('Remote branch {branch} not found'
-                              .format(branch=branch)) >= 0
-      if not not_found:
-        full_command = 'git -C "{dir}" {cmd}'.format(dir=base_dir, cmd=cmd)
-        raise_and_log_error(ExecutionError(full_command, program='git'),
-                            full_command + ' failed with:\n' + stdout)
-
-      if remaining_branches:
-        logging.warning(
-            'Branch %s does not exist in %s. Retry with %s',
-            branch, remote_url, remaining_branches[0])
-        continue
-
-      lines = stdout.split('\n')
-      stdout = '\n   '.join(lines)
-      logging.error('git -C "%s" %s failed with output:\n   %s',
-                    base_dir, cmd, stdout)
-      raise_and_log_error(ConfigError('Branches {0} do not exist in {1}.'
-                                      .format(branches, remote_url)))
-
-  def remove_all_non_version_tags(self, repository, git_dir=None):
-    """Removes tags from the repository that confuse nebula.
-
-    This confusion is because nebula is assuming Netflix policies and tags,
-    but the OSS build has different policies and different tags to avoid
-    conflicts with Netflix internal usage.
-    """
-    tag_matcher = re.compile(r'^v[0-9]+\.[0-9]+\.[0-9]+$')
-    git_dir = git_dir or repository.git_dir
-
-    logging.debug('Clearing all non-version tags from %s', git_dir)
-    all_tags = self.check_run(git_dir, 'tag').split('\n')
-    tags_to_remove = [tag for tag in all_tags if not tag_matcher.match(tag)]
-    self.check_run(git_dir, 'tag -d ' + ' '.join(tags_to_remove))
-    logging.debug('%d of %d tags removed', len(tags_to_remove), len(all_tags))
-
-  def determine_pull_url(self, origin):
-    """Return the pull URL for a given repository from its origin."""
-    parts = self.normalize_repo_url(origin)
-    if len(parts) == 3:
-      return (self.make_ssh_url(*parts) if self.__options.github_pull_ssh
-              else self.make_https_url(*parts))
-    return origin
-
-  def determine_push_url(self, origin):
-    """Return the push URL for a given repository from its origin."""
-    parts = self.normalize_repo_url(origin)
-    if len(parts) == 3:
-      return (self.make_ssh_url(*parts) if self.__options.github_push_ssh
-              else self.make_https_url(*parts))
-    return origin
-
-  def clone_repository_to_path(
-      self, repository, commit=None, branch=None, default_branch=None):
-    """Clone the remote repository at the given commit or branch.
-
-    If requesting a branch and it is not found, then settle for the default
-    branch, if one was explicitly specified.
-    """
-    # pylint: disable=too-many-arguments
-
-    if (commit != None) and (branch != None):
-      raise_and_log_error(
-          ConfigError('At most one of commit or branch can be specified.'))
-
-    pull_url = self.determine_pull_url(repository.origin)
-    git_dir = repository.git_dir
-    logging.debug('Begin cloning %s', pull_url)
-    parent_dir = os.path.dirname(git_dir)
-    ensure_dir_exists(parent_dir)
-
-    clone_command = 'clone ' + pull_url
-    if branch:
-      branches = [branch]
-      if default_branch:
-        branches.append(default_branch)
-      self.__check_clone_branch(pull_url, parent_dir, clone_command, branches)
-    else:
-      self.check_run(parent_dir, clone_command)
-    logging.info('Cloned %s into %s', pull_url, parent_dir)
-
-    if commit:
-      self.checkout(repository, commit)
-
-    upstream = repository.upstream_or_none()
-    origin = repository.origin
-    if upstream and not self.is_same_repo(upstream, origin):
-      logging.debug('Adding upstream %s with disabled push', upstream)
-      self.check_run(git_dir, 'remote add upstream ' + upstream)
-
-    which = ('upstream'
-             if upstream and not self.is_same_repo(upstream, origin)
-             else 'origin')
-    if self.__options.github_disable_upstream_push:
-      self.check_run(
-          git_dir, 'remote set-url --push {which} disabled'.format(which=which))
-    if which != 'origin' or not self.__options.github_disable_upstream_push:
-      parts = self.normalize_repo_url(repository.origin)
-      if len(parts) == 3:
-        # Origin is not a local path
-        logging.debug('Fixing origin push url')
-        push_url = self.determine_push_url(repository.origin)
-        self.check_run(git_dir, 'remote set-url --push origin ' + push_url)
-
-    logging.debug('Finished cloning %s', pull_url)
-
-  def checkout(self, repository, commit):
-    self.check_run(repository.git_dir, 'checkout -q ' + commit, echo=True)
-
-  def tag_head(self, git_dir, tag):
-    """Add tag to the local repository HEAD."""
-    self.check_run(git_dir, 'tag {tag} HEAD'.format(tag=tag))
-
-  def query_tag_commits(self, git_dir, tag_pattern):
-    """Collect the TagCommit for each tag matching the pattern.
-
-      Returns: list of CommitTag sorted most recent first.
-    """
-    retcode, stdout = self.run_git(git_dir, 'show-ref --tags')
-    if retcode and stdout:
-      raise_and_log_error(
-          ExecutionError('git failed in %s' % git_dir, program='git'),
-          'git -C "%s" show-ref --tags: %s' % (git_dir, stdout))
-
-    ref_lines = stdout.split('\n')
-    commit_tags = [CommitTag.make(line) for line in ref_lines if line]
-    matcher = re.compile(tag_pattern)
-    filtered = [ct for ct in commit_tags if matcher.match(ct.tag)]
-    return sorted(filtered, reverse=True)
-
-  def determine_git_repository_spec(self, git_dir):
-    """Infer GitRepositorySpec from a local git repository."""
-    git_text = self.check_run(git_dir, 'remote -v')
-    remote_urls = {
-        match.group(1): match.group(2)
-        for match in re.finditer(r'(\w+)\s+(\S+)\s+\(fetch\)', git_text)
-    }
-    origin_url = remote_urls.get('origin')
-    if not origin_url:
-      raise_and_log_error(
-          UnexpectedError('{0} has no remote "origin"'.format(git_dir)))
-    return GitRepositorySpec(os.path.basename(git_dir),
-                             git_dir=git_dir,
-                             origin=origin_url,
-                             upstream=remote_urls.get('upstream'))
-
-  def collect_repository_summary(self, git_dir, start_commit_id=None):
-    """Collects RepositorySummary from local repository directory up to the
-        latest tag commit.
-
-    Args:
-      start_commit_id [string]: If start_commit_id is provided then return
-          commit messages from it until the latest tag, inclusive.
-    """
-    start_time = time.time()
-    logging.debug('Begin analyzing %s', git_dir)
-
-    head_commit_id = self.query_local_repository_commit_id(git_dir)
-
-    tag, tag_commit_id = self.find_newest_tag_and_common_commit_from_id(
-        git_dir, head_commit_id)
-
-    msgs = []
-    if start_commit_id != None:
-        msgs = self.query_local_repository_commits_between_two_commit_ids(
-                git_dir, start_commit_id, tag_commit_id)
-
-    tag_semver = SemanticVersion.make(tag)
-
-    total_ms = int((time.time() - start_time) * 1000)
-    logging.debug('Finished analyzing %s in %d ms', git_dir, total_ms)
-    return RepositorySummary(tag_commit_id, tag, tag_semver.to_version(), msgs)
-
-  def delete_local_branch_if_exists(self, git_dir, branch):
-    """Delete the branch from git_dir if one exists.
-
-    This will fail if the branch exists and the git_dir is currently in it.
-    """
-    result = self.check_run(git_dir, 'branch -l')
-    branches = []
-    for elem in result.split('\n'):
-      if elem.startswith('*'):
-        elem = elem[1:].strip()
-      branches.append(elem)
-
-    if branch in branches:
-      logging.info('Deleting existing branch %s from %s', branch, git_dir)
-      self.check_run(git_dir, 'branch -D ' + branch)
-      return
-
-  def initiate_github_pull_request(
-      self, git_dir, message, base='master', head=None):
-    """Initialize a pull request for the given commit on the given branch.
-
-    Args:
-      git_dir: [path] The local repository to initiate the pull request with.
-      message: [string] The pull request message. If this is multiple lines
-         then the first line will be the title, subsequent lines will
-         be the PR description.
-      base: [string] The base reference for the pull request.
-         The default is master, but this could be a BRANCH or OWNER:BRANCH
-      head: [string] The branch to use for the pull request. By default this
-         is the current branch state of the the git_dir repository. This
-         too can be BRANCH or OWNER:BRANCH. This branch must have alraedy been
-         pushed to the origin repository -- not the local repository.
-    """
-    options = self.options
-    message = message.strip()
-    if options.pr_notify_list:
-      message.append('\n\n@' + ', @'.join(','.split(options.pr_notify_list)))
-
-    hub_args = []
-    if base:
-      hub_args.extend(['-b', base])
-    if head:
-      hub_args.extend(['-h', head])
-
-    if options.git_never_push:
-      logging.warning(
-          'SKIP creating pull request because --git_never_push=true.'
-          '\nCommand would have been: %s',
-          'git -C "{dir}" pull-request {args} -m {msg!r}'.format(
-              dir=git_dir, args=' '.join(hub_args), msg=message))
-      return
-
-    message_path = None
-    if message.find('\n') < 0:
-      hub_args.extend(['-m', message])
-    else:
-      fd, message_path = tempfile.mkstemp(prefix='hubmsg')
-      os.write(fd, message)
-      os.close(fd)
-      hub_args.extend(['-F', message_path])
-
-    logging.info(
-        'Initiating pull request in %s from %s to %s with message:\n%s',
-        git_dir, base, head if head else '<current branch>', message)
-
-    try:
-      kwargs = {}
-      self.__inject_auth(kwargs)
-      output = check_subprocess(
-          'hub -C "{dir}" pull-request {args}'.format(
-              dir=git_dir, args=' '.join(hub_args)),
-          **kwargs)
-      logging.info(output)
-    finally:
-      if message_path:
-        os.remove(message_path)
+
+    def find_newest_tag_and_common_commit_from_id(self, git_dir, commit_id):
+        """Returns most recent tag and common commit to a given commit_id.
+
+        So if we have this:
+           <tag 0.1.0>
+             |
+             A - B - C <tag 0.2.0) - ...
+             |
+             X
+             |
+             Y - Z <id>
+        Then we want for <id> to get the tag <0.2.0> and commit A.
+        """
+        # Find the ancestor commit, which is most recent tag in our direct history.
+        # For the example in the function docs, this would be tag 0.1.0
+        retcode, most_recent_ancestor_tag = self.run_git(
+            git_dir, "describe --abbrev=0 --tags --match v* " + commit_id
+        )
+        if retcode != 0:
+            tag = "v0.0.0"
+            logging.warning(
+                'No baseline tag for "%s", assuming this is first one.', git_dir
+            )
+            tag_commit = self.check_run(git_dir, "rev-list --max-parents=0 HEAD")
+        else:
+            tag = most_recent_ancestor_tag
+            tag_commit = self.check_run(git_dir, "rev-list -n 1 " + tag)
+
+        if tag_commit == commit_id:
+            logging.debug("Commit %s is already tagged with %s", tag_commit, tag)
+        else:
+            logging.warning(
+                "%s HEAD commit of %s is newer than %s tag at %s. Using last tag & its commit",
+                git_dir.split("/")[2],
+                commit_id,
+                tag,
+                tag_commit,
+            )
+
+        return tag, tag_commit
+
+    def query_local_repository_commits_between_two_commit_ids(
+        self, git_dir, start_commit_id, end_commit_id
+    ):
+        """Returns the list of commit messages to the local repository within the
+           range from start_commit_id to end_commit_id, inclusive.
+
+        Args:
+          start_commit_id [string]: commits including and since this id
+          end_commit_id [string]: commits until and including this id
+        """
+        # pylint: disable=invalid-name
+
+        commit_history = self.check_run(
+            git_dir,
+            "log --pretty=medium {start_commit_id}..{end_commit_id}".format(
+                start_commit_id=start_commit_id, end_commit_id=end_commit_id
+            ),
+        )
+        messages = CommitMessage.make_list_from_result(commit_history)
+        return messages
+
+    def query_commit_at_tag(self, git_dir, tag):
+        """Return the commit for the given tag, or None if tag is not known."""
+        retcode, stdout = self.run_git(git_dir, "show-ref -- " + tag)
+        if retcode != 0:
+            return None
+        lines = stdout.split("\n")
+        if len(lines) != 1:
+            raise_and_log_error(
+                UnexpectedError('"{tag}" -> "{msg}"'.format(tag=tag, msg=stdout))
+            )
+        return stdout.split(" ")[0]
+
+    def query_local_repository_commit_id(self, git_dir):
+        """Returns the current commit for the repository at git_dir."""
+        result = self.check_run(git_dir, "rev-parse HEAD")
+        return result
+
+    def query_remote_repository_commit_id(self, url, branch):
+        """Returns the current commit for the remote repository."""
+        args = {}
+        self.__inject_auth(args)
+        result = check_subprocess("git ls-remote %s %s" % (url, branch), **args)
+        return result.split("\t")[0]
+
+    def query_local_repository_branch(self, git_dir):
+        """Returns the branch for the repository at git_dir."""
+        returncode, stdout = self.run_git(git_dir, "rev-parse --abbrev-ref HEAD")
+        if returncode:
+            raise_and_log_error(
+                ExecutionError("Could detmine branch", program="git"),
+                "Could not determine branch in {dir}: {output}".format(
+                    dir=git_dir, output=stdout
+                ),
+            )
+        return stdout
+
+    def delete_branch_on_origin(self, git_dir, branch):
+        if self.options.git_never_push:
+            logging.warning(
+                "SKIP deleting branch because --git_never_push=true."
+                "\nCommand would have been: %s",
+                'git -C "{dir}" push origin --delete {branch}'.format(
+                    dir=git_dir, branch=branch
+                ),
+            )
+            return
+        logging.warning('Deleting origin branch="%s" for %s', branch, git_dir)
+        self.check_run(git_dir, "push origin --delete " + branch)
+
+    def push_branch_to_origin(self, git_dir, branch, force=False):
+        """Push the given local repository back up to the origin.
+
+        This has no effect if the repository is not in the given branch.
+        """
+        if self.options.git_never_push:
+            logging.warning(
+                "SKIP pushing branch because --git_never_push=true."
+                "\nCommand would have been: %s",
+                'git -C "{dir}" push origin {branch}'.format(
+                    dir=git_dir, branch=branch
+                ),
+            )
+            return
+
+        in_branch = self.query_local_repository_branch(git_dir)
+        if in_branch != branch:
+            logging.warning(
+                'Skipping push %s "%s" to origin because branch is "%s".',
+                git_dir,
+                branch,
+                in_branch,
+            )
+            return
+
+        force_flag = " -f" if force else ""
+        self.check_run(git_dir, "push origin " + branch + force_flag)
+
+    def push_tag_to_origin(self, git_dir, tag):
+        """Push the given tag back up to the origin."""
+        if self.options.git_never_push:
+            logging.warning(
+                "SKIP pushing tag because --git_never_push=true."
+                "\nCommand would have been: %s",
+                'git -C "{dir}" push origin {tag}'.format(dir=git_dir, tag=tag),
+            )
+            return
+
+        logging.debug('Pushing tag "%s" and pushing to origin in %s', tag, git_dir)
+        self.check_run(git_dir, "push origin " + tag)
+
+    def fetch_tags(self, git_dir, remote_name="origin"):
+        """Fetches the tags in the given remote as a list.
+
+        Args:
+          git_dir: [string] Which local repository to update.
+          remote_name: [remote_name] Which remote repository to pull from.
+
+        Returns:
+          A list of tags.
+        """
+        logging.debug("Fetching tags for %s from remote %s", git_dir, remote_name)
+        self.check_run(git_dir, "fetch --tags")
+        raw_tags = self.check_run(git_dir, "tag")
+        return [s.strip() for s in raw_tags.split("\n")]
+
+    def refresh_local_repository(self, git_dir, remote_name):
+        """Refreshes the given local repository from the remote one.
+
+        Args:
+          git_dir: [string] Which local repository to update.
+          remote_name: [remote_name] Which remote repository to pull from.
+          branch: [string] Which branch to pull.
+        """
+        repository = self.determine_git_repository_spec(git_dir)
+        if remote_name == "upstream" and not repository.upstream:
+            logging.warning(
+                "Skipping pull {remote_name} in {repository} because"
+                ' it does not have a remote "{remote_name}"'.format(
+                    remote_name=remote_name, repository=repository.name
+                )
+            )
+            return
+
+        logging.debug("Refreshing %s from %s", git_dir, remote_name)
+        command = "fetch {remote_name} --tags".format(remote_name=remote_name)
+        result = self.check_run(git_dir, command)
+        logging.info("%s:\n%s", repository.name, result)
+
+    def __check_clone_branch(self, remote_url, base_dir, clone_command, branches):
+        remaining_branches = list(branches)
+        while True:
+            branch = remaining_branches.pop(0)
+            cmd = "{clone} -b {branch}".format(clone=clone_command, branch=branch)
+            retcode, stdout = self.run_git(base_dir, cmd)
+            if not retcode:
+                return
+
+            not_found = (
+                stdout.find("Remote branch {branch} not found".format(branch=branch))
+                >= 0
+            )
+            if not not_found:
+                full_command = 'git -C "{dir}" {cmd}'.format(dir=base_dir, cmd=cmd)
+                raise_and_log_error(
+                    ExecutionError(full_command, program="git"),
+                    full_command + " failed with:\n" + stdout,
+                )
+
+            if remaining_branches:
+                logging.warning(
+                    "Branch %s does not exist in %s. Retry with %s",
+                    branch,
+                    remote_url,
+                    remaining_branches[0],
+                )
+                continue
+
+            lines = stdout.split("\n")
+            stdout = "\n   ".join(lines)
+            logging.error(
+                'git -C "%s" %s failed with output:\n   %s', base_dir, cmd, stdout
+            )
+            raise_and_log_error(
+                ConfigError(
+                    "Branches {0} do not exist in {1}.".format(branches, remote_url)
+                )
+            )
+
+    def remove_all_non_version_tags(self, repository, git_dir=None):
+        """Removes tags from the repository that confuse nebula.
+
+        This confusion is because nebula is assuming Netflix policies and tags,
+        but the OSS build has different policies and different tags to avoid
+        conflicts with Netflix internal usage.
+        """
+        tag_matcher = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
+        git_dir = git_dir or repository.git_dir
+
+        logging.debug("Clearing all non-version tags from %s", git_dir)
+        all_tags = self.check_run(git_dir, "tag").split("\n")
+        tags_to_remove = [tag for tag in all_tags if not tag_matcher.match(tag)]
+        self.check_run(git_dir, "tag -d " + " ".join(tags_to_remove))
+        logging.debug("%d of %d tags removed", len(tags_to_remove), len(all_tags))
+
+    def determine_pull_url(self, origin):
+        """Return the pull URL for a given repository from its origin."""
+        parts = self.normalize_repo_url(origin)
+        if len(parts) == 3:
+            return (
+                self.make_ssh_url(*parts)
+                if self.__options.github_pull_ssh
+                else self.make_https_url(*parts)
+            )
+        return origin
+
+    def determine_push_url(self, origin):
+        """Return the push URL for a given repository from its origin."""
+        parts = self.normalize_repo_url(origin)
+        if len(parts) == 3:
+            return (
+                self.make_ssh_url(*parts)
+                if self.__options.github_push_ssh
+                else self.make_https_url(*parts)
+            )
+        return origin
+
+    def clone_repository_to_path(
+        self, repository, commit=None, branch=None, default_branch=None
+    ):
+        """Clone the remote repository at the given commit or branch.
+
+        If requesting a branch and it is not found, then settle for the default
+        branch, if one was explicitly specified.
+        """
+        # pylint: disable=too-many-arguments
+
+        if (commit != None) and (branch != None):
+            raise_and_log_error(
+                ConfigError("At most one of commit or branch can be specified.")
+            )
+
+        pull_url = self.determine_pull_url(repository.origin)
+        git_dir = repository.git_dir
+        logging.debug("Begin cloning %s", pull_url)
+        parent_dir = os.path.dirname(git_dir)
+        ensure_dir_exists(parent_dir)
+
+        clone_command = "clone " + pull_url
+        if branch:
+            branches = [branch]
+            if default_branch:
+                branches.append(default_branch)
+            self.__check_clone_branch(pull_url, parent_dir, clone_command, branches)
+        else:
+            self.check_run(parent_dir, clone_command)
+        logging.info("Cloned %s into %s", pull_url, parent_dir)
+
+        if commit:
+            self.checkout(repository, commit)
+
+        upstream = repository.upstream_or_none()
+        origin = repository.origin
+        if upstream and not self.is_same_repo(upstream, origin):
+            logging.debug("Adding upstream %s with disabled push", upstream)
+            self.check_run(git_dir, "remote add upstream " + upstream)
+
+        which = (
+            "upstream"
+            if upstream and not self.is_same_repo(upstream, origin)
+            else "origin"
+        )
+        if self.__options.github_disable_upstream_push:
+            self.check_run(
+                git_dir, "remote set-url --push {which} disabled".format(which=which)
+            )
+        if which != "origin" or not self.__options.github_disable_upstream_push:
+            parts = self.normalize_repo_url(repository.origin)
+            if len(parts) == 3:
+                # Origin is not a local path
+                logging.debug("Fixing origin push url")
+                push_url = self.determine_push_url(repository.origin)
+                self.check_run(git_dir, "remote set-url --push origin " + push_url)
+
+        logging.debug("Finished cloning %s", pull_url)
+
+    def checkout(self, repository, commit):
+        self.check_run(repository.git_dir, "checkout -q " + commit, echo=True)
+
+    def tag_head(self, git_dir, tag):
+        """Add tag to the local repository HEAD."""
+        self.check_run(git_dir, "tag {tag} HEAD".format(tag=tag))
+
+    def query_tag_commits(self, git_dir, tag_pattern):
+        """Collect the TagCommit for each tag matching the pattern.
+
+        Returns: list of CommitTag sorted most recent first.
+        """
+        retcode, stdout = self.run_git(git_dir, "show-ref --tags")
+        if retcode and stdout:
+            raise_and_log_error(
+                ExecutionError("git failed in %s" % git_dir, program="git"),
+                'git -C "%s" show-ref --tags: %s' % (git_dir, stdout),
+            )
+
+        ref_lines = stdout.split("\n")
+        commit_tags = [CommitTag.make(line) for line in ref_lines if line]
+        matcher = re.compile(tag_pattern)
+        filtered = [ct for ct in commit_tags if matcher.match(ct.tag)]
+        return sorted(filtered, reverse=True)
+
+    def determine_git_repository_spec(self, git_dir):
+        """Infer GitRepositorySpec from a local git repository."""
+        git_text = self.check_run(git_dir, "remote -v")
+        remote_urls = {
+            match.group(1): match.group(2)
+            for match in re.finditer(r"(\w+)\s+(\S+)\s+\(fetch\)", git_text)
+        }
+        origin_url = remote_urls.get("origin")
+        if not origin_url:
+            raise_and_log_error(
+                UnexpectedError('{0} has no remote "origin"'.format(git_dir))
+            )
+        return GitRepositorySpec(
+            os.path.basename(git_dir),
+            git_dir=git_dir,
+            origin=origin_url,
+            upstream=remote_urls.get("upstream"),
+        )
+
+    def collect_repository_summary(self, git_dir, start_commit_id=None):
+        """Collects RepositorySummary from local repository directory up to the
+            latest tag commit.
+
+        Args:
+          start_commit_id [string]: If start_commit_id is provided then return
+              commit messages from it until the latest tag, inclusive.
+        """
+        start_time = time.time()
+        logging.debug("Begin analyzing %s", git_dir)
+
+        head_commit_id = self.query_local_repository_commit_id(git_dir)
+
+        tag, tag_commit_id = self.find_newest_tag_and_common_commit_from_id(
+            git_dir, head_commit_id
+        )
+
+        msgs = []
+        if start_commit_id != None:
+            msgs = self.query_local_repository_commits_between_two_commit_ids(
+                git_dir, start_commit_id, tag_commit_id
+            )
+
+        tag_semver = SemanticVersion.make(tag)
+
+        total_ms = int((time.time() - start_time) * 1000)
+        logging.debug("Finished analyzing %s in %d ms", git_dir, total_ms)
+        return RepositorySummary(tag_commit_id, tag, tag_semver.to_version(), msgs)
+
+    def delete_local_branch_if_exists(self, git_dir, branch):
+        """Delete the branch from git_dir if one exists.
+
+        This will fail if the branch exists and the git_dir is currently in it.
+        """
+        result = self.check_run(git_dir, "branch -l")
+        branches = []
+        for elem in result.split("\n"):
+            if elem.startswith("*"):
+                elem = elem[1:].strip()
+            branches.append(elem)
+
+        if branch in branches:
+            logging.info("Deleting existing branch %s from %s", branch, git_dir)
+            self.check_run(git_dir, "branch -D " + branch)
+            return
+
+    def initiate_github_pull_request(self, git_dir, message, base="master", head=None):
+        """Initialize a pull request for the given commit on the given branch.
+
+        Args:
+          git_dir: [path] The local repository to initiate the pull request with.
+          message: [string] The pull request message. If this is multiple lines
+             then the first line will be the title, subsequent lines will
+             be the PR description.
+          base: [string] The base reference for the pull request.
+             The default is master, but this could be a BRANCH or OWNER:BRANCH
+          head: [string] The branch to use for the pull request. By default this
+             is the current branch state of the the git_dir repository. This
+             too can be BRANCH or OWNER:BRANCH. This branch must have alraedy been
+             pushed to the origin repository -- not the local repository.
+        """
+        options = self.options
+        message = message.strip()
+        if options.pr_notify_list:
+            message.append("\n\n@" + ", @".join(",".split(options.pr_notify_list)))
+
+        hub_args = []
+        if base:
+            hub_args.extend(["-b", base])
+        if head:
+            hub_args.extend(["-h", head])
+
+        if options.git_never_push:
+            logging.warning(
+                "SKIP creating pull request because --git_never_push=true."
+                "\nCommand would have been: %s",
+                'git -C "{dir}" pull-request {args} -m {msg!r}'.format(
+                    dir=git_dir, args=" ".join(hub_args), msg=message
+                ),
+            )
+            return
+
+        message_path = None
+        if message.find("\n") < 0:
+            hub_args.extend(["-m", message])
+        else:
+            fd, message_path = tempfile.mkstemp(prefix="hubmsg")
+            os.write(fd, message)
+            os.close(fd)
+            hub_args.extend(["-F", message_path])
+
+        logging.info(
+            "Initiating pull request in %s from %s to %s with message:\n%s",
+            git_dir,
+            base,
+            head if head else "<current branch>",
+            message,
+        )
+
+        try:
+            kwargs = {}
+            self.__inject_auth(kwargs)
+            output = check_subprocess(
+                'hub -C "{dir}" pull-request {args}'.format(
+                    dir=git_dir, args=" ".join(hub_args)
+                ),
+                **kwargs
+            )
+            logging.info(output)
+        finally:
+            if message_path:
+                os.remove(message_path)

--- a/dev/buildtool/git_support.py
+++ b/dev/buildtool/git_support.py
@@ -277,11 +277,6 @@ class CommitTag(
     version = LooseVersion(tag)
     return CommitTag(line_id, tag, version)
 
-  @staticmethod
-  def compare_tags(first, second):
-    """Comparator for instances compares the lexical order of the tags."""
-    return cmp(first.version, second.version)
-
   # pylint: disable=multiple-statements
   def __cmp__(self, other): return self.version.__cmp__(other.version)
   def __lt__(self, other): return self.version < other.version

--- a/dev/buildtool/gradle_support.py
+++ b/dev/buildtool/gradle_support.py
@@ -20,467 +20,547 @@ import os
 import re
 
 try:
-  from urllib2 import urlopen, Request
-  from urllib2 import HTTPError
+    from urllib2 import urlopen, Request
+    from urllib2 import HTTPError
 except ImportError:
-  from urllib.request import urlopen, Request
-  from urllib.error import HTTPError
+    from urllib.request import urlopen, Request
+    from urllib.error import HTTPError
 
 from buildtool import (
     RepositoryCommandFactory,
     RepositoryCommandProcessor,
     GitRunner,
-
     add_parser_argument,
     check_subprocesses_to_logfile,
     raise_and_log_error,
     exception_to_message,
     ConfigError,
-    ResponseError)
+    ResponseError,
+)
 
 
 class GradleMetricsUpdater(object):
-  """Collect gradle metrics, focusing on characterizing failures."""
+    """Collect gradle metrics, focusing on characterizing failures."""
 
-  def __init__(
-      self, metrics_repository, spinnaker_repository, gradle_context_name):
-    self.__metrics = metrics_repository
-    self.__name = spinnaker_repository.name
-    self.__context = gradle_context_name
+    def __init__(self, metrics_repository, spinnaker_repository, gradle_context_name):
+        self.__metrics = metrics_repository
+        self.__name = spinnaker_repository.name
+        self.__context = gradle_context_name
 
-  def __call__(self, retcode, output):
-    """Update metrics considering the final return code and process output."""
-    labels = self.determine_labels(retcode, output)
-    return self.__metrics.inc_counter('GradleOutcome', labels)
+    def __call__(self, retcode, output):
+        """Update metrics considering the final return code and process output."""
+        labels = self.determine_labels(retcode, output)
+        return self.__metrics.inc_counter("GradleOutcome", labels)
 
-  def __extract_task_failure(self, output):
-    """Extract the task failure, if any."""
-    summary_match = re.search(
-        "Execution failed for task '(.+)'.*\n", output, re.MULTILINE)
-    if not summary_match:
-      return None, None
+    def __extract_task_failure(self, output):
+        """Extract the task failure, if any."""
+        summary_match = re.search(
+            "Execution failed for task '(.+)'.*\n", output, re.MULTILINE
+        )
+        if not summary_match:
+            return None, None
 
-    failed_task = summary_match.group(1)
-    remainder = output[summary_match.end(0):]
-    first_line = remainder[:remainder.find('\n')]
-    logging.debug('Instrumenting failure after stdout[%d..%d]: first_line="%s"',
-                  summary_match.start(0), summary_match.end(0), first_line)
-    return failed_task, first_line
+        failed_task = summary_match.group(1)
+        remainder = output[summary_match.end(0) :]
+        first_line = remainder[: remainder.find("\n")]
+        logging.debug(
+            'Instrumenting failure after stdout[%d..%d]: first_line="%s"',
+            summary_match.start(0),
+            summary_match.end(0),
+            first_line,
+        )
+        return failed_task, first_line
 
-  def extract_failure_summary(self, retcode, output):
-    """Determine the top level failure message from gradle."""
-    if not retcode:
-      return None, None
-    task, first_line = self.__extract_task_failure(output)
-    if task is not None:
-      return task, first_line
-    errno_match = re.search("error=", output)
-    if errno_match:
-      return 'unknown-task', errno_match.group(0)
-    return 'unknown-task', 'unknown-error'
+    def extract_failure_summary(self, retcode, output):
+        """Determine the top level failure message from gradle."""
+        if not retcode:
+            return None, None
+        task, first_line = self.__extract_task_failure(output)
+        if task is not None:
+            return task, first_line
+        errno_match = re.search("error=", output)
+        if errno_match:
+            return "unknown-task", errno_match.group(0)
+        return "unknown-task", "unknown-error"
 
-  def determine_labels(self, retcode, output):
-    """Determine label bindings for this outcome."""
-    labels = {
-        'repository': self.__name,
-        'context': self.__context,
-        'success': retcode == 0,
-        'failed_task': '',
-        'failed_by': '',
-        'failed_reason': ''
-    }
-    if retcode == 0:
-      return labels
+    def determine_labels(self, retcode, output):
+        """Determine label bindings for this outcome."""
+        labels = {
+            "repository": self.__name,
+            "context": self.__context,
+            "success": retcode == 0,
+            "failed_task": "",
+            "failed_by": "",
+            "failed_reason": "",
+        }
+        if retcode == 0:
+            return labels
 
-    failed_task, summary_line = self.extract_failure_summary(retcode, output)
-    self.update_failure_cause(labels, failed_task, summary_line)
+        failed_task, summary_line = self.extract_failure_summary(retcode, output)
+        self.update_failure_cause(labels, failed_task, summary_line)
 
-    return labels
+        return labels
 
-  def __update_http_failure_cause(self, labels, summary_line):
-    """Figure out the labels from the failure summary line."""
-    # This is an example of an error (wrapped from one to multiple lines
-    # for readability here. The ...jar was a long path to the bintray jar.
-    #
-    # > Could not upload to \
-    # 'https://api.bintray.com/content/...jar': HTTP/1.1 409 Conflict \
-    # [message:Unable to upload files: An artifact with the path \
-    # 'com/netflix/spinnaker/echo/echo-core/1.542.0/echo-core-1.542.0.jar' \
-    # already exists]
+    def __update_http_failure_cause(self, labels, summary_line):
+        """Figure out the labels from the failure summary line."""
+        # This is an example of an error (wrapped from one to multiple lines
+        # for readability here. The ...jar was a long path to the bintray jar.
+        #
+        # > Could not upload to \
+        # 'https://api.bintray.com/content/...jar': HTTP/1.1 409 Conflict \
+        # [message:Unable to upload files: An artifact with the path \
+        # 'com/netflix/spinnaker/echo/echo-core/1.542.0/echo-core-1.542.0.jar' \
+        # already exists]
 
-    summary_match = re.match(
-        r"[> ]*(.*?)'(.+?)': HTTP/[0-9\.]+ ([0-9]{3}) ([\w]+)(.*)",
-        summary_line)
-    if not summary_match:
-      return False
+        summary_match = re.match(
+            r"[> ]*(.*?)'(.+?)': HTTP/[0-9\.]+ ([0-9]{3}) ([\w]+)(.*)", summary_line
+        )
+        if not summary_match:
+            return False
 
-    # abstract = summary_match.group(1)
-    thing = summary_match.group(2)
-    abstract_http = summary_match.group(3)
-    # abstract_category = summary_match.group(4)
-    if thing.find('bintray.com') >= 0:
-      logging.debug('Counting another bintray failure.')
-      labels['failed_by'] = 'bintray'
-    labels['failed_reason'] = abstract_http
-    return True
+        # abstract = summary_match.group(1)
+        thing = summary_match.group(2)
+        abstract_http = summary_match.group(3)
+        # abstract_category = summary_match.group(4)
+        if thing.find("bintray.com") >= 0:
+            logging.debug("Counting another bintray failure.")
+            labels["failed_by"] = "bintray"
+        labels["failed_reason"] = abstract_http
+        return True
 
-  def __update_error_failure_cause(self, labels, summary_line):
-    errno_match = re.match(
-        r".*error='(.+?)' \(errno=(\d+)\).*",
-        summary_line)
-    if errno_match:
-      cause = errno_match.group(1)
-      errno = errno_match.group(2)
-      logging.debug('FAILED errno=%s cause="%s"'
-                    '\nSUMMARY=%s', errno, cause, summary_line)
-      labels['failed_by'] = 'other_runtime'
-      labels['failed_reason'] = cause
+    def __update_error_failure_cause(self, labels, summary_line):
+        errno_match = re.match(r".*error='(.+?)' \(errno=(\d+)\).*", summary_line)
+        if errno_match:
+            cause = errno_match.group(1)
+            errno = errno_match.group(2)
+            logging.debug(
+                'FAILED errno=%s cause="%s"' "\nSUMMARY=%s", errno, cause, summary_line
+            )
+            labels["failed_by"] = "other_runtime"
+            labels["failed_reason"] = cause
 
-    return False
+        return False
 
-  def update_failure_cause(self, labels, failed_task, summary_line):
-    """Figure out the labels from the failure summary line."""
+    def update_failure_cause(self, labels, failed_task, summary_line):
+        """Figure out the labels from the failure summary line."""
 
-    labels['failed_task'] = failed_task
-    labels['failed_by'] = 'unknown'
-    labels['failed_reason'] = 'unknown'
-    if self.__update_http_failure_cause(labels, summary_line):
-      return
-    if self.__update_error_failure_cause(labels, summary_line):
-      return
-    logging.error('Cannot interpret cause of failure:\n%s', summary_line)
-    return
-
+        labels["failed_task"] = failed_task
+        labels["failed_by"] = "unknown"
+        labels["failed_reason"] = "unknown"
+        if self.__update_http_failure_cause(labels, summary_line):
+            return
+        if self.__update_error_failure_cause(labels, summary_line):
+            return
+        logging.error("Cannot interpret cause of failure:\n%s", summary_line)
+        return
 
 
 class GradleRunner(object):
-  """Helper module for running gradle."""
+    """Helper module for running gradle."""
 
-  __GRADLE_PUBLISH_FILE = os.path.join("gradle", "init-publish.gradle")
+    __GRADLE_PUBLISH_FILE = os.path.join("gradle", "init-publish.gradle")
 
-  @staticmethod
-  def add_parser_args(parser, defaults):
-    """Add parser arguments for gradle."""
-    if hasattr(parser, 'added_gradle_runner'):
-      return
-    parser.added_gradle_runner = True
+    @staticmethod
+    def add_parser_args(parser, defaults):
+        """Add parser arguments for gradle."""
+        if hasattr(parser, "added_gradle_runner"):
+            return
+        parser.added_gradle_runner = True
 
-    add_parser_argument(
-        parser, 'bintray_jar_repository', defaults, None,
-        help='bintray repository in the bintray_org to publish jar files into.')
-    add_parser_argument(
-        parser, 'gradle_cache_path', defaults,
-        '{home}/.gradle'.format(home=os.environ['HOME'])
-        if os.environ.get('HOME') else None,
-        help='Path to a gradle cache directory to use for the builds.')
-    add_parser_argument(
-        parser, 'gradle_network_timeout_secs', defaults, 60,
-        help='Seconds to configure gradle timeouts (e.g. with bintray).')
-    add_parser_argument(
-        parser, 'maven_custom_init_file', defaults,
-        os.path.join(os.path.dirname(__file__), '..', 'maven-init.gradle'),
-        help='Path to a gradle init file to add to the debian builds.'
-        ' Used to specify any custom behavior in the gradle builds.'
-        ' Argument is a file path relative to the directory this script is'
-        ' executed in.'
-        ' The default value assumes we run this script from the parent'
-        ' directory of spinnaker/buildtool.')
+        add_parser_argument(
+            parser,
+            "bintray_jar_repository",
+            defaults,
+            None,
+            help="bintray repository in the bintray_org to publish jar files into.",
+        )
+        add_parser_argument(
+            parser,
+            "gradle_cache_path",
+            defaults,
+            "{home}/.gradle".format(home=os.environ["HOME"])
+            if os.environ.get("HOME")
+            else None,
+            help="Path to a gradle cache directory to use for the builds.",
+        )
+        add_parser_argument(
+            parser,
+            "gradle_network_timeout_secs",
+            defaults,
+            60,
+            help="Seconds to configure gradle timeouts (e.g. with bintray).",
+        )
+        add_parser_argument(
+            parser,
+            "maven_custom_init_file",
+            defaults,
+            os.path.join(os.path.dirname(__file__), "..", "maven-init.gradle"),
+            help="Path to a gradle init file to add to the debian builds."
+            " Used to specify any custom behavior in the gradle builds."
+            " Argument is a file path relative to the directory this script is"
+            " executed in."
+            " The default value assumes we run this script from the parent"
+            " directory of spinnaker/buildtool.",
+        )
 
-  @property
-  def source_code_manager(self):
-    """Return bound source code manager."""
-    return self.__scm
+    @property
+    def source_code_manager(self):
+        """Return bound source code manager."""
+        return self.__scm
 
-  def __init__(self, options, scm, metrics):
-    self.__options = options
-    self.__metrics = metrics
-    self.__git = GitRunner(options)
-    self.__scm = scm
+    def __init__(self, options, scm, metrics):
+        self.__options = options
+        self.__metrics = metrics
+        self.__git = GitRunner(options)
+        self.__scm = scm
 
-  def __to_bintray_url(self, repo, package_name, repository, build_version):
-    """Return the url for the desired versioned repository in bintray repo."""
-    bintray_path = (
-        'packages/{subject}/{repo}/{package}/versions/{version}'.format(
+    def __to_bintray_url(self, repo, package_name, repository, build_version):
+        """Return the url for the desired versioned repository in bintray repo."""
+        bintray_path = "packages/{subject}/{repo}/{package}/versions/{version}".format(
             subject=self.__options.bintray_org,
-            package=package_name, repo=repo, version=build_version))
-    return 'https://api.bintray.com/' + bintray_path
+            package=package_name,
+            repo=repo,
+            version=build_version,
+        )
+        return "https://api.bintray.com/" + bintray_path
 
-  def __add_bintray_auth_header(self, request):
-    """Adds bintray authentication header to the request."""
-    user = os.environ['BINTRAY_USER']
-    password = os.environ['BINTRAY_KEY']
-    encoded_auth = base64.b64encode('{user}:{password}'.format(user=user, password=password))
-    request.add_header('Authorization', 'Basic ' + bytes.decode(encoded_auth))
+    def __add_bintray_auth_header(self, request):
+        """Adds bintray authentication header to the request."""
+        user = os.environ["BINTRAY_USER"]
+        password = os.environ["BINTRAY_KEY"]
+        encoded_auth = base64.b64encode(
+            "{user}:{password}".format(user=user, password=password)
+        )
+        request.add_header("Authorization", "Basic " + bytes.decode(encoded_auth))
 
-  def bintray_repo_has_version(self, repo, package_name, repository,
-                               build_version):
-    """See if the given bintray repository has the package version to build."""
-    try:
-      bintray_url = self.__to_bintray_url(repo, package_name, repository,
-                                          build_version)
-      logging.debug('Checking for %s', bintray_url)
-      request = Request(url=bintray_url)
-      self.__add_bintray_auth_header(request)
-      urlopen(request)
-      return True
-    except HTTPError as ex:
-      if ex.code == 404:
+    def bintray_repo_has_version(self, repo, package_name, repository, build_version):
+        """See if the given bintray repository has the package version to build."""
+        try:
+            bintray_url = self.__to_bintray_url(
+                repo, package_name, repository, build_version
+            )
+            logging.debug("Checking for %s", bintray_url)
+            request = Request(url=bintray_url)
+            self.__add_bintray_auth_header(request)
+            urlopen(request)
+            return True
+        except HTTPError as ex:
+            if ex.code == 404:
+                return False
+            raise_and_log_error(
+                ResponseError("Bintray failure: {}".format(ex), server="bintray.check"),
+                "Failed on url=%s: %s" % (bintray_url, exception_to_message(ex)),
+            )
+        except Exception as ex:
+            raise
+
+    def consider_debian_on_bintray(self, repository, build_version):
+        """Check whether desired version already exists on bintray."""
+        options = self.__options
+        exists = []
+        missing = []
+
+        # technically we publish to both maven and debian repos.
+        # we can be in a state where we are in one but not the other.
+        # let's not worry about this for now.
+        for bintray_repo in [options.bintray_debian_repository]:  # ,
+            #                         options.bintray_jar_repository]:
+            package_name = repository.name
+            if bintray_repo == options.bintray_debian_repository:
+                if package_name == "spinnaker-monitoring":
+                    package_name = "spinnaker-monitoring-daemon"
+                elif not package_name.startswith("spinnaker"):
+                    package_name = "spinnaker-" + package_name
+            if self.bintray_repo_has_version(
+                bintray_repo, package_name, repository, build_version
+            ):
+                exists.append(bintray_repo)
+            else:
+                missing.append(bintray_repo)
+
+        if exists:
+            if options.skip_existing:
+                if missing:
+                    raise_and_log_error(
+                        ConfigError(
+                            "Have {name} version for {exists} but not {missing}".format(
+                                name=repository.name,
+                                exists=exists[0],
+                                missing=missing[0],
+                            )
+                        )
+                    )
+                logging.info("Already have %s -- skipping build", repository.name)
+                labels = {"repository": repository.name, "artifact": "debian"}
+                self.__metrics.inc_counter("ReuseArtifact", labels)
+                return True
+
+            if options.delete_existing:
+                for repo in exists:
+                    self.bintray_repo_delete_version(
+                        repo, package_name, repository, build_version=build_version
+                    )
+            else:
+                raise_and_log_error(
+                    ConfigError(
+                        "Already have debian for {name}".format(name=repository.name)
+                    )
+                )
         return False
-      raise_and_log_error(
-          ResponseError('Bintray failure: {}'.format(ex),
-                        server='bintray.check'),
-          'Failed on url=%s: %s' % (bintray_url, exception_to_message(ex)))
-    except Exception as ex:
-      raise
 
+    def bintray_repo_delete_version(
+        self, repo, package_name, repository, build_version=None
+    ):
+        """Delete the given bintray repository version if it exsts."""
+        try:
+            bintray_url = self.__to_bintray_url(
+                repo, package_name, repository, build_version
+            )
+            logging.debug("Checking for %s", bintray_url)
+            request = Request(url=bintray_url)
+            request.get_method = lambda: "DELETE"
+            self.__add_bintray_auth_header(request)
 
-  def consider_debian_on_bintray(self, repository, build_version):
-    """Check whether desired version already exists on bintray."""
-    options = self.__options
-    exists = []
-    missing = []
+            labels = {"repo": repo, "repository": repository.name, "artifact": "debian"}
+            self.__metrics.count_call("DeleteArtifact", labels, urlopen, request)
+            return True
+        except HTTPError as ex:
+            if ex.code == 404:
+                return True
+            raise_and_log_error(
+                ResponseError(
+                    "Bintray failure: {}".format(ex), server="bintray.delete"
+                ),
+                "Failed on url=%s: %s" % (bintray_url, exception_to_message(ex)),
+            )
 
-    # technically we publish to both maven and debian repos.
-    # we can be in a state where we are in one but not the other.
-    # let's not worry about this for now.
-    for bintray_repo in [options.bintray_debian_repository]:#,
-#                         options.bintray_jar_repository]:
-      package_name = repository.name
-      if bintray_repo == options.bintray_debian_repository:
-        if package_name == 'spinnaker-monitoring':
-          package_name = 'spinnaker-monitoring-daemon'
-        elif not package_name.startswith('spinnaker'):
-          package_name = 'spinnaker-' + package_name
-      if self.bintray_repo_has_version(
-          bintray_repo, package_name, repository, build_version):
-        exists.append(bintray_repo)
-      else:
-        missing.append(bintray_repo)
+    def get_common_args(self):
+        """Return standard gradle args."""
+        options = self.__options
+        args = [
+            "--stacktrace",
+            "--info",
+        ]
 
-    if exists:
-      if options.skip_existing:
-        if missing:
-          raise_and_log_error(
-              ConfigError('Have {name} version for {exists} but not {missing}'
-                          .format(name=repository.name,
-                                  exists=exists[0], missing=missing[0])))
-        logging.info('Already have %s -- skipping build', repository.name)
-        labels = {'repository': repository.name, 'artifact': 'debian'}
-        self.__metrics.inc_counter('ReuseArtifact', labels)
-        return True
+        if options.maven_custom_init_file:
+            # Note, this was only debians
+            args.append("-I {}".format(options.maven_custom_init_file))
 
-      if options.delete_existing:
-        for repo in exists:
-          self.bintray_repo_delete_version(repo, package_name, repository,
-                                           build_version=build_version)
-      else:
-        raise_and_log_error(
-            ConfigError('Already have debian for {name}'.format(
-                name=repository.name)))
-    return False
+        return args
 
-  def bintray_repo_delete_version(self, repo, package_name, repository,
-                                  build_version=None):
-    """Delete the given bintray repository version if it exsts."""
-    try:
-      bintray_url = self.__to_bintray_url(repo, package_name, repository,
-                                          build_version)
-      logging.debug('Checking for %s', bintray_url)
-      request = Request(url=bintray_url)
-      request.get_method = lambda: 'DELETE'
-      self.__add_bintray_auth_header(request)
+    def get_debian_args(self, distribution):
+        """Return the debian args for the given distribution name."""
+        bintray_key = os.environ["BINTRAY_KEY"]
+        bintray_user = os.environ["BINTRAY_USER"]
+        options = self.__options
+        bintray_org = options.bintray_org
+        jar_repo = options.bintray_jar_repository
+        debian_repo = options.bintray_debian_repository
+        publish_wait_secs = options.bintray_publish_wait_secs
 
-      labels = {
-          'repo': repo,
-          'repository': repository.name,
-          'artifact': 'debian'
-      }
-      self.__metrics.count_call(
-          'DeleteArtifact', labels, urlopen, request)
-      return True
-    except HTTPError as ex:
-      if ex.code == 404:
-        return True
-      raise_and_log_error(
-          ResponseError('Bintray failure: {}'.format(ex),
-                        server='bintray.delete'),
-          'Failed on url=%s: %s' % (bintray_url, exception_to_message(ex)))
+        args = [
+            '-PbintrayOrg="{org}"'.format(org=bintray_org),
+            '-PbintrayPackageRepo="{repo}"'.format(repo=debian_repo),
+            '-PbintrayJarRepo="{jarRepo}"'.format(jarRepo=jar_repo),
+            '-PbintrayKey="{key}"'.format(key=bintray_key),
+            '-PbintrayUser="{user}"'.format(user=bintray_user),
+            "-PbintrayPackageDebDistribution={distribution}".format(
+                distribution=distribution
+            ),
+            "-PbintrayPublishWaitForSecs={publishWaitSecs}".format(
+                publishWaitSecs=publish_wait_secs
+            ),
+        ]
 
-  def get_common_args(self):
-    """Return standard gradle args."""
-    options = self.__options
-    args = [
-        '--stacktrace',
-        '--info',
-    ]
+        return args
 
-    if options.maven_custom_init_file:
-      # Note, this was only debians
-      args.append('-I {}'.format(options.maven_custom_init_file))
+    def check_run(
+        self,
+        args,
+        command_processor,
+        repository,
+        target,
+        context,
+        version,
+        build_number,
+        gradle_dir=None,
+    ):
+        """Run the gradle command on the given repository."""
+        gradle_dir = gradle_dir or repository.git_dir
 
-    return args
+        if self.__has_init_publish_file(repository):
+            args.extend(["-I", self.__GRADLE_PUBLISH_FILE])
 
-  def get_debian_args(self, distribution):
-    """Return the debian args for the given distribution name."""
-    bintray_key = os.environ['BINTRAY_KEY']
-    bintray_user = os.environ['BINTRAY_USER']
-    options = self.__options
-    bintray_org = options.bintray_org
-    jar_repo = options.bintray_jar_repository
-    debian_repo = options.bintray_debian_repository
-    publish_wait_secs = options.bintray_publish_wait_secs
+        if self.__is_plugin_version_6(repository):
+            args.extend(["-Pversion=%s-%s" % (version, build_number)])
+        else:
+            args.append("-Prelease.useLastTag=true")
+            build_number = self.prepare_local_git_for_nebula(
+                gradle_dir, repository, version=version, build_number=build_number
+            )
 
-    args = [
-        '-PbintrayOrg="{org}"'.format(org=bintray_org),
-        '-PbintrayPackageRepo="{repo}"'.format(repo=debian_repo),
-        '-PbintrayJarRepo="{jarRepo}"'.format(jarRepo=jar_repo),
-        '-PbintrayKey="{key}"'.format(key=bintray_key),
-        '-PbintrayUser="{user}"'.format(user=bintray_user),
-        '-PbintrayPackageDebDistribution={distribution}'.format(
-            distribution=distribution),
-        '-PbintrayPublishWaitForSecs={publishWaitSecs}'.format(
-            publishWaitSecs=publish_wait_secs)
-    ]
+        full_args = list(args)
+        full_args.append("-PbintrayPackageBuildNumber=%s" % build_number)
 
-    return args
+        # This gradle options wasnt introduced until 4.10.2
+        timeout = self.__options.gradle_network_timeout_secs * 1000
+        if timeout:
+            full_args.append("-Dorg.gradle.internal.http.socketTimeout=%d" % timeout)
+            full_args.append(
+                "-Dorg.gradle.internal.http.connectionTimeout=%d" % timeout
+            )
 
-  def check_run(self, args, command_processor, repository, target, context,
-      version, build_number, gradle_dir=None):
-    """Run the gradle command on the given repository."""
-    gradle_dir = gradle_dir or repository.git_dir
+        name = repository.name
+        logfile = command_processor.get_logfile_path(name + "-" + context)
+        cmd = "./gradlew {args} {target}".format(
+            args=" ".join(full_args), target=target
+        )
 
-    if self.__has_init_publish_file(repository):
-      args.extend(['-I', self.__GRADLE_PUBLISH_FILE])
+        labels = {"repository": repository.name, "context": context, "target": target}
+        self.__metrics.time_call(
+            "GradleBuild",
+            labels,
+            self.__metrics.default_determine_outcome_labels,
+            check_subprocesses_to_logfile,
+            name + " gradle " + context,
+            logfile,
+            [cmd],
+            cwd=gradle_dir,
+            postprocess_hook=GradleMetricsUpdater(self.__metrics, repository, target),
+        )
 
-    if self.__is_plugin_version_6(repository):
-      args.extend(['-Pversion=%s-%s' % (version, build_number)])
-    else:
-      args.append('-Prelease.useLastTag=true')
-      build_number = self.prepare_local_git_for_nebula(
-          gradle_dir, repository, version=version, build_number=build_number)
+    def __is_plugin_version_6(self, repository):
+        return (
+            not self.__has_init_publish_file(repository)
+            and not repository.name == "spinnaker-monitoring"
+        )
 
-    full_args = list(args)
-    full_args.append('-PbintrayPackageBuildNumber=%s' % build_number)
+    def __has_init_publish_file(self, repository):
+        return os.path.isfile(
+            os.path.join(repository.git_dir, self.__GRADLE_PUBLISH_FILE)
+        )
 
-    # This gradle options wasnt introduced until 4.10.2
-    timeout = self.__options.gradle_network_timeout_secs * 1000
-    if timeout:
-      full_args.append('-Dorg.gradle.internal.http.socketTimeout=%d' % timeout)
-      full_args.append('-Dorg.gradle.internal.http.connectionTimeout=%d' % timeout)
+    def prepare_local_git_for_nebula(
+        self, gradle_dir, repository, version=None, build_number=None
+    ):
+        """Tag the repository with the version we want to build.
 
-    name = repository.name
-    logfile = command_processor.get_logfile_path(name + '-' + context)
-    cmd = './gradlew {args} {target}'.format(
-        args=' '.join(full_args), target=target)
+        Args:
+          version: optional version to tag with. If not provided then infer it.
+          gradle_dir: The dir to prepare if supplied
+        """
+        git_dir = gradle_dir or repository.git_dir
+        self.__scm.ensure_local_repository(repository)
+        self.__git.remove_all_non_version_tags(repository, git_dir=git_dir)
 
-    labels = {
-        'repository': repository.name,
-        'context': context,
-        'target': target
-    }
-    self.__metrics.time_call(
-        'GradleBuild', labels, self.__metrics.default_determine_outcome_labels,
-        check_subprocesses_to_logfile,
-        name + ' gradle ' + context, logfile, [cmd], cwd=gradle_dir,
-        postprocess_hook=GradleMetricsUpdater(self.__metrics,
-                                              repository, target))
+        if not build_number:
+            build_number = self.__scm.determine_build_number(repository)
+        # This doesn't really work because get_repository_service_build_version only
+        # exists in BomSourceCodeManager.
+        if not version:
+            build_version = self.__scm.get_repository_service_build_version(repository)
+        else:
+            build_version = "%s-%s" % (version, build_number)
 
-  def __is_plugin_version_6(self, repository):
-    return not self.__has_init_publish_file(
-        repository) and not repository.name == 'spinnaker-monitoring'
-
-  def __has_init_publish_file(self, repository):
-    return os.path.isfile(
-      os.path.join(repository.git_dir, self.__GRADLE_PUBLISH_FILE))
-
-  def prepare_local_git_for_nebula(
-      self, gradle_dir, repository, version=None, build_number=None):
-    """Tag the repository with the version we want to build.
-
-    Args:
-      version: optional version to tag with. If not provided then infer it.
-      gradle_dir: The dir to prepare if supplied
-    """
-    git_dir = gradle_dir or repository.git_dir
-    self.__scm.ensure_local_repository(repository)
-    self.__git.remove_all_non_version_tags(repository, git_dir=git_dir)
-
-    if not build_number:
-      build_number = self.__scm.determine_build_number(repository)
-    # This doesn't really work because get_repository_service_build_version only
-    # exists in BomSourceCodeManager.
-    if not version:
-      build_version = self.__scm.get_repository_service_build_version(
-          repository)
-    else:
-      build_version = '%s-%s' % (version, build_number)
-
-    logging.debug('Tagging repository %s with "%s" for nebula',
-                  git_dir, build_version)
-    self.__git.tag_head(git_dir, build_version)
-    return build_number
+        logging.debug(
+            'Tagging repository %s with "%s" for nebula', git_dir, build_version
+        )
+        self.__git.tag_head(git_dir, build_version)
+        return build_number
 
 
 class GradleCommandFactory(RepositoryCommandFactory):
-  """Base class for build commands using Gradle."""
-  # pylint: disable=too-few-public-methods
+    """Base class for build commands using Gradle."""
 
-  @staticmethod
-  def add_bom_parser_args(parser, defaults):
-    """Adds publishing arguments of interest to the BOM commands as well."""
-    if hasattr(parser, 'added_gradle_bom'):
-      return
-    parser.added_gradle_bom = True
+    # pylint: disable=too-few-public-methods
 
-    GradleCommandFactory.add_argument(
-        parser, 'bintray_org', defaults, None,
-        help='The bintray organization for the bintray_*_repositories.')
+    @staticmethod
+    def add_bom_parser_args(parser, defaults):
+        """Adds publishing arguments of interest to the BOM commands as well."""
+        if hasattr(parser, "added_gradle_bom"):
+            return
+        parser.added_gradle_bom = True
 
-    GradleCommandFactory.add_argument(
-        parser, 'bintray_debian_repository', defaults, None,
-        help='Repository in the --bintray_org to publish debians to.')
+        GradleCommandFactory.add_argument(
+            parser,
+            "bintray_org",
+            defaults,
+            None,
+            help="The bintray organization for the bintray_*_repositories.",
+        )
 
-    GradleCommandFactory.add_argument(
-        parser, 'bintray_publish_wait_secs', defaults, '0',
-        help='How many seconds to synchronously wait when publishing packages to'
-             'Bintray. When set to -1, wait the maximum time supported by the'
-             'server; when set to 0, publish asynchronously.')
+        GradleCommandFactory.add_argument(
+            parser,
+            "bintray_debian_repository",
+            defaults,
+            None,
+            help="Repository in the --bintray_org to publish debians to.",
+        )
 
+        GradleCommandFactory.add_argument(
+            parser,
+            "bintray_publish_wait_secs",
+            defaults,
+            "0",
+            help="How many seconds to synchronously wait when publishing packages to"
+            "Bintray. When set to -1, wait the maximum time supported by the"
+            "server; when set to 0, publish asynchronously.",
+        )
 
-  def init_argparser(self, parser, defaults):
-    """Adds command-specific arguments."""
-    super(GradleCommandFactory, self).init_argparser(parser, defaults)
-    GradleRunner.add_parser_args(parser, defaults)
-    self.add_bom_parser_args(parser, defaults)
+    def init_argparser(self, parser, defaults):
+        """Adds command-specific arguments."""
+        super(GradleCommandFactory, self).init_argparser(parser, defaults)
+        GradleRunner.add_parser_args(parser, defaults)
+        self.add_bom_parser_args(parser, defaults)
 
-    self.add_argument(
-        parser, 'skip_existing', defaults, False, type=bool,
-        help='Skip builds if the desired version already exists on bintray.')
+        self.add_argument(
+            parser,
+            "skip_existing",
+            defaults,
+            False,
+            type=bool,
+            help="Skip builds if the desired version already exists on bintray.",
+        )
 
-    self.add_argument(
-        parser, 'delete_existing', defaults, None, type=bool,
-        help='Delete pre-existing desired versions if from bintray.')
+        self.add_argument(
+            parser,
+            "delete_existing",
+            defaults,
+            None,
+            type=bool,
+            help="Delete pre-existing desired versions if from bintray.",
+        )
 
-    self.add_argument(
-        parser, 'max_local_builds', defaults, None, type=int,
-        help='Maximum build concurrency.')
+        self.add_argument(
+            parser,
+            "max_local_builds",
+            defaults,
+            None,
+            type=int,
+            help="Maximum build concurrency.",
+        )
 
-    self.add_argument(
-        parser, 'run_unit_tests', defaults, False, type=bool,
-        help='Run unit tests during build for all components other than Deck.')
+        self.add_argument(
+            parser,
+            "run_unit_tests",
+            defaults,
+            False,
+            type=bool,
+            help="Run unit tests during build for all components other than Deck.",
+        )
 
 
 class GradleCommandProcessor(RepositoryCommandProcessor):
-  """Base class for build commands using Gradle."""
-  # pylint: disable=too-few-public-methods
-  # pylint: disable=abstract-method
+    """Base class for build commands using Gradle."""
 
-  @property
-  def gradle(self):
-    """Return bound gradle runner."""
-    return self.__gradle
+    # pylint: disable=too-few-public-methods
+    # pylint: disable=abstract-method
 
-  def __init__(self, factory, options, **kwargs):
-    super(GradleCommandProcessor, self).__init__(factory, options, **kwargs)
-    self.__gradle = GradleRunner(options, self.source_code_manager,
-                                 self.metrics)
+    @property
+    def gradle(self):
+        """Return bound gradle runner."""
+        return self.__gradle
+
+    def __init__(self, factory, options, **kwargs):
+        super(GradleCommandProcessor, self).__init__(factory, options, **kwargs)
+        self.__gradle = GradleRunner(options, self.source_code_manager, self.metrics)

--- a/dev/buildtool/hal_support.py
+++ b/dev/buildtool/hal_support.py
@@ -32,125 +32,156 @@ import os
 import yaml
 
 try:
-  from urllib2 import urlopen, HTTPError
+    from urllib2 import urlopen, HTTPError
 except ImportError:
-  from urllib.request import urlopen
-  from urllib.error import HTTPError
+    from urllib.request import urlopen
+    from urllib.error import HTTPError
 
 from buildtool import (
     add_parser_argument,
     check_subprocess,
     raise_and_log_error,
     ConfigError,
-    ResponseError)
+    ResponseError,
+)
 
 
 class HalRunner(object):
-  """Encapsulates knowledge of administering halyard releases."""
+    """Encapsulates knowledge of administering halyard releases."""
 
-  @staticmethod
-  def add_parser_args(parser, defaults):
-    """Add parser arguments used to administer halyard."""
-    if hasattr(parser, 'added_halrunner'):
-      return
-    parser.added_halrunner = True
-    add_parser_argument(
-        parser, 'hal_path', defaults, '/usr/local/bin/hal',
-        help='Path to local Halyard "hal" CLI.')
-    add_parser_argument(
-        parser, 'halyard_daemon', defaults, 'localhost:8064',
-        help='Network location for halyard server.')
+    @staticmethod
+    def add_parser_args(parser, defaults):
+        """Add parser arguments used to administer halyard."""
+        if hasattr(parser, "added_halrunner"):
+            return
+        parser.added_halrunner = True
+        add_parser_argument(
+            parser,
+            "hal_path",
+            defaults,
+            "/usr/local/bin/hal",
+            help='Path to local Halyard "hal" CLI.',
+        )
+        add_parser_argument(
+            parser,
+            "halyard_daemon",
+            defaults,
+            "localhost:8064",
+            help="Network location for halyard server.",
+        )
 
-  @property
-  def options(self):
-    """Returns bound options."""
-    return self.__options
+    @property
+    def options(self):
+        """Returns bound options."""
+        return self.__options
 
-  def check_property(self, name, want):
-    """Check a configuration property meets our needs."""
-    have = self.__halyard_runtime_config[name]
-    if have == want:
-      logging.debug('Confirmed Halyard server is configured with %s="%s"',
-                    name, have)
-    else:
-      raise_and_log_error(
-          ConfigError(
-              'Halyard server is not configured to support this request.\n'
-              'It is using {name}={have!r} rather than {want!r}.\n'
-              'You will need to modify /opt/spinnaker/config/halyard-local.yml'
-              ' and restart the halyard server.'.format(
-                  name=name, have=have, want=want),
-              cause='config/halyard'))
+    def check_property(self, name, want):
+        """Check a configuration property meets our needs."""
+        have = self.__halyard_runtime_config[name]
+        if have == want:
+            logging.debug(
+                'Confirmed Halyard server is configured with %s="%s"', name, have
+            )
+        else:
+            raise_and_log_error(
+                ConfigError(
+                    "Halyard server is not configured to support this request.\n"
+                    "It is using {name}={have!r} rather than {want!r}.\n"
+                    "You will need to modify /opt/spinnaker/config/halyard-local.yml"
+                    " and restart the halyard server.".format(
+                        name=name, have=have, want=want
+                    ),
+                    cause="config/halyard",
+                )
+            )
 
-  def __init__(self, options):
-    self.__options = options
-    self.__hal_path = options.hal_path
+    def __init__(self, options):
+        self.__options = options
+        self.__hal_path = options.hal_path
 
-    logging.debug('Retrieving halyard runtime configuration.')
-    url = 'http://' + options.halyard_daemon + '/resolvedEnv'
-    try:
-      response = urlopen(url)
-    except HTTPError as error:
-      raise_and_log_error(
-          ResponseError(
-              '{url}: {code}\n{body}'.format(
-                  url=url, code=error.code, body=error.read()),
-              server='halyard'))
-    self.__halyard_runtime_config = yaml.safe_load(response)
+        logging.debug("Retrieving halyard runtime configuration.")
+        url = "http://" + options.halyard_daemon + "/resolvedEnv"
+        try:
+            response = urlopen(url)
+        except HTTPError as error:
+            raise_and_log_error(
+                ResponseError(
+                    "{url}: {code}\n{body}".format(
+                        url=url, code=error.code, body=error.read()
+                    ),
+                    server="halyard",
+                )
+            )
+        self.__halyard_runtime_config = yaml.safe_load(response)
 
-  def check_writer_enabled(self):
-    """Ensure halyard has writerEnabled true."""
-    self.check_property('spinnaker.config.input.writerEnabled', 'true')
+    def check_writer_enabled(self):
+        """Ensure halyard has writerEnabled true."""
+        self.check_property("spinnaker.config.input.writerEnabled", "true")
 
-  def check_run(self, command_line):
-    """Run hal with the supplied command_line."""
-    args = ' --color false --daemon-endpoint http://{daemon} '.format(
-        daemon=self.__options.halyard_daemon)
-    return check_subprocess(self.__hal_path + args + command_line)
+    def check_run(self, command_line):
+        """Run hal with the supplied command_line."""
+        args = " --color false --daemon-endpoint http://{daemon} ".format(
+            daemon=self.__options.halyard_daemon
+        )
+        return check_subprocess(self.__hal_path + args + command_line)
 
-  def publish_profile(self, component, profile_path, bom_path):
-    """Publish the profile for the given component for the given bom."""
-    logging.info('Publishing %s profile=%s for bom=%s',
-                 component, profile_path, bom_path)
-    self.check_run('admin publish profile ' + component
-                   + ' --bom-path ' + bom_path
-                   + ' --profile-path ' + profile_path)
+    def publish_profile(self, component, profile_path, bom_path):
+        """Publish the profile for the given component for the given bom."""
+        logging.info(
+            "Publishing %s profile=%s for bom=%s", component, profile_path, bom_path
+        )
+        self.check_run(
+            "admin publish profile "
+            + component
+            + " --bom-path "
+            + bom_path
+            + " --profile-path "
+            + profile_path
+        )
 
-  def publish_bom_path(self, path):
-    """Publish a bom path via halyard."""
-    logging.info('Publishing bom from %s', path)
-    self.check_run('admin publish bom --bom-path ' + os.path.abspath(path))
+    def publish_bom_path(self, path):
+        """Publish a bom path via halyard."""
+        logging.info("Publishing bom from %s", path)
+        self.check_run("admin publish bom --bom-path " + os.path.abspath(path))
 
-  def retrieve_bom_version(self, version):
-    """Retrieve the specified BOM version as a dict."""
-    logging.info('Getting bom version %s', version)
-    content = self.check_run('version bom ' + version + ' --quiet')
-    return yaml.safe_load(content)
+    def retrieve_bom_version(self, version):
+        """Retrieve the specified BOM version as a dict."""
+        logging.info("Getting bom version %s", version)
+        content = self.check_run("version bom " + version + " --quiet")
+        return yaml.safe_load(content)
 
-  def publish_halyard_release(self, release_version):
-    """Make release_version available as the latest version."""
-    logging.info('Publishing latest halyard version "%s"', release_version)
-    self.check_run('admin publish latest-halyard ' + release_version)
+    def publish_halyard_release(self, release_version):
+        """Make release_version available as the latest version."""
+        logging.info('Publishing latest halyard version "%s"', release_version)
+        self.check_run("admin publish latest-halyard " + release_version)
 
-  def deprecate_spinnaker_release(self, release_version):
-    """Deprecate release_version."""
-    logging.info('Deprecating Spinnaker version "%s"', release_version)
-    self.check_run('admin deprecate version --version ' + release_version)
+    def deprecate_spinnaker_release(self, release_version):
+        """Deprecate release_version."""
+        logging.info('Deprecating Spinnaker version "%s"', release_version)
+        self.check_run("admin deprecate version --version " + release_version)
 
-  def publish_spinnaker_release(
-      self, release_version, alias_name, changelog_uri, min_halyard_version,
-      latest=True):
-    """Release spinnaker version to halyard repository."""
-    logging.info('Publishing spinnaker version "%s" to halyard',
-                 release_version)
-    self.check_run('admin publish version --version "{version}"'
-                   ' --alias "{alias}" --changelog {changelog}'
-                   ' --minimum-halyard-version {halyard_version}'
-                   .format(version=release_version, alias=alias_name,
-                           changelog=changelog_uri,
-                           halyard_version=min_halyard_version))
-    if latest:
-      logging.info(
-          'Publishing spinnaker version "%s" as latest', release_version)
-      self.check_run('admin publish latest "{version}"'.format(
-          version=release_version))
+    def publish_spinnaker_release(
+        self,
+        release_version,
+        alias_name,
+        changelog_uri,
+        min_halyard_version,
+        latest=True,
+    ):
+        """Release spinnaker version to halyard repository."""
+        logging.info('Publishing spinnaker version "%s" to halyard', release_version)
+        self.check_run(
+            'admin publish version --version "{version}"'
+            ' --alias "{alias}" --changelog {changelog}'
+            " --minimum-halyard-version {halyard_version}".format(
+                version=release_version,
+                alias=alias_name,
+                changelog=changelog_uri,
+                halyard_version=min_halyard_version,
+            )
+        )
+        if latest:
+            logging.info('Publishing spinnaker version "%s" as latest', release_version)
+            self.check_run(
+                'admin publish latest "{version}"'.format(version=release_version)
+            )

--- a/dev/buildtool/halyard_commands.py
+++ b/dev/buildtool/halyard_commands.py
@@ -30,7 +30,6 @@ from buildtool import (
     DEFAULT_BUILD_NUMBER,
     SPINNAKER_IO_REPOSITORY_NAME,
     SPINNAKER_HALYARD_REPOSITORY_NAME,
-
     BranchSourceCodeManager,
     CommandProcessor,
     CommandFactory,
@@ -39,9 +38,7 @@ from buildtool import (
     GradleCommandProcessor,
     GradleRunner,
     HalRunner,
-
     SpinnakerSourceCodeManager,
-
     run_subprocess,
     check_subprocess,
     check_subprocesses_to_logfile,
@@ -49,506 +46,657 @@ from buildtool import (
     raise_and_log_error,
     write_to_path,
     ConfigError,
-    ExecutionError)
+    ExecutionError,
+)
 
 
 def build_halyard_docs(command, repository):
-  """Builds Halyard's CLI and updates documentation in its repo."""
-  cli_dir = os.path.join(repository.git_dir, 'halyard-cli')
+    """Builds Halyard's CLI and updates documentation in its repo."""
+    cli_dir = os.path.join(repository.git_dir, "halyard-cli")
 
-  # Before, we were doing this first:
-  # check_run_quick('git -C halyard rev-parse HEAD'
-  #                 ' | xargs git -C halyard checkout ;')
-  # however now the repository should already be at the desired commit.
-  logging.debug('Building Halyard CLI and docs.')
-  logfile = command.get_logfile_path('build-docs')
-  check_subprocesses_to_logfile(
-      'Build halyard docs', logfile, ['make'], cwd=cli_dir)
+    # Before, we were doing this first:
+    # check_run_quick('git -C halyard rev-parse HEAD'
+    #                 ' | xargs git -C halyard checkout ;')
+    # however now the repository should already be at the desired commit.
+    logging.debug("Building Halyard CLI and docs.")
+    logfile = command.get_logfile_path("build-docs")
+    check_subprocesses_to_logfile("Build halyard docs", logfile, ["make"], cwd=cli_dir)
 
 
 class BuildHalyardCommand(GradleCommandProcessor):
-  """Implements the build_halyard command."""
-  # pylint: disable=too-few-public-methods
+    """Implements the build_halyard command."""
 
-  HALYARD_VERSIONS_BASENAME = 'nightly-version-commits.yml'
+    # pylint: disable=too-few-public-methods
 
-  def __init__(self, factory, options, **kwargs):
-    options_copy = copy.copy(options)
-    options_copy.bom_path = None
-    options_copy.bom_version = None
-    self.__build_version = None  # recorded after build
-    self.__versions_url = options.halyard_version_commits_url
+    HALYARD_VERSIONS_BASENAME = "nightly-version-commits.yml"
 
-    if not self.__versions_url:
-      self.__versions_url = '{base}/{filename}'.format(
-          base=options.halyard_bucket_base_url,
-          filename=self.HALYARD_VERSIONS_BASENAME)
-    super(BuildHalyardCommand, self).__init__(
-        factory, options_copy,
-        source_repository_names=[SPINNAKER_HALYARD_REPOSITORY_NAME],
-        **kwargs)
+    def __init__(self, factory, options, **kwargs):
+        options_copy = copy.copy(options)
+        options_copy.bom_path = None
+        options_copy.bom_version = None
+        self.__build_version = None  # recorded after build
+        self.__versions_url = options.halyard_version_commits_url
 
-  def publish_halyard_version_commits(self, repository):
-    """Publish the halyard build to the bucket.
+        if not self.__versions_url:
+            self.__versions_url = "{base}/{filename}".format(
+                base=options.halyard_bucket_base_url,
+                filename=self.HALYARD_VERSIONS_BASENAME,
+            )
+        super(BuildHalyardCommand, self).__init__(
+            factory,
+            options_copy,
+            source_repository_names=[SPINNAKER_HALYARD_REPOSITORY_NAME],
+            **kwargs
+        )
 
-    This also writes the built version to
-        <output_dir>/halyard/last_version_commit.yml
-    so callers can know what version was written.
+    def publish_halyard_version_commits(self, repository):
+        """Publish the halyard build to the bucket.
 
-    NOTE(ewiseblatt): 20180110 Halyard's policies should be revisited here.
-    Although this is a "Publish" it is not a release. It is publishing
-    the 'nightly' build which isnt really nightly just 'last-build',
-    which could even be on an older branch than latest.
-    """
-    commit_id = self.source_code_manager.git.query_local_repository_commit_id(
-        repository.git_dir)
+        This also writes the built version to
+            <output_dir>/halyard/last_version_commit.yml
+        so callers can know what version was written.
 
-    # This is only because we need a file to gsutil cp
-    # We already need gsutil so its easier to just use it again here.
-    output_dir = self.get_output_dir()
-    tmp_path = os.path.join(output_dir, self.HALYARD_VERSIONS_BASENAME)
+        NOTE(ewiseblatt): 20180110 Halyard's policies should be revisited here.
+        Although this is a "Publish" it is not a release. It is publishing
+        the 'nightly' build which isnt really nightly just 'last-build',
+        which could even be on an older branch than latest.
+        """
+        commit_id = self.source_code_manager.git.query_local_repository_commit_id(
+            repository.git_dir
+        )
 
-    contents = self.load_halyard_version_commits()
-    new_entry = '{version}: {commit}\n'.format(
-        version=self.__build_version, commit=commit_id)
+        # This is only because we need a file to gsutil cp
+        # We already need gsutil so its easier to just use it again here.
+        output_dir = self.get_output_dir()
+        tmp_path = os.path.join(output_dir, self.HALYARD_VERSIONS_BASENAME)
 
-    logging.info('Updating %s with %s', self.__versions_url, new_entry)
-    if contents and contents[-1] != '\n':
-      contents += '\n'
-    contents = contents + new_entry
-    with open(tmp_path, 'w') as stream:
-      stream.write(contents)
-    check_subprocess('gsutil cp {path} {url}'.format(
-        path=tmp_path, url=self.__versions_url))
-    self.__emit_last_commit_entry(new_entry)
+        contents = self.load_halyard_version_commits()
+        new_entry = "{version}: {commit}\n".format(
+            version=self.__build_version, commit=commit_id
+        )
 
-  def __emit_last_commit_entry(self, entry):
-    last_version_commit_path = os.path.join(
-        self.get_output_dir(), 'last_version_commit.yml')
-    write_to_path(entry, last_version_commit_path)
+        logging.info("Updating %s with %s", self.__versions_url, new_entry)
+        if contents and contents[-1] != "\n":
+            contents += "\n"
+        contents = contents + new_entry
+        with open(tmp_path, "w") as stream:
+            stream.write(contents)
+        check_subprocess(
+            "gsutil cp {path} {url}".format(path=tmp_path, url=self.__versions_url)
+        )
+        self.__emit_last_commit_entry(new_entry)
 
-  def publish_to_nightly(self, repository):
-    options = self.options
-    cmd = './release/promote-all.sh {version} nightly'.format(
-        version=self.__build_version)
-    env = dict(os.environ)
-    env.update({
-        'PUBLISH_HALYARD_ARTIFACT_REGISTRY_IMAGE_BASE': options.halyard_artifact_registry_image_base,
-        'PUBLISH_HALYARD_BUCKET_BASE_URL': options.halyard_bucket_base_url,
-        'PUBLISH_HALYARD_DOCKER_IMAGE_BASE': options.halyard_docker_image_base
-    })
-    logging.info(
-        'Preparing the environment variables for release/all.sh:\n'
-        '    PUBLISH_HALYARD_ARTIFACT_REGISTRY_IMAGE_BASE=%s\n'
-        '    PUBLISH_HALYARD_DOCKER_IMAGE_BASE=%s\n'
-        '    PUBLISH_HALYARD_BUCKET_BASE_URL=%s',
-        options.halyard_artifact_registry_image_base,
-        options.halyard_docker_image_base,
-        options.halyard_bucket_base_url)
+    def __emit_last_commit_entry(self, entry):
+        last_version_commit_path = os.path.join(
+            self.get_output_dir(), "last_version_commit.yml"
+        )
+        write_to_path(entry, last_version_commit_path)
 
-    logfile = self.get_logfile_path('halyard-publish-to-nightly')
-    check_subprocesses_to_logfile(
-        'halyard publish to nightly', logfile,
-        [cmd], cwd=repository.git_dir, env=env)
+    def publish_to_nightly(self, repository):
+        options = self.options
+        cmd = "./release/promote-all.sh {version} nightly".format(
+            version=self.__build_version
+        )
+        env = dict(os.environ)
+        env.update(
+            {
+                "PUBLISH_HALYARD_ARTIFACT_REGISTRY_IMAGE_BASE": options.halyard_artifact_registry_image_base,
+                "PUBLISH_HALYARD_BUCKET_BASE_URL": options.halyard_bucket_base_url,
+                "PUBLISH_HALYARD_DOCKER_IMAGE_BASE": options.halyard_docker_image_base,
+            }
+        )
+        logging.info(
+            "Preparing the environment variables for release/all.sh:\n"
+            "    PUBLISH_HALYARD_ARTIFACT_REGISTRY_IMAGE_BASE=%s\n"
+            "    PUBLISH_HALYARD_DOCKER_IMAGE_BASE=%s\n"
+            "    PUBLISH_HALYARD_BUCKET_BASE_URL=%s",
+            options.halyard_artifact_registry_image_base,
+            options.halyard_docker_image_base,
+            options.halyard_bucket_base_url,
+        )
 
-  def build_all_halyard_deployments(self, repository):
-    """Helper function for building halyard."""
-    options = self.options
+        logfile = self.get_logfile_path("halyard-publish-to-nightly")
+        check_subprocesses_to_logfile(
+            "halyard publish to nightly",
+            logfile,
+            [cmd],
+            cwd=repository.git_dir,
+            env=env,
+        )
 
-    git_dir = repository.git_dir
-    summary = self.source_code_manager.git.collect_repository_summary(git_dir)
-    self.__build_version = '%s-%s' % (summary.version, options.build_number)
+    def build_all_halyard_deployments(self, repository):
+        """Helper function for building halyard."""
+        options = self.options
 
-    commands = [
-        self.gcloud_command(name='halyard-container-build',
-                            config_filename='containers.yml',
-                            git_dir=git_dir,
-                            substitutions={'TAG_NAME': self.__build_version,
-                                           '_ARTIFACT_REGISTRY': options.artifact_registry}),
-        self.gcloud_command(name='halyard-deb-build',
-                            config_filename='debs.yml',
-                            git_dir=git_dir,
-                            substitutions={'_VERSION': summary.version,
-                                           '_BUILD_NUMBER': options.build_number}),
-        self.gcloud_command(name='halyard-tar-build',
-                            config_filename='halyard-tars.yml',
-                            git_dir=git_dir,
-                            substitutions={'TAG_NAME': self.__build_version}),
-    ]
+        git_dir = repository.git_dir
+        summary = self.source_code_manager.git.collect_repository_summary(git_dir)
+        self.__build_version = "%s-%s" % (summary.version, options.build_number)
 
-    pool = ThreadPool(len(commands))
-    pool.map(self.run_gcloud_build, commands)
-    pool.close()
-    pool.join()
+        commands = [
+            self.gcloud_command(
+                name="halyard-container-build",
+                config_filename="containers.yml",
+                git_dir=git_dir,
+                substitutions={
+                    "TAG_NAME": self.__build_version,
+                    "_ARTIFACT_REGISTRY": options.artifact_registry,
+                },
+            ),
+            self.gcloud_command(
+                name="halyard-deb-build",
+                config_filename="debs.yml",
+                git_dir=git_dir,
+                substitutions={
+                    "_VERSION": summary.version,
+                    "_BUILD_NUMBER": options.build_number,
+                },
+            ),
+            self.gcloud_command(
+                name="halyard-tar-build",
+                config_filename="halyard-tars.yml",
+                git_dir=git_dir,
+                substitutions={"TAG_NAME": self.__build_version},
+            ),
+        ]
 
-  def gcloud_command(self, name, config_filename, git_dir, substitutions):
-    options = self.options
-    branch = options.git_branch
-    config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                               'cloudbuild', config_filename)
-    standard_substitutions = {'_BRANCH_NAME': branch,
-                              '_BRANCH_TAG': re.sub(r'\W', '_', branch),
-                              '_IMAGE_NAME': 'halyard'}
-    full_substitutions = dict(standard_substitutions, **substitutions)
-    # Convert it to the format expected by gcloud: "_FOO=bar,_BAZ=qux"
-    substitutions_arg = ','.join('='.join((str(k), str(v))) for k, v in
-                                 full_substitutions.items())
-    command = ('gcloud builds submit '
-               ' --account={account} --project={project}'
-               ' --substitutions={substitutions_arg},'
-               ' --config={config} .'
-               .format(account=options.gcb_service_account,
-                       project=options.gcb_project,
-                       substitutions_arg=substitutions_arg,
-                       config=config_path))
-    return {'name': name, 'git_dir': git_dir, 'command': command}
+        pool = ThreadPool(len(commands))
+        pool.map(self.run_gcloud_build, commands)
+        pool.close()
+        pool.join()
 
-  def run_gcloud_build(self, command):
-    logfile = self.get_logfile_path(command['name'])
-    self.metrics.time_call(
-        'GcrBuild', {}, self.metrics.default_determine_outcome_labels,
-        check_subprocesses_to_logfile,
-        command['name'], logfile, [command['command']],
-        cwd=command['git_dir'])
+    def gcloud_command(self, name, config_filename, git_dir, substitutions):
+        options = self.options
+        branch = options.git_branch
+        config_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "cloudbuild", config_filename
+        )
+        standard_substitutions = {
+            "_BRANCH_NAME": branch,
+            "_BRANCH_TAG": re.sub(r"\W", "_", branch),
+            "_IMAGE_NAME": "halyard",
+        }
+        full_substitutions = dict(standard_substitutions, **substitutions)
+        # Convert it to the format expected by gcloud: "_FOO=bar,_BAZ=qux"
+        substitutions_arg = ",".join(
+            "=".join((str(k), str(v))) for k, v in full_substitutions.items()
+        )
+        command = (
+            "gcloud builds submit "
+            " --account={account} --project={project}"
+            " --substitutions={substitutions_arg},"
+            " --config={config} .".format(
+                account=options.gcb_service_account,
+                project=options.gcb_project,
+                substitutions_arg=substitutions_arg,
+                config=config_path,
+            )
+        )
+        return {"name": name, "git_dir": git_dir, "command": command}
 
-  def load_halyard_version_commits(self):
-    logging.debug('Fetching existing halyard build versions')
-    retcode, stdout = run_subprocess('gsutil cat ' + self.__versions_url)
-    if not retcode:
-      contents = stdout + '\n'
-    else:
-      if stdout.find('No URLs matched') < 0:
-        raise_and_log_error(
-            ExecutionError('No URLs matched', program='gsutil'),
-            'Could not fetch "%s": %s' % (self.__versions_url, stdout))
-      contents = ''
-      logging.warning(
-          '%s did not exist. Creating a new one.', self.__versions_url)
-    return contents
+    def run_gcloud_build(self, command):
+        logfile = self.get_logfile_path(command["name"])
+        self.metrics.time_call(
+            "GcrBuild",
+            {},
+            self.metrics.default_determine_outcome_labels,
+            check_subprocesses_to_logfile,
+            command["name"],
+            logfile,
+            [command["command"]],
+            cwd=command["git_dir"],
+        )
 
-  def find_commit_version_entry(self, repository):
-    logging.debug('Looking for existing halyard version for this commit.')
-    if os.path.exists(repository.git_dir):
-      commit_id = self.git.query_local_repository_commit_id(repository.git_dir)
-    else:
-      commit_id = self.git.query_remote_repository_commit_id(
-          repository.origin, self.options.git_branch)
-    commits = self.load_halyard_version_commits().split('\n')
-    commits.reverse()
-    postfix = ' ' + commit_id
-    for line in commits:
-      if line.endswith(postfix):
-        return line
-    return None
+    def load_halyard_version_commits(self):
+        logging.debug("Fetching existing halyard build versions")
+        retcode, stdout = run_subprocess("gsutil cat " + self.__versions_url)
+        if not retcode:
+            contents = stdout + "\n"
+        else:
+            if stdout.find("No URLs matched") < 0:
+                raise_and_log_error(
+                    ExecutionError("No URLs matched", program="gsutil"),
+                    'Could not fetch "%s": %s' % (self.__versions_url, stdout),
+                )
+            contents = ""
+            logging.warning(
+                "%s did not exist. Creating a new one.", self.__versions_url
+            )
+        return contents
 
-  def _do_can_skip_repository(self, repository):
-    if self.options.skip_existing:
-      entry = self.find_commit_version_entry(repository)
-      if entry:
-        logging.info('Found existing halyard version "%s"', entry)
-        labels = {'repository': repository.name, 'artifact': 'halyard'}
-        self.metrics.inc_counter('ReuseArtifact', labels)
-        self.__emit_last_commit_entry(entry)
-        return True
-    return False
+    def find_commit_version_entry(self, repository):
+        logging.debug("Looking for existing halyard version for this commit.")
+        if os.path.exists(repository.git_dir):
+            commit_id = self.git.query_local_repository_commit_id(repository.git_dir)
+        else:
+            commit_id = self.git.query_remote_repository_commit_id(
+                repository.origin, self.options.git_branch
+            )
+        commits = self.load_halyard_version_commits().split("\n")
+        commits.reverse()
+        postfix = " " + commit_id
+        for line in commits:
+            if line.endswith(postfix):
+                return line
+        return None
 
-  def _do_repository(self, repository):
-    """Implements RepositoryCommandProcessor interface."""
-    # The gradle prepare for nebula needs the build version
-    # which it will get from the source info, so make it here.
-    source_info = self.source_code_manager.refresh_source_info(
-        repository, self.options.build_number)
+    def _do_can_skip_repository(self, repository):
+        if self.options.skip_existing:
+            entry = self.find_commit_version_entry(repository)
+            if entry:
+                logging.info('Found existing halyard version "%s"', entry)
+                labels = {"repository": repository.name, "artifact": "halyard"}
+                self.metrics.inc_counter("ReuseArtifact", labels)
+                self.__emit_last_commit_entry(entry)
+                return True
+        return False
 
-    # I guess we build the docs just as a test? We never put them anywhere...
-    # PublishHalyardCommand _does_ actually publish them after building, so I
-    # suppose we're just making sure we don't die at publish time
-    build_halyard_docs(self, repository)
-    self.build_all_halyard_deployments(repository)
-    self.publish_to_nightly(repository)
-    self.publish_halyard_version_commits(repository)
+    def _do_repository(self, repository):
+        """Implements RepositoryCommandProcessor interface."""
+        # The gradle prepare for nebula needs the build version
+        # which it will get from the source info, so make it here.
+        source_info = self.source_code_manager.refresh_source_info(
+            repository, self.options.build_number
+        )
+
+        # I guess we build the docs just as a test? We never put them anywhere...
+        # PublishHalyardCommand _does_ actually publish them after building, so I
+        # suppose we're just making sure we don't die at publish time
+        build_halyard_docs(self, repository)
+        self.build_all_halyard_deployments(repository)
+        self.publish_to_nightly(repository)
+        self.publish_halyard_version_commits(repository)
 
 
 class BuildHalyardFactory(GradleCommandFactory):
-  """Implements the build_halyard command."""
-  # pylint: disable=too-few-public-methods
+    """Implements the build_halyard command."""
 
-  def __init__(self):
-    super(BuildHalyardFactory, self).__init__(
-        'build_halyard', BuildHalyardCommand,
-        'Build halyard from the local git repository.',
-        BranchSourceCodeManager)
+    # pylint: disable=too-few-public-methods
 
-  def init_argparser(self, parser, defaults):
-    """Adds command-specific arguments."""
-    super(BuildHalyardFactory, self).init_argparser(parser, defaults)
+    def __init__(self):
+        super(BuildHalyardFactory, self).__init__(
+            "build_halyard",
+            BuildHalyardCommand,
+            "Build halyard from the local git repository.",
+            BranchSourceCodeManager,
+        )
 
-    self.add_argument(
-        parser, 'halyard_version_commits_url', defaults, None,
-        help='URL to file containing version and git commit for successful'
-             ' nightly builds. By default this will be'
-             ' "{filename}" in the'
-             ' --halyard_bucket_base_url.'.format(
-                 filename=BuildHalyardCommand.HALYARD_VERSIONS_BASENAME))
-    self.add_argument(
-        parser, 'build_number', defaults, DEFAULT_BUILD_NUMBER,
-        help='The build number is used when generating halyard.')
-    self.add_argument(
-        parser, 'halyard_bucket_base_url',
-        defaults, None,
-        help='Base Google Cloud Storage URL for writing halyard builds.')
-    self.add_argument(
-        parser, 'halyard_docker_image_base',
-        defaults, None,
-        help='Base Docker image name for writing halyard builds.')
-    self.add_argument(
-        parser, 'halyard_artifact_registry_image_base',
-        defaults, None,
-        help='Base Artifact Registry image name for writing halyard builds.')
-    self.add_argument(
-        parser, 'gcb_project', defaults, None,
-        help='The GCP project ID when using the GCP Container Builder.')
-    self.add_argument(
-        parser, 'gcb_service_account', defaults, None,
-        help='Google Service Account when using the GCP Container Builder.')
-    self.add_argument(
-        parser, 'artifact_registry', defaults, None,
-        help='Artifact registry to push the container images to.')
+    def init_argparser(self, parser, defaults):
+        """Adds command-specific arguments."""
+        super(BuildHalyardFactory, self).init_argparser(parser, defaults)
+
+        self.add_argument(
+            parser,
+            "halyard_version_commits_url",
+            defaults,
+            None,
+            help="URL to file containing version and git commit for successful"
+            " nightly builds. By default this will be"
+            ' "{filename}" in the'
+            " --halyard_bucket_base_url.".format(
+                filename=BuildHalyardCommand.HALYARD_VERSIONS_BASENAME
+            ),
+        )
+        self.add_argument(
+            parser,
+            "build_number",
+            defaults,
+            DEFAULT_BUILD_NUMBER,
+            help="The build number is used when generating halyard.",
+        )
+        self.add_argument(
+            parser,
+            "halyard_bucket_base_url",
+            defaults,
+            None,
+            help="Base Google Cloud Storage URL for writing halyard builds.",
+        )
+        self.add_argument(
+            parser,
+            "halyard_docker_image_base",
+            defaults,
+            None,
+            help="Base Docker image name for writing halyard builds.",
+        )
+        self.add_argument(
+            parser,
+            "halyard_artifact_registry_image_base",
+            defaults,
+            None,
+            help="Base Artifact Registry image name for writing halyard builds.",
+        )
+        self.add_argument(
+            parser,
+            "gcb_project",
+            defaults,
+            None,
+            help="The GCP project ID when using the GCP Container Builder.",
+        )
+        self.add_argument(
+            parser,
+            "gcb_service_account",
+            defaults,
+            None,
+            help="Google Service Account when using the GCP Container Builder.",
+        )
+        self.add_argument(
+            parser,
+            "artifact_registry",
+            defaults,
+            None,
+            help="Artifact registry to push the container images to.",
+        )
 
 
 class PublishHalyardCommandFactory(CommandFactory):
-  def __init__(self):
-    super(PublishHalyardCommandFactory, self).__init__(
-        'publish_halyard', PublishHalyardCommand,
-        'Publish a new halyard release.')
+    def __init__(self):
+        super(PublishHalyardCommandFactory, self).__init__(
+            "publish_halyard", PublishHalyardCommand, "Publish a new halyard release."
+        )
 
-  def init_argparser(self, parser, defaults):
-    super(PublishHalyardCommandFactory, self).init_argparser(
-        parser, defaults)
-    GradleCommandFactory.add_bom_parser_args(parser, defaults)
-    SpinnakerSourceCodeManager.add_parser_args(parser, defaults)
-    GradleRunner.add_parser_args(parser, defaults)
-    GitRunner.add_publishing_parser_args(parser, defaults)
-    HalRunner.add_parser_args(parser, defaults)
+    def init_argparser(self, parser, defaults):
+        super(PublishHalyardCommandFactory, self).init_argparser(parser, defaults)
+        GradleCommandFactory.add_bom_parser_args(parser, defaults)
+        SpinnakerSourceCodeManager.add_parser_args(parser, defaults)
+        GradleRunner.add_parser_args(parser, defaults)
+        GitRunner.add_publishing_parser_args(parser, defaults)
+        HalRunner.add_parser_args(parser, defaults)
 
-    self.add_argument(
-        parser, 'build_number', defaults, DEFAULT_BUILD_NUMBER,
-        help='Publishing halyard requires a rebuild. This is the build number'
-             ' to use when rebuilding halyard.')
+        self.add_argument(
+            parser,
+            "build_number",
+            defaults,
+            DEFAULT_BUILD_NUMBER,
+            help="Publishing halyard requires a rebuild. This is the build number"
+            " to use when rebuilding halyard.",
+        )
 
-    self.add_argument(
-        parser, 'halyard_version', defaults, None,
-        help='The semantic version of the release to publish.')
+        self.add_argument(
+            parser,
+            "halyard_version",
+            defaults,
+            None,
+            help="The semantic version of the release to publish.",
+        )
 
-    self.add_argument(
-        parser, 'halyard_version_commits_url', defaults, None,
-        help='URL to file containing version and git commit for successful'
-             ' nightly builds. By default this will be'
-             ' "{filename}" in the'
-             ' --halyard_bucket_base_url.'.format(
-                 filename=BuildHalyardCommand.HALYARD_VERSIONS_BASENAME))
-    self.add_argument(
-        parser, 'halyard_docker_image_base',
-        defaults, None,
-        help='Base Docker image name for writing halyard builds.')
-    self.add_argument(
-        parser, 'halyard_artifact_registry_image_base',
-        defaults, None,
-        help='Base Artifact Registry image name for writing halyard builds.')
-    self.add_argument(
-        parser, 'halyard_bucket_base_url',
-        defaults, None,
-        help='Base Google Cloud Storage URL for writing halyard builds.')
+        self.add_argument(
+            parser,
+            "halyard_version_commits_url",
+            defaults,
+            None,
+            help="URL to file containing version and git commit for successful"
+            " nightly builds. By default this will be"
+            ' "{filename}" in the'
+            " --halyard_bucket_base_url.".format(
+                filename=BuildHalyardCommand.HALYARD_VERSIONS_BASENAME
+            ),
+        )
+        self.add_argument(
+            parser,
+            "halyard_docker_image_base",
+            defaults,
+            None,
+            help="Base Docker image name for writing halyard builds.",
+        )
+        self.add_argument(
+            parser,
+            "halyard_artifact_registry_image_base",
+            defaults,
+            None,
+            help="Base Artifact Registry image name for writing halyard builds.",
+        )
+        self.add_argument(
+            parser,
+            "halyard_bucket_base_url",
+            defaults,
+            None,
+            help="Base Google Cloud Storage URL for writing halyard builds.",
+        )
 
-    self.add_argument(parser, 'docs_repo_owner', defaults, None,
-                      help='Owner of the docs repo if one was'
-                      ' specified. The default is --github_owner.')
-    self.add_argument(
-        parser, 'skip_existing', defaults, False, type=bool,
-        help='Skip builds if the desired version already exists on bintray.')
+        self.add_argument(
+            parser,
+            "docs_repo_owner",
+            defaults,
+            None,
+            help="Owner of the docs repo if one was"
+            " specified. The default is --github_owner.",
+        )
+        self.add_argument(
+            parser,
+            "skip_existing",
+            defaults,
+            False,
+            type=bool,
+            help="Skip builds if the desired version already exists on bintray.",
+        )
 
-    self.add_argument(
-        parser, 'delete_existing', defaults, None, type=bool,
-        help='Delete pre-existing desired versions if from bintray.')
+        self.add_argument(
+            parser,
+            "delete_existing",
+            defaults,
+            None,
+            type=bool,
+            help="Delete pre-existing desired versions if from bintray.",
+        )
 
-    self.add_argument(
-        parser, 'gcb_project', defaults, None,
-        help='The GCP project ID when using the GCP Container Builder.')
-    self.add_argument(
-        parser, 'gcb_service_account', defaults, None,
-        help='Google Service Account when using the GCP Container Builder.')
-    self.add_argument(
-        parser, 'artifact_registry', defaults, None,
-        help='Artifact Registry to push the container images to.')
+        self.add_argument(
+            parser,
+            "gcb_project",
+            defaults,
+            None,
+            help="The GCP project ID when using the GCP Container Builder.",
+        )
+        self.add_argument(
+            parser,
+            "gcb_service_account",
+            defaults,
+            None,
+            help="Google Service Account when using the GCP Container Builder.",
+        )
+        self.add_argument(
+            parser,
+            "artifact_registry",
+            defaults,
+            None,
+            help="Artifact Registry to push the container images to.",
+        )
 
 
 class PublishHalyardCommand(CommandProcessor):
-  """Publish halyard version to the public repository."""
+    """Publish halyard version to the public repository."""
 
-  def __init__(self, factory, options, **kwargs):
-    options_copy = copy.copy(options)
-    options_copy.bom_path = None
-    options_copy.bom_version = None
-    options_copy.git_branch = 'master'
-    options_copy.github_hostname = 'github.com'
-    # Overrides later if --git_allow_publish_master_branch is false
-    super(PublishHalyardCommand, self).__init__(factory, options_copy, **kwargs)
+    def __init__(self, factory, options, **kwargs):
+        options_copy = copy.copy(options)
+        options_copy.bom_path = None
+        options_copy.bom_version = None
+        options_copy.git_branch = "master"
+        options_copy.github_hostname = "github.com"
+        # Overrides later if --git_allow_publish_master_branch is false
+        super(PublishHalyardCommand, self).__init__(factory, options_copy, **kwargs)
 
-    check_options_set(options, ['halyard_version'])
-    match = re.match(r'(\d+)\.(\d+)\.(\d+)-\d+', options.halyard_version)
-    if match is None:
-      raise_and_log_error(
-          ConfigError('--halyard_version={version} is not X.Y.Z-<buildnum>'
-                      .format(version=options.halyard_version)))
-    self.__stable_version = '{major}.{minor}.{patch}'.format(
-        major=match.group(1), minor=match.group(2), patch=match.group(3))
+        check_options_set(options, ["halyard_version"])
+        match = re.match(r"(\d+)\.(\d+)\.(\d+)-\d+", options.halyard_version)
+        if match is None:
+            raise_and_log_error(
+                ConfigError(
+                    "--halyard_version={version} is not X.Y.Z-<buildnum>".format(
+                        version=options.halyard_version
+                    )
+                )
+            )
+        self.__stable_version = "{major}.{minor}.{patch}".format(
+            major=match.group(1), minor=match.group(2), patch=match.group(3)
+        )
 
-    self.__scm = BranchSourceCodeManager(options_copy, self.get_input_dir())
-    self.__hal = HalRunner(options_copy)
-    self.__gradle = GradleRunner(options_copy, self.__scm, self.metrics)
-    self.__halyard_repo_md_path = os.path.join('docs', 'commands.md')
+        self.__scm = BranchSourceCodeManager(options_copy, self.get_input_dir())
+        self.__hal = HalRunner(options_copy)
+        self.__gradle = GradleRunner(options_copy, self.__scm, self.metrics)
+        self.__halyard_repo_md_path = os.path.join("docs", "commands.md")
 
-    dash = self.options.halyard_version.find('-')
-    semver_str = self.options.halyard_version[0:dash]
-    semver_parts = semver_str.split('.')
-    if len(semver_parts) != 3:
-      raise_and_log_error(
-          ConfigError('Expected --halyard_version in the form X.Y.Z-N'))
-    self.__release_branch = 'release-{maj}.{min}.x'.format(
-        maj=semver_parts[0], min=semver_parts[1])
-    self.__release_tag = 'version-' + semver_str
-    self.__release_version = semver_str
+        dash = self.options.halyard_version.find("-")
+        semver_str = self.options.halyard_version[0:dash]
+        semver_parts = semver_str.split(".")
+        if len(semver_parts) != 3:
+            raise_and_log_error(
+                ConfigError("Expected --halyard_version in the form X.Y.Z-N")
+            )
+        self.__release_branch = "release-{maj}.{min}.x".format(
+            maj=semver_parts[0], min=semver_parts[1]
+        )
+        self.__release_tag = "version-" + semver_str
+        self.__release_version = semver_str
 
-  def determine_halyard_commit(self):
-    """Determine the commit_id that we want to publish."""
-    options = self.options
-    versions_url = options.halyard_version_commits_url
-    if not versions_url:
-      versions_url = '{base}/{filename}'.format(
-          base=options.halyard_bucket_base_url,
-          filename=BuildHalyardCommand.HALYARD_VERSIONS_BASENAME)
+    def determine_halyard_commit(self):
+        """Determine the commit_id that we want to publish."""
+        options = self.options
+        versions_url = options.halyard_version_commits_url
+        if not versions_url:
+            versions_url = "{base}/{filename}".format(
+                base=options.halyard_bucket_base_url,
+                filename=BuildHalyardCommand.HALYARD_VERSIONS_BASENAME,
+            )
 
-    if os.path.exists(versions_url):
-      logging.debug('Loading halyard version info from file %s', versions_url)
-      with open(versions_url, 'r') as stream:
-        version_data = stream.read()
-    else:
-      logging.debug('Loading halyard version info from bucket %s', versions_url)
-      gsutil_output = check_subprocess(
-          'gsutil cat {url}'.format(url=versions_url), stderr=subprocess.PIPE)
+        if os.path.exists(versions_url):
+            logging.debug("Loading halyard version info from file %s", versions_url)
+            with open(versions_url, "r") as stream:
+                version_data = stream.read()
+        else:
+            logging.debug("Loading halyard version info from bucket %s", versions_url)
+            gsutil_output = check_subprocess(
+                "gsutil cat {url}".format(url=versions_url), stderr=subprocess.PIPE
+            )
 
-      # The latest version of gsutil prints a bunch of python warnings to stdout
-      # (see b/152449160). This file is a series of lines that look like...
-      #   0.41.0-180209172926: 05f1e832ab438e5a980d1102e84cdb348a0ab055
-      # ...so we'll just throw out any lines that don't start with digits.
-      valid_lines = [line for line in gsutil_output.splitlines()
-                     if line[0].isdigit()]
-      version_data = "\n".join(valid_lines)
+            # The latest version of gsutil prints a bunch of python warnings to stdout
+            # (see b/152449160). This file is a series of lines that look like...
+            #   0.41.0-180209172926: 05f1e832ab438e5a980d1102e84cdb348a0ab055
+            # ...so we'll just throw out any lines that don't start with digits.
+            valid_lines = [
+                line for line in gsutil_output.splitlines() if line[0].isdigit()
+            ]
+            version_data = "\n".join(valid_lines)
 
-    commit = yaml.safe_load(version_data).get(options.halyard_version)
-    if commit is None:
-      raise_and_log_error(
-          ConfigError('Unknown halyard version "{version}" in "{url}"'.format(
-              version=options.halyard_version, url=versions_url)))
-    return commit
+        commit = yaml.safe_load(version_data).get(options.halyard_version)
+        if commit is None:
+            raise_and_log_error(
+                ConfigError(
+                    'Unknown halyard version "{version}" in "{url}"'.format(
+                        version=options.halyard_version, url=versions_url
+                    )
+                )
+            )
+        return commit
 
-  def _prepare_repository(self):
-    """Prepare a local repository to build for release.
+    def _prepare_repository(self):
+        """Prepare a local repository to build for release.
 
-    Were rebuilding it only to have nebula give a new distribution tag.
-    However we will also use the repository to tag and branch the release
-    into github so want to at least clone the repo regardless.
-    """
-    logging.debug('Preparing repository for publishing a halyard release.')
-    commit = self.determine_halyard_commit()
-    repository = self.__scm.make_repository_spec(
-        SPINNAKER_HALYARD_REPOSITORY_NAME, commit_id=commit)
-    git_dir = repository.git_dir
-    if os.path.exists(git_dir):
-      logging.info('Deleting existing %s to build fresh.', git_dir)
-      shutil.rmtree(git_dir)
-    git = self.__scm.git
-    git.clone_repository_to_path(repository, commit=commit)
-    return repository
+        Were rebuilding it only to have nebula give a new distribution tag.
+        However we will also use the repository to tag and branch the release
+        into github so want to at least clone the repo regardless.
+        """
+        logging.debug("Preparing repository for publishing a halyard release.")
+        commit = self.determine_halyard_commit()
+        repository = self.__scm.make_repository_spec(
+            SPINNAKER_HALYARD_REPOSITORY_NAME, commit_id=commit
+        )
+        git_dir = repository.git_dir
+        if os.path.exists(git_dir):
+            logging.info("Deleting existing %s to build fresh.", git_dir)
+            shutil.rmtree(git_dir)
+        git = self.__scm.git
+        git.clone_repository_to_path(repository, commit=commit)
+        return repository
 
-  def _promote_halyard(self, repository):
-    """Promote an existing build to become the halyard stable version."""
-    options = self.options
-    logfile = self.get_logfile_path('promote-all')
-    env = dict(os.environ)
-    env.update({
-        'PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_SRC_BASE': options.halyard_artifact_registry_image_base,
-        'PUBLISH_HALYARD_BUCKET_BASE_URL': options.halyard_bucket_base_url,
-        'PUBLISH_HALYARD_DOCKER_IMAGE_BASE': options.halyard_docker_image_base
-    })
-    check_subprocesses_to_logfile(
-        'Promote Halyard', logfile,
-        ['gcloud docker -a',  # if repo is private it needs authenticated
-         './release/promote-all.sh {candidate} {stable}'.format(
-             candidate=options.halyard_version,
-             stable=self.__stable_version),
-         './release/promote-all.sh {candidate} stable'.format(
-             candidate=options.halyard_version)],
-        env=env,
-        cwd=repository.git_dir)
+    def _promote_halyard(self, repository):
+        """Promote an existing build to become the halyard stable version."""
+        options = self.options
+        logfile = self.get_logfile_path("promote-all")
+        env = dict(os.environ)
+        env.update(
+            {
+                "PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_SRC_BASE": options.halyard_artifact_registry_image_base,
+                "PUBLISH_HALYARD_BUCKET_BASE_URL": options.halyard_bucket_base_url,
+                "PUBLISH_HALYARD_DOCKER_IMAGE_BASE": options.halyard_docker_image_base,
+            }
+        )
+        check_subprocesses_to_logfile(
+            "Promote Halyard",
+            logfile,
+            [
+                "gcloud docker -a",  # if repo is private it needs authenticated
+                "./release/promote-all.sh {candidate} {stable}".format(
+                    candidate=options.halyard_version, stable=self.__stable_version
+                ),
+                "./release/promote-all.sh {candidate} stable".format(
+                    candidate=options.halyard_version
+                ),
+            ],
+            env=env,
+            cwd=repository.git_dir,
+        )
 
-  def _build_release(self, repository):
-    """Rebuild the actual release debian package.
+    def _build_release(self, repository):
+        """Rebuild the actual release debian package.
 
-    We dont necessarily need to rebuild here. We just need to push as
-    debian to the "-stable". However there isnt an easy way to do this.
+        We dont necessarily need to rebuild here. We just need to push as
+        debian to the "-stable". However there isnt an easy way to do this.
 
-    Note that this is not the promoted version. For safety[*] and simplicity
-    we'll promote the candidate whose version was used to build this.
-    Ideally this function can go away.
+        Note that this is not the promoted version. For safety[*] and simplicity
+        we'll promote the candidate whose version was used to build this.
+        Ideally this function can go away.
 
-    [*] Safety because the candidate was tested whereas this build was not.
-    """
-    # Ideally we would just modify the existing bintray version to add
-    # *-stable to the distributions, however it does not appear possible
-    # to patch the debian attributes of a bintray version, only the
-    # version metadata. Therefore, we'll rebuild it.
-    # Alternatively we could download the existing and push a new one,
-    # however I dont see how to get at the existing debian metadata and
-    # dont want to ommit something
+        [*] Safety because the candidate was tested whereas this build was not.
+        """
+        # Ideally we would just modify the existing bintray version to add
+        # *-stable to the distributions, however it does not appear possible
+        # to patch the debian attributes of a bintray version, only the
+        # version metadata. Therefore, we'll rebuild it.
+        # Alternatively we could download the existing and push a new one,
+        # however I dont see how to get at the existing debian metadata and
+        # dont want to ommit something
 
-    options = self.options
-    git_dir = repository.git_dir
-    summary = self.__scm.git.collect_repository_summary(git_dir)
+        options = self.options
+        git_dir = repository.git_dir
+        summary = self.__scm.git.collect_repository_summary(git_dir)
 
+        config_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "cloudbuild", "debs.yml"
+        )
+        substitutions = {
+            "_BRANCH_NAME": options.git_branch,
+            "_BRANCH_TAG": re.sub(r"\W", "_", options.git_branch),
+            "_BUILD_NUMBER": options.build_number,
+            "_IMAGE_NAME": "halyard",
+            "_VERSION": summary.version,
+        }
+        # Convert it to the format expected by gcloud: "_FOO=bar,_BAZ=qux"
+        substitutions_arg = ",".join(
+            "=".join((str(k), str(v))) for k, v in substitutions.items()
+        )
+        command = (
+            "gcloud builds submit "
+            " --account={account} --project={project}"
+            " --substitutions={substitutions_arg},"
+            " --config={config} .".format(
+                account=options.gcb_service_account,
+                project=options.gcb_project,
+                substitutions_arg=substitutions_arg,
+                config=config_path,
+            )
+        )
+        logfile = self.get_logfile_path("build-deb")
+        check_subprocesses_to_logfile(
+            "building deb with published version", logfile, [command], cwd=git_dir
+        )
 
-    config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                               'cloudbuild', 'debs.yml')
-    substitutions = {'_BRANCH_NAME': options.git_branch,
-                     '_BRANCH_TAG': re.sub(r'\W', '_', options.git_branch),
-                     '_BUILD_NUMBER': options.build_number,
-                     '_IMAGE_NAME': 'halyard',
-                     '_VERSION': summary.version}
-    # Convert it to the format expected by gcloud: "_FOO=bar,_BAZ=qux"
-    substitutions_arg = ','.join('='.join((str(k), str(v))) for k, v in
-                                 substitutions.items())
-    command = ('gcloud builds submit '
-               ' --account={account} --project={project}'
-               ' --substitutions={substitutions_arg},'
-               ' --config={config} .'
-               .format(account=options.gcb_service_account,
-                       project=options.gcb_project,
-                       substitutions_arg=substitutions_arg,
-                       config=config_path))
-    logfile = self.get_logfile_path('build-deb')
-    check_subprocesses_to_logfile('building deb with published version',
-                                  logfile,
-                                  [command],
-                                  cwd=git_dir)
-
-  def write_target_docs(self, source_repository, target_repository):
-    source_path = os.path.join(source_repository.git_dir,
-                               self.__halyard_repo_md_path)
-    target_rel_path = os.path.join('reference', 'halyard', 'commands.md')
-    target_path = os.path.join(target_repository.git_dir, target_rel_path)
-    now = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
-    logging.debug('Writing documentation into %s', target_path)
-    header = textwrap.dedent(
-        """\
+    def write_target_docs(self, source_repository, target_repository):
+        source_path = os.path.join(
+            source_repository.git_dir, self.__halyard_repo_md_path
+        )
+        target_rel_path = os.path.join("reference", "halyard", "commands.md")
+        target_path = os.path.join(target_repository.git_dir, target_rel_path)
+        now = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        logging.debug("Writing documentation into %s", target_path)
+        header = textwrap.dedent(
+            """\
         ---
         layout: single
         title: "Commands"
@@ -556,94 +704,114 @@ class PublishHalyardCommand(CommandProcessor):
           nav: reference
         ---
         Published: {now}
-        """.format(now=now))
-    with open(source_path, 'r') as source:
-      body = source.read()
-    with open(target_path, 'w') as stream:
-      stream.write(header)
-      stream.write(body)
-    return target_rel_path
+        """.format(
+                now=now
+            )
+        )
+        with open(source_path, "r") as source:
+            body = source.read()
+        with open(target_path, "w") as stream:
+            stream.write(header)
+            stream.write(body)
+        return target_rel_path
 
-  def push_docs(self, repository):
-    base_branch = 'master'
-    target_repository = self.__scm.make_repository_spec(
-        SPINNAKER_IO_REPOSITORY_NAME)
-    self.__scm.ensure_git_path(target_repository)
-    target_rel_path = self.write_target_docs(repository, target_repository)
+    def push_docs(self, repository):
+        base_branch = "master"
+        target_repository = self.__scm.make_repository_spec(
+            SPINNAKER_IO_REPOSITORY_NAME
+        )
+        self.__scm.ensure_git_path(target_repository)
+        target_rel_path = self.write_target_docs(repository, target_repository)
 
-    if self.options.git_allow_publish_master_branch:
-      head_branch = 'master'
-      branch_flag = ''
-    else:
-      head_branch = self.__release_version + '-haldocs'
-      branch_flag = '-b'
-    logging.debug('Commiting changes into local repository "%s" branch=%s',
-                  target_repository.git_dir, head_branch)
+        if self.options.git_allow_publish_master_branch:
+            head_branch = "master"
+            branch_flag = ""
+        else:
+            head_branch = self.__release_version + "-haldocs"
+            branch_flag = "-b"
+        logging.debug(
+            'Commiting changes into local repository "%s" branch=%s',
+            target_repository.git_dir,
+            head_branch,
+        )
 
-    git_dir = target_repository.git_dir
-    message = 'docs(halyard): ' + self.__release_version
-    local_git_commands = [
-        # These commands are accomodating to a branch already existing
-        # because the branch is on the version, not build. A rejected
-        # build for some reason that is re-tried will have the same version
-        # so the branch may already exist from the earlier attempt.
-        'checkout ' + base_branch,
-        'checkout {flag} {branch}'.format(
-            flag=branch_flag, branch=head_branch),
-        'add ' + target_rel_path,
-    ]
+        git_dir = target_repository.git_dir
+        message = "docs(halyard): " + self.__release_version
+        local_git_commands = [
+            # These commands are accomodating to a branch already existing
+            # because the branch is on the version, not build. A rejected
+            # build for some reason that is re-tried will have the same version
+            # so the branch may already exist from the earlier attempt.
+            "checkout " + base_branch,
+            "checkout {flag} {branch}".format(flag=branch_flag, branch=head_branch),
+            "add " + target_rel_path,
+        ]
 
-    logging.debug('Commiting changes into local repository "%s" branch=%s',
-                  target_repository.git_dir, head_branch)
-    git = self.__scm.git
-    git.check_run_sequence(git_dir, local_git_commands)
-    git.check_commit_or_no_changes(
-        git_dir, '-m "{msg}" {path}'.format(msg=message, path=target_rel_path))
+        logging.debug(
+            'Commiting changes into local repository "%s" branch=%s',
+            target_repository.git_dir,
+            head_branch,
+        )
+        git = self.__scm.git
+        git.check_run_sequence(git_dir, local_git_commands)
+        git.check_commit_or_no_changes(
+            git_dir, '-m "{msg}" {path}'.format(msg=message, path=target_rel_path)
+        )
 
-    logging.info('Pushing halyard docs to %s branch="%s"',
-                 target_repository.origin, head_branch)
-    git.push_branch_to_origin(
-        target_repository.git_dir, branch=head_branch, force=True)
+        logging.info(
+            'Pushing halyard docs to %s branch="%s"',
+            target_repository.origin,
+            head_branch,
+        )
+        git.push_branch_to_origin(
+            target_repository.git_dir, branch=head_branch, force=True
+        )
 
-  def _do_command(self):
-    """Implements CommandProcessor interface."""
-    repository = self._prepare_repository()
-    # Removing debian publishing, until we have a new place to push them to.
-    #self._build_release(repository)
-    self._promote_halyard(repository)
-    build_halyard_docs(self, repository)
-    self.push_docs(repository)
-    self.push_tag_and_branch(repository)
-    self.__hal.publish_halyard_release(self.__release_version)
+    def _do_command(self):
+        """Implements CommandProcessor interface."""
+        repository = self._prepare_repository()
+        # Removing debian publishing, until we have a new place to push them to.
+        # self._build_release(repository)
+        self._promote_halyard(repository)
+        build_halyard_docs(self, repository)
+        self.push_docs(repository)
+        self.push_tag_and_branch(repository)
+        self.__hal.publish_halyard_release(self.__release_version)
 
-  def push_tag_and_branch(self, repository):
-    """Pushes a stable branch and git version tag to the origin repository."""
-    git_dir = repository.git_dir
-    git = self.__scm.git
+    def push_tag_and_branch(self, repository):
+        """Pushes a stable branch and git version tag to the origin repository."""
+        git_dir = repository.git_dir
+        git = self.__scm.git
 
-    release_url = git.determine_push_url(repository.origin)
-    logging.info('Pushing branch=%s and tag=%s to %s',
-                 self.__release_branch, self.__release_tag, release_url)
+        release_url = git.determine_push_url(repository.origin)
+        logging.info(
+            "Pushing branch=%s and tag=%s to %s",
+            self.__release_branch,
+            self.__release_tag,
+            release_url,
+        )
 
-    existing_commit = git.query_commit_at_tag(git_dir, self.__release_tag)
-    if existing_commit:
-      want_commit = git.query_local_repository_commit_id(git_dir)
-      if want_commit == existing_commit:
-        logging.debug('Already have "%s" at %s',
-                      self.__release_tag, want_commit)
-        return
+        existing_commit = git.query_commit_at_tag(git_dir, self.__release_tag)
+        if existing_commit:
+            want_commit = git.query_local_repository_commit_id(git_dir)
+            if want_commit == existing_commit:
+                logging.debug(
+                    'Already have "%s" at %s', self.__release_tag, want_commit
+                )
+                return
 
-    git.check_run_sequence(
-        git_dir,
-        [
-            'checkout -b ' + self.__release_branch,
-            'remote add release ' + release_url,
-            'push release ' + self.__release_branch,
-            'tag ' + self.__release_tag,
-            'push release ' + self.__release_tag
-        ])
+        git.check_run_sequence(
+            git_dir,
+            [
+                "checkout -b " + self.__release_branch,
+                "remote add release " + release_url,
+                "push release " + self.__release_branch,
+                "tag " + self.__release_tag,
+                "push release " + self.__release_tag,
+            ],
+        )
 
 
 def register_commands(registry, subparsers, defaults):
-  BuildHalyardFactory().register(registry, subparsers, defaults)
-  PublishHalyardCommandFactory().register(registry, subparsers, defaults)
+    BuildHalyardFactory().register(registry, subparsers, defaults)
+    PublishHalyardCommandFactory().register(registry, subparsers, defaults)

--- a/dev/buildtool/image_commands.py
+++ b/dev/buildtool/image_commands.py
@@ -24,253 +24,358 @@ import re
 
 from buildtool import (
     SPINNAKER_RUNNABLE_REPOSITORY_NAMES,
-
     BomSourceCodeManager,
     RepositoryCommandFactory,
     RepositoryCommandProcessor,
-
     GitRepositorySpec,
     GitRunner,
     HalRunner,
-
     check_subprocess,
     check_subprocesses_to_logfile,
     check_options_set,
     raise_and_log_error,
     ConfigError,
-    UnexpectedError)
+    UnexpectedError,
+)
 
 
 # TODO(ewiseblatt): 20180203
 # Really these should come from "bom_dependencies_path" file
 # so that it is extendable
-EXTRA_REPO_NAMES = ['consul', 'redis', 'vault']
+EXTRA_REPO_NAMES = ["consul", "redis", "vault"]
+
 
 class BuildGceComponentImages(RepositoryCommandProcessor):
-  """Builds GCE VM images for each of the runtime components.
+    """Builds GCE VM images for each of the runtime components.
 
-  Although we are calling this a RepositoryCommandProcessor, it
-  isnt really processing repositories. Some of the images we build
-  are not associated with github or repos at all (e.g. redis). However
-  the RepositoryCommandProcessor is a useful abstraction for its ability
-  to parallelize across the different subsystems so we're going to overload
-  it and pretend we have repositories even though we'll never do anything
-  with their urls.
-  """
+    Although we are calling this a RepositoryCommandProcessor, it
+    isnt really processing repositories. Some of the images we build
+    are not associated with github or repos at all (e.g. redis). However
+    the RepositoryCommandProcessor is a useful abstraction for its ability
+    to parallelize across the different subsystems so we're going to overload
+    it and pretend we have repositories even though we'll never do anything
+    with their urls.
+    """
 
-  def _do_determine_source_repositories(self):
-    """Implements RepositoryCommandProcessor interface."""
-    # These arent actually used, just the names.
-    repositories = [self.source_code_manager.make_repository_spec(name)
-                    for name in SPINNAKER_RUNNABLE_REPOSITORY_NAMES]
-    repositories.extend([
-        GitRepositorySpec(name) for name in EXTRA_REPO_NAMES])
-    return repositories
+    def _do_determine_source_repositories(self):
+        """Implements RepositoryCommandProcessor interface."""
+        # These arent actually used, just the names.
+        repositories = [
+            self.source_code_manager.make_repository_spec(name)
+            for name in SPINNAKER_RUNNABLE_REPOSITORY_NAMES
+        ]
+        repositories.extend([GitRepositorySpec(name) for name in EXTRA_REPO_NAMES])
+        return repositories
 
-  def __init__(self, factory, options, **kwargs):
-    check_options_set(
-        options,
-        ['build_gce_service_account',
-         'build_gce_project'])
+    def __init__(self, factory, options, **kwargs):
+        check_options_set(options, ["build_gce_service_account", "build_gce_project"])
 
-    options.github_disable_upstream_push = True
-    super(BuildGceComponentImages, self).__init__(factory, options, **kwargs)
-    artifact_sources = self.source_code_manager.bom['artifactSources']
-    self.__image_project = artifact_sources['googleImageProject']
-    if not self.__image_project:
-      raise_and_log_error(
-          ConfigError('BOM has no artifactSources.googleImageProject'))
+        options.github_disable_upstream_push = True
+        super(BuildGceComponentImages, self).__init__(factory, options, **kwargs)
+        artifact_sources = self.source_code_manager.bom["artifactSources"]
+        self.__image_project = artifact_sources["googleImageProject"]
+        if not self.__image_project:
+            raise_and_log_error(
+                ConfigError("BOM has no artifactSources.googleImageProject")
+            )
 
-  def __determine_repo_install_args(self, repository):
-    """Determine --spinnaker_dev-github_[owner|user] args for install script."""
-    options = self.options
-    branch = options.git_branch
-    owner = ('spinnaker'
-             if options.github_owner in ('default', 'upstream')
-             else options.github_owner)
-    git_dir = os.path.dirname(__file__)
-    if not branch:
-      branch = GitRunner(options).query_local_repository_branch(git_dir)
-    if not owner:
-      url = repository.origin
-      match = re.search('github.com/([^/]+)/', url)
-      if not match:
-        raise_and_log_error(
-            UnexpectedError('Cannot determine owner from url=%s' % url,
-                            cause='BadUrl'))
-      owner = match.group(1)
-    return [
-        '--spinnaker_dev_github_owner', owner,
-        '--spinnaker_dev_github_branch', branch
-    ]
+    def __determine_repo_install_args(self, repository):
+        """Determine --spinnaker_dev-github_[owner|user] args for install script."""
+        options = self.options
+        branch = options.git_branch
+        owner = (
+            "spinnaker"
+            if options.github_owner in ("default", "upstream")
+            else options.github_owner
+        )
+        git_dir = os.path.dirname(__file__)
+        if not branch:
+            branch = GitRunner(options).query_local_repository_branch(git_dir)
+        if not owner:
+            url = repository.origin
+            match = re.search("github.com/([^/]+)/", url)
+            if not match:
+                raise_and_log_error(
+                    UnexpectedError(
+                        "Cannot determine owner from url=%s" % url, cause="BadUrl"
+                    )
+                )
+            owner = match.group(1)
+        return [
+            "--spinnaker_dev_github_owner",
+            owner,
+            "--spinnaker_dev_github_branch",
+            branch,
+        ]
 
-  def have_image(self, repository):
-    """Determine if we already have an image for the repository or not."""
-    bom = self.source_code_manager.bom
-    dependencies = bom['dependencies']
-    services = bom['services']
-    service_name = self.scm.repository_name_to_service_name(repository.name)
-    if service_name in dependencies:
-      build_version = dependencies[service_name]['version']
-    else:
-      build_version = services[service_name]['version']
+    def have_image(self, repository):
+        """Determine if we already have an image for the repository or not."""
+        bom = self.source_code_manager.bom
+        dependencies = bom["dependencies"]
+        services = bom["services"]
+        service_name = self.scm.repository_name_to_service_name(repository.name)
+        if service_name in dependencies:
+            build_version = dependencies[service_name]["version"]
+        else:
+            build_version = services[service_name]["version"]
 
-    options = self.options
-    image_name = 'spinnaker-{repo}-{version}'.format(
-        repo=repository.name,
-        version=build_version.replace('.', '-').replace(':', '-'))
-    lookup_command = ['gcloud', '--account', options.build_gce_service_account,
-                      'compute', 'images', 'list', '--filter', image_name,
-                      '--project', self.__image_project,
-                      '--quiet', '--format=json']
-    logging.debug('Checking for existing image for "%s"', repository.name)
-    got = check_subprocess(' '.join(lookup_command))
-    if got.strip() == '[]':
-      return False
-    labels = {'repository': repository.name, 'artifact': 'gce-image'}
-    if self.options.skip_existing:
-      logging.info('Already have %s -- skipping build', image_name)
-      self.metrics.inc_counter('ReuseArtifact', labels)
-      return True
-    if not self.options.delete_existing:
-      raise_and_log_error(
-          ConfigError('Already have image "{name}"'.format(name=image_name)))
+        options = self.options
+        image_name = "spinnaker-{repo}-{version}".format(
+            repo=repository.name,
+            version=build_version.replace(".", "-").replace(":", "-"),
+        )
+        lookup_command = [
+            "gcloud",
+            "--account",
+            options.build_gce_service_account,
+            "compute",
+            "images",
+            "list",
+            "--filter",
+            image_name,
+            "--project",
+            self.__image_project,
+            "--quiet",
+            "--format=json",
+        ]
+        logging.debug('Checking for existing image for "%s"', repository.name)
+        got = check_subprocess(" ".join(lookup_command))
+        if got.strip() == "[]":
+            return False
+        labels = {"repository": repository.name, "artifact": "gce-image"}
+        if self.options.skip_existing:
+            logging.info("Already have %s -- skipping build", image_name)
+            self.metrics.inc_counter("ReuseArtifact", labels)
+            return True
+        if not self.options.delete_existing:
+            raise_and_log_error(
+                ConfigError('Already have image "{name}"'.format(name=image_name))
+            )
 
-    delete_command = ['gcloud', '--account', options.gcb_service_account,
-                      'compute', 'images', 'delete', image_name,
-                      '--project', options.build_gce_project,
-                      '--quiet']
-    logging.debug('Deleting existing image %s', image_name)
-    self.metrics.count_call(
-        'DeleteArtifact', labels,
-        'Attempts to delete existing GCE images.',
-        check_subprocess, ' '.join(delete_command))
-    return False
+        delete_command = [
+            "gcloud",
+            "--account",
+            options.gcb_service_account,
+            "compute",
+            "images",
+            "delete",
+            image_name,
+            "--project",
+            options.build_gce_project,
+            "--quiet",
+        ]
+        logging.debug("Deleting existing image %s", image_name)
+        self.metrics.count_call(
+            "DeleteArtifact",
+            labels,
+            "Attempts to delete existing GCE images.",
+            check_subprocess,
+            " ".join(delete_command),
+        )
+        return False
 
-  def ensure_local_repository(self, repository):
-    """Local repositories are used to get version information."""
-    if repository.name in EXTRA_REPO_NAMES:
-      return None
-    return super(BuildGceComponentImages, self).ensure_local_repository(
-        repository)
+    def ensure_local_repository(self, repository):
+        """Local repositories are used to get version information."""
+        if repository.name in EXTRA_REPO_NAMES:
+            return None
+        return super(BuildGceComponentImages, self).ensure_local_repository(repository)
 
-  def _do_can_skip_repository(self, repository):
-    if not repository.name in SPINNAKER_RUNNABLE_REPOSITORY_NAMES:
-      logging.debug('%s does not build a GCE component image -- skip',
-                    repository.name)
-      return True
-    return self.have_image(repository)
+    def _do_can_skip_repository(self, repository):
+        if not repository.name in SPINNAKER_RUNNABLE_REPOSITORY_NAMES:
+            logging.debug(
+                "%s does not build a GCE component image -- skip", repository.name
+            )
+            return True
+        return self.have_image(repository)
 
-  def _do_repository(self, repository):
-    """Implements RepositoryCommandProcessor interface."""
+    def _do_repository(self, repository):
+        """Implements RepositoryCommandProcessor interface."""
 
-    name = repository.name
-    build_component_image_sh = os.path.join(
-        os.path.dirname(__file__), '..', 'build_google_component_image.sh')
+        name = repository.name
+        build_component_image_sh = os.path.join(
+            os.path.dirname(__file__), "..", "build_google_component_image.sh"
+        )
 
-    options = self.options
-    bom_version = self.source_code_manager.determine_bom_version()
-    command_line = [
-        build_component_image_sh,
-        '--artifact ', name,
-        '--account', options.build_gce_service_account,
-        '--hal_daemon_endpoint', 'http://' + options.halyard_daemon,
-        '--build_project', options.build_gce_project,
-        '--install_script', options.install_image_script,
-        '--publish_project', self.__image_project,
-        '--publish_script', options.publish_gce_image_script,
-        '--version', bom_version,
-        '--zone', options.build_gce_zone]
-    command_line.extend(self.__determine_repo_install_args(repository))
+        options = self.options
+        bom_version = self.source_code_manager.determine_bom_version()
+        command_line = [
+            build_component_image_sh,
+            "--artifact ",
+            name,
+            "--account",
+            options.build_gce_service_account,
+            "--hal_daemon_endpoint",
+            "http://" + options.halyard_daemon,
+            "--build_project",
+            options.build_gce_project,
+            "--install_script",
+            options.install_image_script,
+            "--publish_project",
+            self.__image_project,
+            "--publish_script",
+            options.publish_gce_image_script,
+            "--version",
+            bom_version,
+            "--zone",
+            options.build_gce_zone,
+        ]
+        command_line.extend(self.__determine_repo_install_args(repository))
 
-    extra_install_args = []
-    if options.halyard_bom_bucket:
-      extra_install_args.extend(
-          ['--halyard_config_bucket', options.halyard_bom_bucket])
+        extra_install_args = []
+        if options.halyard_bom_bucket:
+            extra_install_args.extend(
+                ["--halyard_config_bucket", options.halyard_bom_bucket]
+            )
 
-    if options.bintray_debian_repository:
-      bintray_url = 'https://dl.bintray.com/{org}/{repo}'.format(
-          org=options.bintray_org,
-          repo=options.bintray_debian_repository)
-      extra_install_args.extend([
-          '--release_track', options.halyard_release_track,
-          '--halyard_repository', bintray_url,
-          '--spinnaker_repository', bintray_url])
+        if options.bintray_debian_repository:
+            bintray_url = "https://dl.bintray.com/{org}/{repo}".format(
+                org=options.bintray_org, repo=options.bintray_debian_repository
+            )
+            extra_install_args.extend(
+                [
+                    "--release_track",
+                    options.halyard_release_track,
+                    "--halyard_repository",
+                    bintray_url,
+                    "--spinnaker_repository",
+                    bintray_url,
+                ]
+            )
 
-    if extra_install_args:
-      command_line.extend(['--extra_install_script_args',
-                           '"{0}"'.format(' '.join(extra_install_args))])
+        if extra_install_args:
+            command_line.extend(
+                [
+                    "--extra_install_script_args",
+                    '"{0}"'.format(" ".join(extra_install_args)),
+                ]
+            )
 
-    command = ' '.join(command_line)
-    logfile = self.get_logfile_path(name + '-gce-image')
+        command = " ".join(command_line)
+        logfile = self.get_logfile_path(name + "-gce-image")
 
-    what = u'{name} component image'.format(name=name)
-    check_subprocesses_to_logfile(what, logfile, [command])
-    return what
+        what = "{name} component image".format(name=name)
+        check_subprocesses_to_logfile(what, logfile, [command])
+        return what
 
 
 class BuildGceComponentImagesFactory(RepositoryCommandFactory):
-  """Builds GCE VM images for each of the runtime components."""
+    """Builds GCE VM images for each of the runtime components."""
 
-  def __init__(self):
-    super(BuildGceComponentImagesFactory, self).__init__(
-        'build_gce_component_images', BuildGceComponentImages,
-        'Build Google Compute Engine VM Images For Each Service.',
-        BomSourceCodeManager)
+    def __init__(self):
+        super(BuildGceComponentImagesFactory, self).__init__(
+            "build_gce_component_images",
+            BuildGceComponentImages,
+            "Build Google Compute Engine VM Images For Each Service.",
+            BomSourceCodeManager,
+        )
 
-  def init_argparser(self, parser, defaults):
-    super(BuildGceComponentImagesFactory, self).init_argparser(
-        parser, defaults)
-    HalRunner.add_parser_args(parser, defaults)
+    def init_argparser(self, parser, defaults):
+        super(BuildGceComponentImagesFactory, self).init_argparser(parser, defaults)
+        HalRunner.add_parser_args(parser, defaults)
 
-    self.add_argument(
-        parser, 'halyard_release_track', defaults, 'stable',
-        choices=['nightly', 'stable'],
-        help='Which halyard release track to use when installing images.')
-    self.add_argument(
-        parser, 'skip_existing', defaults, False, type=bool,
-        help='Skip builds if the desired image already exists in GCE.')
-    self.add_argument(
-        parser, 'delete_existing', defaults, None, type=bool,
-        help='Delete pre-existing desired images from GCE.')
+        self.add_argument(
+            parser,
+            "halyard_release_track",
+            defaults,
+            "stable",
+            choices=["nightly", "stable"],
+            help="Which halyard release track to use when installing images.",
+        )
+        self.add_argument(
+            parser,
+            "skip_existing",
+            defaults,
+            False,
+            type=bool,
+            help="Skip builds if the desired image already exists in GCE.",
+        )
+        self.add_argument(
+            parser,
+            "delete_existing",
+            defaults,
+            None,
+            type=bool,
+            help="Delete pre-existing desired images from GCE.",
+        )
 
-    self.add_argument(
-        parser, 'build_gce_service_account', defaults, None,
-        help='Service account for building images.')
-    self.add_argument(
-        parser, 'build_gce_project', defaults, None,
-        help='Project to build image in.')
-    self.add_argument(
-        parser, 'build_gce_zone', defaults, 'us-central1-f',
-        help='Zone to build image in.')
+        self.add_argument(
+            parser,
+            "build_gce_service_account",
+            defaults,
+            None,
+            help="Service account for building images.",
+        )
+        self.add_argument(
+            parser,
+            "build_gce_project",
+            defaults,
+            None,
+            help="Project to build image in.",
+        )
+        self.add_argument(
+            parser,
+            "build_gce_zone",
+            defaults,
+            "us-central1-f",
+            help="Zone to build image in.",
+        )
 
-    halyard_install_sh = 'dev/halyard_install_component.sh'
-    self.add_argument(
-        parser, 'install_image_script', defaults, halyard_install_sh,
-        help='Script for installing images.')
+        halyard_install_sh = "dev/halyard_install_component.sh"
+        self.add_argument(
+            parser,
+            "install_image_script",
+            defaults,
+            halyard_install_sh,
+            help="Script for installing images.",
+        )
 
-    publish_image_sh = os.path.join(
-        os.path.dirname(__file__), '..', '..', 'google', 'dev',
-        'publish_gce_release.sh')
-    self.add_argument(
-        parser, 'publish_gce_image_script', defaults, publish_image_sh,
-        help='Script for publishing images to a project.')
+        publish_image_sh = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "google",
+            "dev",
+            "publish_gce_release.sh",
+        )
+        self.add_argument(
+            parser,
+            "publish_gce_image_script",
+            defaults,
+            publish_image_sh,
+            help="Script for publishing images to a project.",
+        )
 
-    self.add_argument(
-        parser, 'git_branch', defaults, None,
-        help='Github branch to get install scripts from.'
-             ' If none, then use the source repo branch that this script'
-             ' is running from.')
-    self.add_argument(
-        parser, 'bintray_org', defaults, None,
-        help='The bintray organization for the bintray_*_repositories.')
-    self.add_argument(
-        parser, 'bintray_debian_repository', defaults, None,
-        help='Repository where built debians were placed.')
-    self.add_argument(
-        parser, 'halyard_bom_bucket', defaults, 'halconfig',
-        help='The bucket manaing halyard BOMs and config profiles.')
+        self.add_argument(
+            parser,
+            "git_branch",
+            defaults,
+            None,
+            help="Github branch to get install scripts from."
+            " If none, then use the source repo branch that this script"
+            " is running from.",
+        )
+        self.add_argument(
+            parser,
+            "bintray_org",
+            defaults,
+            None,
+            help="The bintray organization for the bintray_*_repositories.",
+        )
+        self.add_argument(
+            parser,
+            "bintray_debian_repository",
+            defaults,
+            None,
+            help="Repository where built debians were placed.",
+        )
+        self.add_argument(
+            parser,
+            "halyard_bom_bucket",
+            defaults,
+            "halconfig",
+            help="The bucket manaing halyard BOMs and config profiles.",
+        )
 
 
 def register_commands(registry, subparsers, defaults):
-  BuildGceComponentImagesFactory().register(registry, subparsers, defaults)
+    BuildGceComponentImagesFactory().register(registry, subparsers, defaults)

--- a/dev/buildtool/image_commands.py
+++ b/dev/buildtool/image_commands.py
@@ -181,7 +181,7 @@ class BuildGceComponentImages(RepositoryCommandProcessor):
         return super(BuildGceComponentImages, self).ensure_local_repository(repository)
 
     def _do_can_skip_repository(self, repository):
-        if not repository.name in SPINNAKER_RUNNABLE_REPOSITORY_NAMES:
+        if repository.name not in SPINNAKER_RUNNABLE_REPOSITORY_NAMES:
             logging.debug(
                 "%s does not build a GCE component image -- skip", repository.name
             )

--- a/dev/buildtool/influxdb_metrics.py
+++ b/dev/buildtool/influxdb_metrics.py
@@ -35,9 +35,9 @@ import datetime
 import logging
 
 try:
-  from urllib2 import urlopen, Request
+    from urllib2 import urlopen, Request
 except ImportError:
-  from urllib.request import urlopen, Request
+    from urllib.request import urlopen, Request
 
 from buildtool import add_parser_argument
 from buildtool.inmemory_metrics import InMemoryMetricsRegistry
@@ -47,148 +47,177 @@ EPOCH = datetime.datetime(1970, 1, 1)
 SECONDS_PER_DAY = 24 * 60 * 60
 NANOS_PER_SECOND = 1000000000
 
+
 def to_timestamp(utc):
-  """Convert UTC datetime into epoch timestamp in nanoseconds for influxdb."""
-  time_delta = utc - EPOCH
-  epoch_secs = time_delta.seconds + time_delta.days * SECONDS_PER_DAY
-  epoch_nanos = epoch_secs * NANOS_PER_SECOND + time_delta.microseconds * 1000
-  return epoch_nanos
+    """Convert UTC datetime into epoch timestamp in nanoseconds for influxdb."""
+    time_delta = utc - EPOCH
+    epoch_secs = time_delta.seconds + time_delta.days * SECONDS_PER_DAY
+    epoch_nanos = epoch_secs * NANOS_PER_SECOND + time_delta.microseconds * 1000
+    return epoch_nanos
 
 
 class InfluxDbMetricsRegistry(InMemoryMetricsRegistry):
-  @staticmethod
-  def init_argument_parser(parser, defaults):
-    InMemoryMetricsRegistry.init_argument_parser(parser, defaults)
-    add_parser_argument(parser, 'influxdb_url', defaults,
-                        'http://localhost:8086',
-                        help='Server address to push metrics to.')
-    add_parser_argument(parser, 'influxdb_database', defaults,
-                        'SpinnakerBuildTool',
-                        help='Influxdb to push metrics to.')
-    add_parser_argument(
-        parser, 'influxdb_reiterate_gauge_secs', defaults, 60,
-        help='Reiterate gauge values for the specified period of seconds.'
-             ' This is because when they get chunked into time blocks, the'
-             'values become lost, in particular settling back to 0.')
+    @staticmethod
+    def init_argument_parser(parser, defaults):
+        InMemoryMetricsRegistry.init_argument_parser(parser, defaults)
+        add_parser_argument(
+            parser,
+            "influxdb_url",
+            defaults,
+            "http://localhost:8086",
+            help="Server address to push metrics to.",
+        )
+        add_parser_argument(
+            parser,
+            "influxdb_database",
+            defaults,
+            "SpinnakerBuildTool",
+            help="Influxdb to push metrics to.",
+        )
+        add_parser_argument(
+            parser,
+            "influxdb_reiterate_gauge_secs",
+            defaults,
+            60,
+            help="Reiterate gauge values for the specified period of seconds."
+            " This is because when they get chunked into time blocks, the"
+            "values become lost, in particular settling back to 0.",
+        )
 
-  def __init__(self, *pos_args, **kwargs):
-    super(InfluxDbMetricsRegistry, self).__init__(*pos_args, **kwargs)
-    self.__export_func_map = {
-        'COUNTER': self.__export_counter_points,
-        'GAUGE': self.__export_gauge_points,
-        'TIMER': self.__export_timer_points,
-    }
-    self.__recent_gauges = set([])
+    def __init__(self, *pos_args, **kwargs):
+        super(InfluxDbMetricsRegistry, self).__init__(*pos_args, **kwargs)
+        self.__export_func_map = {
+            "COUNTER": self.__export_counter_points,
+            "GAUGE": self.__export_gauge_points,
+            "TIMER": self.__export_timer_points,
+        }
+        self.__recent_gauges = set([])
 
-  def _do_flush_final_metrics(self):
-    """Implements interface."""
-    self.flush_updated_metrics()
+    def _do_flush_final_metrics(self):
+        """Implements interface."""
+        self.flush_updated_metrics()
 
-  def _do_flush_updated_metrics(self, updated_metrics):
-    """Implements interface.
+    def _do_flush_updated_metrics(self, updated_metrics):
+        """Implements interface.
 
-    We'll turn the metrics into events for when they changed
-    because influxDb doesnt really handle counters, rather it
-    just aggregates events. So we'll treat counter changes as events
-    with delta values from the prior counter.
-    """
-    super(InfluxDbMetricsRegistry, self)._do_flush_updated_metrics(
-        updated_metrics)
-    payload = []
+        We'll turn the metrics into events for when they changed
+        because influxDb doesnt really handle counters, rather it
+        just aggregates events. So we'll treat counter changes as events
+        with delta values from the prior counter.
+        """
+        super(InfluxDbMetricsRegistry, self)._do_flush_updated_metrics(updated_metrics)
+        payload = []
 
-    recent_gauges = self.__recent_gauges
-    self.__recent_gauges = set([])
-    for metric in updated_metrics:
-      name = metric.name
-      label_text = self.__to_label_text(metric)
-      ingest = self.__export_func_map[metric.family.family_type]
-      ingest(name, label_text, metric, payload)
+        recent_gauges = self.__recent_gauges
+        self.__recent_gauges = set([])
+        for metric in updated_metrics:
+            name = metric.name
+            label_text = self.__to_label_text(metric)
+            ingest = self.__export_func_map[metric.family.family_type]
+            ingest(name, label_text, metric, payload)
 
-    remaining_gauges = recent_gauges - self.__recent_gauges
-    self.__reiterate_recent_gauges(remaining_gauges, payload)
+        remaining_gauges = recent_gauges - self.__recent_gauges
+        self.__reiterate_recent_gauges(remaining_gauges, payload)
 
-    if not payload:
-      logging.debug('No metrics updated.')
-      return
+        if not payload:
+            logging.debug("No metrics updated.")
+            return
 
-    url = '{prefix}/write?db={db}'.format(
-        prefix=self.options.influxdb_url, db=self.options.influxdb_database)
-    payload_text = '\n'.join(payload)
-    request = Request(url, data=str.encode(payload_text))
-    request.get_method = lambda: 'POST'
-    try:
-      urlopen(request)
-      logging.debug('Updated %d metrics to %s', len(payload), url)
-    except IOError as ioex:
-      logging.error('Cannot write metrics to %s:\n%s', url, ioex)
+        url = "{prefix}/write?db={db}".format(
+            prefix=self.options.influxdb_url, db=self.options.influxdb_database
+        )
+        payload_text = "\n".join(payload)
+        request = Request(url, data=str.encode(payload_text))
+        request.get_method = lambda: "POST"
+        try:
+            urlopen(request)
+            logging.debug("Updated %d metrics to %s", len(payload), url)
+        except IOError as ioex:
+            logging.error("Cannot write metrics to %s:\n%s", url, ioex)
 
-  def __to_label_text(self, metric):
-    return ','.join(['%s=%s' % (key, value)
-                     for key, value in metric.labels.items()
-                     if value != ''])
+    def __to_label_text(self, metric):
+        return ",".join(
+            [
+                "%s=%s" % (key, value)
+                for key, value in metric.labels.items()
+                if value != ""
+            ]
+        )
 
-  def __reiterate_recent_gauges(self, gauges, payload):
-    now = datetime.datetime.utcnow()
-    keep_if_newer_than = (
-        now - datetime.timedelta(0, self.options.influxdb_reiterate_gauge_secs))
+    def __reiterate_recent_gauges(self, gauges, payload):
+        now = datetime.datetime.utcnow()
+        keep_if_newer_than = now - datetime.timedelta(
+            0, self.options.influxdb_reiterate_gauge_secs
+        )
 
-    for gauge in gauges:
-      current = gauge.timeseries[-1]
-      if gauge.value != 0 or current.utc > keep_if_newer_than:
-        # Gauge is still lingering in our reporting
-        self.__recent_gauges.add(gauge)
+        for gauge in gauges:
+            current = gauge.timeseries[-1]
+            if gauge.value != 0 or current.utc > keep_if_newer_than:
+                # Gauge is still lingering in our reporting
+                self.__recent_gauges.add(gauge)
 
-      payload.append(
-          self.__to_payload_line('gauge', gauge.name,
-                                 self.__to_label_text(gauge),
-                                 current.value, now))
+            payload.append(
+                self.__to_payload_line(
+                    "gauge", gauge.name, self.__to_label_text(gauge), current.value, now
+                )
+            )
 
-  def __to_payload_line(self, type_name, name, labels, value, utc):
-    if labels.endswith(','):
-      # This can happen if we have a context but no labels for this occurance
-      labels = labels[:-1]
+    def __to_payload_line(self, type_name, name, labels, value, utc):
+        if labels.endswith(","):
+            # This can happen if we have a context but no labels for this occurance
+            labels = labels[:-1]
 
-    if labels:
-      series = '{name}__{type},{labels}'.format(
-          name=name, type=type_name, labels=labels)
-    else:
-      series = '{name}__{type}'.format(name=name, type=type_name)
-    return '{series} value={value} {time}'.format(
-        series=series, value=value, time=to_timestamp(utc))
+        if labels:
+            series = "{name}__{type},{labels}".format(
+                name=name, type=type_name, labels=labels
+            )
+        else:
+            series = "{name}__{type}".format(name=name, type=type_name)
+        return "{series} value={value} {time}".format(
+            series=series, value=value, time=to_timestamp(utc)
+        )
 
-  def __export_counter_points(self, name, label_text, metric, payload):
-    prev_value = 0
-    for entry in metric.mark_as_delta():
-      delta_value = entry.value - prev_value
-      prev_value = entry.value
-      payload.append(
-          self.__to_payload_line('counter', name, label_text,
-                                 delta_value, entry.utc))
+    def __export_counter_points(self, name, label_text, metric, payload):
+        prev_value = 0
+        for entry in metric.mark_as_delta():
+            delta_value = entry.value - prev_value
+            prev_value = entry.value
+            payload.append(
+                self.__to_payload_line(
+                    "counter", name, label_text, delta_value, entry.utc
+                )
+            )
 
-  def __export_gauge_points(self, name, label_text, metric, payload):
-    self.__recent_gauges.add(metric)
-    for entry in metric.mark_as_delta():
-      payload.append(
-          self.__to_payload_line('gauge', name, label_text,
-                                 entry.value, entry.utc))
+    def __export_gauge_points(self, name, label_text, metric, payload):
+        self.__recent_gauges.add(metric)
+        for entry in metric.mark_as_delta():
+            payload.append(
+                self.__to_payload_line(
+                    "gauge", name, label_text, entry.value, entry.utc
+                )
+            )
 
-  def __export_timer_points(self, name, label_text, metric, payload):
-    prev_count = 0
-    prev_total = 0
-    for entry in metric.mark_as_delta():
-      count = entry.value[0]
-      total_secs = entry.value[1]
-      delta_count = count - prev_count
-      delta_total = total_secs - prev_total
-      prev_count = count
-      prev_total = total_secs
-      payload.append(
-          self.__to_payload_line('count', name, label_text,
-                                 delta_count, entry.utc))
-      payload.append(
-          self.__to_payload_line('totalSecs', name, label_text,
-                                 delta_total, entry.utc))
-      avg_secs = delta_total / delta_count
-      payload.append(
-          self.__to_payload_line('AvgSecs', name, label_text,
-                                 avg_secs, entry.utc))
+    def __export_timer_points(self, name, label_text, metric, payload):
+        prev_count = 0
+        prev_total = 0
+        for entry in metric.mark_as_delta():
+            count = entry.value[0]
+            total_secs = entry.value[1]
+            delta_count = count - prev_count
+            delta_total = total_secs - prev_total
+            prev_count = count
+            prev_total = total_secs
+            payload.append(
+                self.__to_payload_line(
+                    "count", name, label_text, delta_count, entry.utc
+                )
+            )
+            payload.append(
+                self.__to_payload_line(
+                    "totalSecs", name, label_text, delta_total, entry.utc
+                )
+            )
+            avg_secs = delta_total / delta_count
+            payload.append(
+                self.__to_payload_line("AvgSecs", name, label_text, avg_secs, entry.utc)
+            )

--- a/dev/buildtool/inmemory_metrics.py
+++ b/dev/buildtool/inmemory_metrics.py
@@ -44,297 +44,312 @@ import os
 import sys
 import threading
 
-from buildtool import (
-    add_parser_argument,
-    write_to_path)
+from buildtool import add_parser_argument, write_to_path
 
 from buildtool.base_metrics import (
     BaseMetricsRegistry,
     Counter,
     Gauge,
     Timer,
-    MetricFamily)
+    MetricFamily,
+)
 
 SNAPSHOT_CATEGORY = {
-    MetricFamily.COUNTER: 'counters',
-    MetricFamily.GAUGE: 'gauges',
-    MetricFamily.TIMER: 'timers'
+    MetricFamily.COUNTER: "counters",
+    MetricFamily.GAUGE: "gauges",
+    MetricFamily.TIMER: "timers",
 }
 
-class DataPoint(collections.namedtuple('DataPoint', ['value', 'utc'])):
-  """A time-series data point."""
-  pass
+
+class DataPoint(collections.namedtuple("DataPoint", ["value", "utc"])):
+    """A time-series data point."""
+
+    pass
 
 
 class InMemoryCounter(Counter):
-  """Specializes for in memory tracking.
+    """Specializes for in memory tracking.
 
-  This class also supports systems that want change events
-  rather than aggregated counters. To provide this support,
-  we have "mark as delta" that returns each of the last events
-  since the last mark with the counter values relative to the previous
-  event (how much was counted) rather than absolute.
+    This class also supports systems that want change events
+    rather than aggregated counters. To provide this support,
+    we have "mark as delta" that returns each of the last events
+    since the last mark with the counter values relative to the previous
+    event (how much was counted) rather than absolute.
 
-  We'll still accumulate values and write them to files for possible
-  convienence if influxDB is not available.
-  """
-  # pylint: disable=too-few-public-methods
-
-  CATEGORY = SNAPSHOT_CATEGORY[MetricFamily.COUNTER]
-
-  def __init__(self, family, labels):
-    super(InMemoryCounter, self).__init__(family, labels)
-    self.__timeseries = []
-    self.__timeseries_mutex = threading.Lock()
-    self.__mark = (0, 0)
-
-  def mark(self):
-    """Return the slice of changes since the last mark."""
-    with self.__timeseries_mutex:
-      count = len(self.__timeseries)
-      start = self.__mark[0]
-      self.__mark = (count, self.__timeseries[-1][0])
-    return self.__timeseries[start:count]
-
-  def mark_as_delta(self):
-    """Return the slice of changes since the last mark.
-
-    Return values as delta since previous known value.
+    We'll still accumulate values and write them to files for possible
+    convienence if influxDB is not available.
     """
-    with self.__timeseries_mutex:
-      prev_value = self.__mark[1]
-    raw_result = self.mark()
-    result = []
-    for entry in raw_result:
-      delta = entry.value - prev_value
-      result.append(DataPoint(delta, entry.utc))
 
-    return result
+    # pylint: disable=too-few-public-methods
 
-  def touch(self, utc=None):
-    super(InMemoryCounter, self).touch(utc=utc)
-    with self.__timeseries_mutex:
-      self.__timeseries.append(DataPoint(self.count, self.last_modified))
+    CATEGORY = SNAPSHOT_CATEGORY[MetricFamily.COUNTER]
 
-  def append_to_metrics_snapshot(self, snapshot):
-    """Add this counter to the given tsnapshot."""
-    with self.__timeseries_mutex:
-      values = [{'time': point.utc.isoformat(), 'value': point.value}
-                for point in self.__timeseries]
-    family_timeseries = snapshot[self.CATEGORY][self.name]['collectors']
-    family_timeseries.append({
-        'labels': self.labels,
-        'values': values})
-    return len(values)
+    def __init__(self, family, labels):
+        super(InMemoryCounter, self).__init__(family, labels)
+        self.__timeseries = []
+        self.__timeseries_mutex = threading.Lock()
+        self.__mark = (0, 0)
+
+    def mark(self):
+        """Return the slice of changes since the last mark."""
+        with self.__timeseries_mutex:
+            count = len(self.__timeseries)
+            start = self.__mark[0]
+            self.__mark = (count, self.__timeseries[-1][0])
+        return self.__timeseries[start:count]
+
+    def mark_as_delta(self):
+        """Return the slice of changes since the last mark.
+
+        Return values as delta since previous known value.
+        """
+        with self.__timeseries_mutex:
+            prev_value = self.__mark[1]
+        raw_result = self.mark()
+        result = []
+        for entry in raw_result:
+            delta = entry.value - prev_value
+            result.append(DataPoint(delta, entry.utc))
+
+        return result
+
+    def touch(self, utc=None):
+        super(InMemoryCounter, self).touch(utc=utc)
+        with self.__timeseries_mutex:
+            self.__timeseries.append(DataPoint(self.count, self.last_modified))
+
+    def append_to_metrics_snapshot(self, snapshot):
+        """Add this counter to the given tsnapshot."""
+        with self.__timeseries_mutex:
+            values = [
+                {"time": point.utc.isoformat(), "value": point.value}
+                for point in self.__timeseries
+            ]
+        family_timeseries = snapshot[self.CATEGORY][self.name]["collectors"]
+        family_timeseries.append({"labels": self.labels, "values": values})
+        return len(values)
 
 
 class InMemoryGauge(Gauge):
-  """Specializes for in memory tracking."""
-  # pylint: disable=too-few-public-methods
+    """Specializes for in memory tracking."""
 
-  CATEGORY = SNAPSHOT_CATEGORY[MetricFamily.GAUGE]
+    # pylint: disable=too-few-public-methods
 
-  @property
-  def timeseries(self):
-    return self.__timeseries
+    CATEGORY = SNAPSHOT_CATEGORY[MetricFamily.GAUGE]
 
-  def __init__(self, family, labels):
-    super(InMemoryGauge, self).__init__(family, labels)
-    self.__timeseries = []
-    self.__timeseries_mutex = threading.Lock()
-    self.__mark = 0
+    @property
+    def timeseries(self):
+        return self.__timeseries
 
-  def mark(self):
-    """Return the slice of changes since the last mark."""
-    with self.__timeseries_mutex:
-      count = len(self.__timeseries)
-      start = self.__mark
-      self.__mark = count
-    return self.__timeseries[start:count]
+    def __init__(self, family, labels):
+        super(InMemoryGauge, self).__init__(family, labels)
+        self.__timeseries = []
+        self.__timeseries_mutex = threading.Lock()
+        self.__mark = 0
 
-  def mark_as_delta(self):
-    return self.mark()
+    def mark(self):
+        """Return the slice of changes since the last mark."""
+        with self.__timeseries_mutex:
+            count = len(self.__timeseries)
+            start = self.__mark
+            self.__mark = count
+        return self.__timeseries[start:count]
 
-  def touch(self, utc=None):
-    super(InMemoryGauge, self).touch(utc=utc)
-    data_point = DataPoint(self.value, self.last_modified)
-    with self.__timeseries_mutex:
-      self.__timeseries.append(data_point)
+    def mark_as_delta(self):
+        return self.mark()
 
-  def append_to_metrics_snapshot(self, snapshot):
-    """Add this gauge to the given snapshot."""
-    with self.__timeseries_mutex:
-      values = [{'time': point.utc.isoformat(), 'value': point.value}
-                for point in self.__timeseries]
+    def touch(self, utc=None):
+        super(InMemoryGauge, self).touch(utc=utc)
+        data_point = DataPoint(self.value, self.last_modified)
+        with self.__timeseries_mutex:
+            self.__timeseries.append(data_point)
 
-    family_timeseries = snapshot[self.CATEGORY][self.name]['collectors']
-    family_timeseries.append({
-        'labels': self.labels,
-        'values': values})
-    return len(values)
+    def append_to_metrics_snapshot(self, snapshot):
+        """Add this gauge to the given snapshot."""
+        with self.__timeseries_mutex:
+            values = [
+                {"time": point.utc.isoformat(), "value": point.value}
+                for point in self.__timeseries
+            ]
+
+        family_timeseries = snapshot[self.CATEGORY][self.name]["collectors"]
+        family_timeseries.append({"labels": self.labels, "values": values})
+        return len(values)
 
 
 class InMemoryTimer(Timer):
-  """Specializes for in memory tracking."""
-  # pylint: disable=too-few-public-methods
+    """Specializes for in memory tracking."""
 
-  CATEGORY = SNAPSHOT_CATEGORY[MetricFamily.TIMER]
+    # pylint: disable=too-few-public-methods
 
-  def __init__(self, family, labels):
-    super(InMemoryTimer, self).__init__(family, labels)
-    self.__timeseries = []
-    self.__timeseries_mutex = threading.Lock()
-    self.__mark = (0, 0, 0)
+    CATEGORY = SNAPSHOT_CATEGORY[MetricFamily.TIMER]
 
-  def mark(self):
-    """Return the slice of changes since the last mark."""
-    with self.__timeseries_mutex:
-      count = len(self.__timeseries)
-      start = self.__mark[0]
-      self.__mark = (count,
-                     self.__timeseries[-1][0][0],
-                     self.__timeseries[-1][0][1])
-    return self.__timeseries[start:count]
+    def __init__(self, family, labels):
+        super(InMemoryTimer, self).__init__(family, labels)
+        self.__timeseries = []
+        self.__timeseries_mutex = threading.Lock()
+        self.__mark = (0, 0, 0)
 
-  def mark_as_delta(self):
-    """Return the slice of changes since the last mark.
+    def mark(self):
+        """Return the slice of changes since the last mark."""
+        with self.__timeseries_mutex:
+            count = len(self.__timeseries)
+            start = self.__mark[0]
+            self.__mark = (
+                count,
+                self.__timeseries[-1][0][0],
+                self.__timeseries[-1][0][1],
+            )
+        return self.__timeseries[start:count]
 
-    Return values as delta since previous known value.
-    """
-    with self.__timeseries_mutex:
-      prev_count = self.__mark[1]
-      prev_total = self.__mark[2]
+    def mark_as_delta(self):
+        """Return the slice of changes since the last mark.
 
-    raw_result = self.mark()
-    result = []
-    for entry in raw_result:
-      delta_count = entry.value[0] - prev_count
-      delta_total = entry.value[1] - prev_total
-      result.append(DataPoint((delta_count, delta_total), entry.utc))
+        Return values as delta since previous known value.
+        """
+        with self.__timeseries_mutex:
+            prev_count = self.__mark[1]
+            prev_total = self.__mark[2]
 
-    return result
+        raw_result = self.mark()
+        result = []
+        for entry in raw_result:
+            delta_count = entry.value[0] - prev_count
+            delta_total = entry.value[1] - prev_total
+            result.append(DataPoint((delta_count, delta_total), entry.utc))
 
-  def touch(self, utc=None):
-    super(InMemoryTimer, self).touch(utc=utc)
-    with self.__timeseries_mutex:
-      self.__timeseries.append(DataPoint((self.count, self.total_seconds),
-                                         self.last_modified))
+        return result
 
-  def append_to_metrics_snapshot(self, snapshot):
-    """Add this gauge to the given snapshot."""
-    with self.__timeseries_mutex:
-      values = [{'time': point.utc.isoformat(),
-                 'count': point.value[0],
-                 'totalSecs': point.value[1]}
-                for point in self.__timeseries]
-    family_timeseries = snapshot[self.CATEGORY][self.name]['collectors']
-    family_timeseries.append({
-        'labels': self.labels,
-        'values': values})
-    return len(values)
+    def touch(self, utc=None):
+        super(InMemoryTimer, self).touch(utc=utc)
+        with self.__timeseries_mutex:
+            self.__timeseries.append(
+                DataPoint((self.count, self.total_seconds), self.last_modified)
+            )
+
+    def append_to_metrics_snapshot(self, snapshot):
+        """Add this gauge to the given snapshot."""
+        with self.__timeseries_mutex:
+            values = [
+                {
+                    "time": point.utc.isoformat(),
+                    "count": point.value[0],
+                    "totalSecs": point.value[1],
+                }
+                for point in self.__timeseries
+            ]
+        family_timeseries = snapshot[self.CATEGORY][self.name]["collectors"]
+        family_timeseries.append({"labels": self.labels, "values": values})
+        return len(values)
 
 
 class InMemoryMetricsRegistry(BaseMetricsRegistry):
-  """Implements MetricsRegistry using in memroy DataPoints."""
-  # pylint: disable=too-few-public-methods
+    """Implements MetricsRegistry using in memroy DataPoints."""
 
-  @staticmethod
-  def init_argument_parser(parser, defaults):
-    """Initialize argument parser with in-memory parameters."""
-    if hasattr(parser, 'added_inmemory'):
-      return
-    add_parser_argument(
-        parser, 'metrics_dir', defaults, None,
-        help='Path to file to write metrics into')
-    parser.added_inmemory = True
+    # pylint: disable=too-few-public-methods
 
-  def __init__(self, options):
-    super(InMemoryMetricsRegistry, self).__init__(options)
-    self.__metrics_snapshot_prototype = {
-        SNAPSHOT_CATEGORY[MetricFamily.COUNTER]: {},
-        SNAPSHOT_CATEGORY[MetricFamily.GAUGE]: {},
-        SNAPSHOT_CATEGORY[MetricFamily.TIMER]: {},
-        'argv': sys.argv,
-        'job': options.program if hasattr(options, 'program') else 'buildtool',
-        'options': vars(self.options),
-        'pid': os.getpid(),
-        'start_time': datetime.datetime.utcnow().isoformat()
-    }
+    @staticmethod
+    def init_argument_parser(parser, defaults):
+        """Initialize argument parser with in-memory parameters."""
+        if hasattr(parser, "added_inmemory"):
+            return
+        add_parser_argument(
+            parser,
+            "metrics_dir",
+            defaults,
+            None,
+            help="Path to file to write metrics into",
+        )
+        parser.added_inmemory = True
 
-    self.__known_counter_families = {}
-    self.__known_gauge_families = {}
+    def __init__(self, options):
+        super(InMemoryMetricsRegistry, self).__init__(options)
+        self.__metrics_snapshot_prototype = {
+            SNAPSHOT_CATEGORY[MetricFamily.COUNTER]: {},
+            SNAPSHOT_CATEGORY[MetricFamily.GAUGE]: {},
+            SNAPSHOT_CATEGORY[MetricFamily.TIMER]: {},
+            "argv": sys.argv,
+            "job": options.program if hasattr(options, "program") else "buildtool",
+            "options": vars(self.options),
+            "pid": os.getpid(),
+            "start_time": datetime.datetime.utcnow().isoformat(),
+        }
 
-    self.__metrics_path = None
-    if not options.monitoring_enabled:
-      logging.warning('Monitoring is disabled')
-      return
+        self.__known_counter_families = {}
+        self.__known_gauge_families = {}
 
-    pid = os.getpid()
-    dir_path = (options.metrics_dir
-                or os.path.join(options.output_dir, 'metrics'))
-    self.__metrics_path = os.path.join(
-        dir_path,
-        'metrics__{command}__{pid}.json'.format(
-            command=options.command, pid=pid))
-    logging.debug('Metrics snapshots will write to %s', self.__metrics_path)
+        self.__metrics_path = None
+        if not options.monitoring_enabled:
+            logging.warning("Monitoring is disabled")
+            return
 
-  def _do_make_family(
-      self, family_type, name, label_names):
-    """Implements interface."""
-    return self.__new_family(name, label_names, family_type)
+        pid = os.getpid()
+        dir_path = options.metrics_dir or os.path.join(options.output_dir, "metrics")
+        self.__metrics_path = os.path.join(
+            dir_path,
+            "metrics__{command}__{pid}.json".format(command=options.command, pid=pid),
+        )
+        logging.debug("Metrics snapshots will write to %s", self.__metrics_path)
 
-  def make_snapshot(self):
-    """Writes metrics to file."""
-    snapshot = dict(self.__metrics_snapshot_prototype)
-    snapshot['end_time'] = datetime.datetime.utcnow().isoformat()
+    def _do_make_family(self, family_type, name, label_names):
+        """Implements interface."""
+        return self.__new_family(name, label_names, family_type)
 
-    total_metric_count = 0
-    total_datapoint_count = 0
-    for family in self.metric_family_list:
-      all_instances = family.instance_list
-      total_metric_count += len(all_instances)
-      snapshot_category = SNAPSHOT_CATEGORY[family.family_type]
-      snapshot[snapshot_category][family.name]['collectors'] = []
-      for metric in all_instances:
-        total_datapoint_count += metric.append_to_metrics_snapshot(snapshot)
-    return snapshot, total_metric_count, total_datapoint_count
+    def make_snapshot(self):
+        """Writes metrics to file."""
+        snapshot = dict(self.__metrics_snapshot_prototype)
+        snapshot["end_time"] = datetime.datetime.utcnow().isoformat()
 
-  def __flush_snapshot(self, snapshot):
-    """Writes metric snapshot to file."""
-    text = json.JSONEncoder(indent=2, separators=(',', ': ')).encode(snapshot)
+        total_metric_count = 0
+        total_datapoint_count = 0
+        for family in self.metric_family_list:
+            all_instances = family.instance_list
+            total_metric_count += len(all_instances)
+            snapshot_category = SNAPSHOT_CATEGORY[family.family_type]
+            snapshot[snapshot_category][family.name]["collectors"] = []
+            for metric in all_instances:
+                total_datapoint_count += metric.append_to_metrics_snapshot(snapshot)
+        return snapshot, total_metric_count, total_datapoint_count
 
-    # Use intermediate temp file to not clobber old snapshot metrics on failure.
-    metrics_path = self.__metrics_path
-    tmp_path = metrics_path + '.tmp'
-    write_to_path(text, tmp_path)
-    os.rename(tmp_path, metrics_path)
+    def __flush_snapshot(self, snapshot):
+        """Writes metric snapshot to file."""
+        text = json.JSONEncoder(indent=2, separators=(",", ": ")).encode(snapshot)
 
-  def _do_flush_final_metrics(self):
-    """Writes metrics to file."""
-    snapshot, metric_count, datapoint_count = self.make_snapshot()
-    logging.debug('Flushing final snapshot with %d data points over %d metrics',
-                  datapoint_count, metric_count)
-    self.__flush_snapshot(snapshot)
+        # Use intermediate temp file to not clobber old snapshot metrics on failure.
+        metrics_path = self.__metrics_path
+        tmp_path = metrics_path + ".tmp"
+        write_to_path(text, tmp_path)
+        os.rename(tmp_path, metrics_path)
 
-  def _do_flush_updated_metrics(self, updated_metrics):
-    """Implements interface."""
-    snapshot, _, _ = self.make_snapshot()
-    self.__flush_snapshot(snapshot)
+    def _do_flush_final_metrics(self):
+        """Writes metrics to file."""
+        snapshot, metric_count, datapoint_count = self.make_snapshot()
+        logging.debug(
+            "Flushing final snapshot with %d data points over %d metrics",
+            datapoint_count,
+            metric_count,
+        )
+        self.__flush_snapshot(snapshot)
 
-  def __new_family(self, name, label_names, family_type):
-    """Defines a new family container instance."""
-    # pylint: disable=unused-argument
-    # We dont use label_names, but take it because it is part of the interface
-    # that the calling methods have.
-    self.__metrics_snapshot_prototype[SNAPSHOT_CATEGORY[family_type]][name] = {
-        'name': name,
-        'type': family_type,
-        'collectors': []
-    }
-    type_to_factory = {
-        MetricFamily.COUNTER: InMemoryCounter,
-        MetricFamily.GAUGE: InMemoryGauge,
-        MetricFamily.TIMER: InMemoryTimer
-    }
-    factory = type_to_factory[family_type]
-    return MetricFamily(self, name, factory, family_type)
+    def _do_flush_updated_metrics(self, updated_metrics):
+        """Implements interface."""
+        snapshot, _, _ = self.make_snapshot()
+        self.__flush_snapshot(snapshot)
+
+    def __new_family(self, name, label_names, family_type):
+        """Defines a new family container instance."""
+        # pylint: disable=unused-argument
+        # We dont use label_names, but take it because it is part of the interface
+        # that the calling methods have.
+        self.__metrics_snapshot_prototype[SNAPSHOT_CATEGORY[family_type]][name] = {
+            "name": name,
+            "type": family_type,
+            "collectors": [],
+        }
+        type_to_factory = {
+            MetricFamily.COUNTER: InMemoryCounter,
+            MetricFamily.GAUGE: InMemoryGauge,
+            MetricFamily.TIMER: InMemoryTimer,
+        }
+        factory = type_to_factory[family_type]
+        return MetricFamily(self, name, factory, family_type)

--- a/dev/buildtool/inspection_commands.py
+++ b/dev/buildtool/inspection_commands.py
@@ -58,10 +58,10 @@ import sys
 import yaml
 
 try:
-  from urllib2 import urlopen, HTTPError, Request
+    from urllib2 import urlopen, HTTPError, Request
 except ImportError:
-  from urllib.request import urlopen, Request
-  from urllib.error import HTTPError
+    from urllib.request import urlopen, Request
+    from urllib.error import HTTPError
 
 
 from buildtool import (
@@ -77,1324 +77,1515 @@ from buildtool import (
     write_to_path,
     ConfigError,
     UnexpectedError,
-    ResponseError)
+    ResponseError,
+)
 
 
 def my_unicode_representer(self, data):
-  return self.represent_str(data.encode('utf-8'))
+    return self.represent_str(data.encode("utf-8"))
+
 
 if sys.version_info[0] == 2:
-  yaml.representer.Representer.add_representer(str, my_unicode_representer)
+    yaml.representer.Representer.add_representer(str, my_unicode_representer)
 
 yaml.Dumper.ignore_aliases = lambda *args: True
 
 
 class CollectBomVersions(CommandProcessor):
-  """Determine which artifact versions are in use by which boms.
+    """Determine which artifact versions are in use by which boms.
 
-  Ultimately this produces an inverse map of boms. Whereas a bom
-  maps to a collection of services and their build information, this
-  produces a map of service build information and which boms they apepar in.
-  Historically boms were unique builds, however this wasnt supposed to be
-  the case, and is no longer the case.
+    Ultimately this produces an inverse map of boms. Whereas a bom
+    maps to a collection of services and their build information, this
+    produces a map of service build information and which boms they apepar in.
+    Historically boms were unique builds, however this wasnt supposed to be
+    the case, and is no longer the case.
 
-  The map is further partitioned into two files where one contains
-  released boms and the other unreleased boms. Unreleased boms are not
-  necessarily obsolete.
+    The map is further partitioned into two files where one contains
+    released boms and the other unreleased boms. Unreleased boms are not
+    necessarily obsolete.
 
-  Emits files:
-     bom_list.txt: A list of all the boms, released and unreleased
-     bad_boms.txt: A list of malformed boms with what makes it malformed.
-     all_bom_sevice_map.yml: The inverse service version mapping of all the boms
-     released_bom_service_map.yml: The subset of all_bom_service_map for boms
-        that were released.
-     unreleased_bom_service_map.yml: The subset of all_bom_service_map for
-        service versions that only appear in unreleased boms.
-     nonstandard_boms.txt: A list of boms whose artifactSources do not match
-       the values specified via options. Unspecified options match anything.
-     config.yml: The configuration values used to determine standard compliance.
-  """
-
-  RELEASED_VERSION_MATCHER = re.compile(r'^\d+(?:\.\d+){2}$')
-
-  @staticmethod
-  def url_to_bom_name(url):
-    """Given a url to a bom, return the name of the bom."""
-    name = url
-    dash = name.rfind('/')
-    if dash >= 0:
-      name = name[dash + 1:]
-    return os.path.splitext(name)[0]
-
-  def __init__(self, factory, options, **kwargs):
-    if options.bintray_org is None != options.bintray_debian_repository is None:
-      raise_and_log_error(
-          ConfigError('Either neither or both "bintray_org"'
-                      ' and "bintray_debian_repository" should be specified'))
-    self.__bad_files = {}
-    self.__non_standard_boms = {}
-
-    # We're going to have a bunch of threads each writing into different keys
-    # in order to deconflict with one another lockless. Then we'll aggregate
-    # it all together when we're done processing for a single aggregate result.
-    self.__per_thread_result_map = {}
-
-    self.__expect_docker_registry = options.docker_registry
-    self.__expect_debian_repository = (
-        'https://dl.bintray.com/%s/%s' % (options.bintray_org,
-                                          options.bintray_debian_repository)
-        if options.bintray_org
-        else None)
-
-    super(CollectBomVersions, self).__init__(
-        factory, options, **kwargs)
-
-  def load_bom_from_url(self, url):
-    """Returns the bom specification dict from a gcs url."""
-    logging.debug('Loading %s', url)
-    try:
-      text = check_subprocess('gsutil cat ' + url)
-      return yaml.safe_load(text)
-    except Exception as ex:
-      self.__bad_files[self.url_to_bom_name(url)] = exception_to_message(ex)
-      maybe_log_exception('load_from_from_url', ex,
-                          action_msg='Skipping %s' % url)
-      return None
-
-  def extract_bom_info(self, bom):
-    """Return a minimal dict identifying this BOM.
-
-    This also includes non-standard config specified by this BOM.
+    Emits files:
+       bom_list.txt: A list of all the boms, released and unreleased
+       bad_boms.txt: A list of malformed boms with what makes it malformed.
+       all_bom_sevice_map.yml: The inverse service version mapping of all the boms
+       released_bom_service_map.yml: The subset of all_bom_service_map for boms
+          that were released.
+       unreleased_bom_service_map.yml: The subset of all_bom_service_map for
+          service versions that only appear in unreleased boms.
+       nonstandard_boms.txt: A list of boms whose artifactSources do not match
+         the values specified via options. Unspecified options match anything.
+       config.yml: The configuration values used to determine standard compliance.
     """
-    info = {
-        'bom_version': bom['version'],
-        'bom_timestamp': bom.get('timestamp', 'NotRecorded')
-    }
-    artifact_sources = bom.get('artifactSources')
-    if artifact_sources is None:
-      logging.warning('%s does not have artifactSources', bom['version'])
-      return info
 
-    def add_if_nonstandard(name, expect):
-      if artifact_sources[name] != expect:
-        logging.warning('%s has nonstandard %s = %s',
-                        bom['version'], name, artifact_sources[name])
-        info[name] = artifact_sources[name]
+    RELEASED_VERSION_MATCHER = re.compile(r"^\d+(?:\.\d+){2}$")
 
-    add_if_nonstandard('dockerRegistry', self.__expect_docker_registry)
-    add_if_nonstandard('debianRepository', self.__expect_debian_repository)
-    if len(info) > 2:
-      problems = dict(info)
-      del problems['bom_version']
-      del problems['bom_timestamp']
-      self.__non_standard_boms[bom['version']] = problems
+    @staticmethod
+    def url_to_bom_name(url):
+        """Given a url to a bom, return the name of the bom."""
+        name = url
+        dash = name.rfind("/")
+        if dash >= 0:
+            name = name[dash + 1 :]
+        return os.path.splitext(name)[0]
 
-    return info
+    def __init__(self, factory, options, **kwargs):
+        if options.bintray_org is None != options.bintray_debian_repository is None:
+            raise_and_log_error(
+                ConfigError(
+                    'Either neither or both "bintray_org"'
+                    ' and "bintray_debian_repository" should be specified'
+                )
+            )
+        self.__bad_files = {}
+        self.__non_standard_boms = {}
 
-  def analyze_bom(self, bom):
-    """Analyzes one bom and breaks it down into this threads result_map.
+        # We're going to have a bunch of threads each writing into different keys
+        # in order to deconflict with one another lockless. Then we'll aggregate
+        # it all together when we're done processing for a single aggregate result.
+        self.__per_thread_result_map = {}
 
-    Boms are processed within a single thread, but multiple boms can be
-    processed in different threads.
-    """
-    tid = current_thread().name
-    thread_service_map = self.__per_thread_result_map.get(tid, {})
-    self.__per_thread_result_map[tid] = thread_service_map
+        self.__expect_docker_registry = options.docker_registry
+        self.__expect_debian_repository = (
+            "https://dl.bintray.com/%s/%s"
+            % (options.bintray_org, options.bintray_debian_repository)
+            if options.bintray_org
+            else None
+        )
 
-    bom_info = self.extract_bom_info(bom)
-    for name, entry in bom['services'].items():
-      if name == 'defaultArtifact':
-        continue
-      build_version = entry['version']
-      parts = build_version.split('-', 1)
-      if len(parts) == 1:
-        version = parts[0]
-        buildnum = 'NotRecorded'
-      else:
-        version, buildnum = parts
+        super(CollectBomVersions, self).__init__(factory, options, **kwargs)
 
-      commit = entry.get('commit', 'NotRecorded')
-      service_record = thread_service_map.get(name)
-      if service_record is None:
-        service_record = {}
-        thread_service_map[name] = service_record
-      version_map = service_record.get(version)
-      if version_map is None:
-        version_map = {}
-        service_record[version] = version_map
-      commit_map = version_map.get(commit)
-      if commit_map is None:
-        commit_map = {}
-        version_map[commit] = commit_map
-      build_list = commit_map.get(buildnum)
-      if build_list is None:
-        build_list = []
-        commit_map[buildnum] = build_list
+    def load_bom_from_url(self, url):
+        """Returns the bom specification dict from a gcs url."""
+        logging.debug("Loading %s", url)
+        try:
+            text = check_subprocess("gsutil cat " + url)
+            return yaml.safe_load(text)
+        except Exception as ex:
+            self.__bad_files[self.url_to_bom_name(url)] = exception_to_message(ex)
+            maybe_log_exception(
+                "load_from_from_url", ex, action_msg="Skipping %s" % url
+            )
+            return None
 
-      build_list.append(bom_info)
+    def extract_bom_info(self, bom):
+        """Return a minimal dict identifying this BOM.
 
-  def ingest_bom(self, line):
-    """Function to ingest a single bom into the result map."""
-    bom = self.load_bom_from_url(line)
-    if not bom:
-      return
-    try:
-      if bom['version'] + '.yml' != line[line.rfind('/') + 1:]:
-        message = 'BOM version "%s" != filename "%s"' % (bom['version'], line)
-        self.__bad_files[self.url_to_bom_name(line.strip())] = message
-        logging.warning(message)
-        raise_and_log_error(UnexpectedError(message))
-      self.analyze_bom(bom)
-    except Exception as ex:
-      self.__bad_files[self.url_to_bom_name(line.strip())] = (
-          exception_to_message(ex))
-      maybe_log_exception('analyze_bom', ex,
-                          action_msg='Skipping %s' % line)
+        This also includes non-standard config specified by this BOM.
+        """
+        info = {
+            "bom_version": bom["version"],
+            "bom_timestamp": bom.get("timestamp", "NotRecorded"),
+        }
+        artifact_sources = bom.get("artifactSources")
+        if artifact_sources is None:
+            logging.warning("%s does not have artifactSources", bom["version"])
+            return info
 
-  def join_result_maps(self):
-    """Join the individual thread result maps into a single one.
+        def add_if_nonstandard(name, expect):
+            if artifact_sources[name] != expect:
+                logging.warning(
+                    "%s has nonstandard %s = %s",
+                    bom["version"],
+                    name,
+                    artifact_sources[name],
+                )
+                info[name] = artifact_sources[name]
 
-    This assumes a single threaded environment.
-    """
-    def join_buildnums(commit_buildnums, result_buildnums):
-      for buildnum, info_list in commit_buildnums.items():
-        result_info_list = result_buildnums.get(buildnum)
-        if result_info_list is None:
-          result_info_list = []
-          result_buildnums[buildnum] = result_info_list
-        result_info_list.extend(info_list)
-        result_info_list.sort(key=lambda info: info['bom_timestamp'])
+        add_if_nonstandard("dockerRegistry", self.__expect_docker_registry)
+        add_if_nonstandard("debianRepository", self.__expect_debian_repository)
+        if len(info) > 2:
+            problems = dict(info)
+            del problems["bom_version"]
+            del problems["bom_timestamp"]
+            self.__non_standard_boms[bom["version"]] = problems
 
-    def join_commits(commit_map, result_commits):
-      for commit, commit_buildnums in commit_map.items():
-        result_buildnums = result_commits.get(commit)
-        if result_buildnums is None:
-          result_buildnums = {}
-          result_commits[commit] = result_buildnums
-        join_buildnums(commit_buildnums, result_buildnums)
+        return info
 
-    def join_versions(version_map, result_versions):
-      for version, commit_map in version_map.items():
-        result_commits = result_versions.get(version)
-        if result_commits is None:
-          result_commits = {}
-          result_versions[version] = result_commits
-        join_commits(commit_map, result_commits)
+    def analyze_bom(self, bom):
+        """Analyzes one bom and breaks it down into this threads result_map.
 
-    def join_results(thread_results, result_map):
-      for name, version_map in thread_results.items():
-        result_versions = result_map.get(name)
-        if result_versions is None:
-          result_versions = {}
-          result_map[name] = result_versions
-        join_versions(version_map, result_versions)
+        Boms are processed within a single thread, but multiple boms can be
+        processed in different threads.
+        """
+        tid = current_thread().name
+        thread_service_map = self.__per_thread_result_map.get(tid, {})
+        self.__per_thread_result_map[tid] = thread_service_map
 
-    result_map = {}
-    for thread_results in self.__per_thread_result_map.values():
-      join_results(thread_results, result_map)
-    return result_map
+        bom_info = self.extract_bom_info(bom)
+        for name, entry in bom["services"].items():
+            if name == "defaultArtifact":
+                continue
+            build_version = entry["version"]
+            parts = build_version.split("-", 1)
+            if len(parts) == 1:
+                version = parts[0]
+                buildnum = "NotRecorded"
+            else:
+                version, buildnum = parts
 
-  def ingest_bom_list(self, bom_list):
-    """Ingest each of the boms."""
-    max_threads = 1 if self.options.one_at_a_time else 4
-    pool = ThreadPool(min(max_threads, len(bom_list)))
-    pool.map(self.ingest_bom, bom_list)
-    pool.close()
-    pool.join()
-    return self.join_result_maps()
+            commit = entry.get("commit", "NotRecorded")
+            service_record = thread_service_map.get(name)
+            if service_record is None:
+                service_record = {}
+                thread_service_map[name] = service_record
+            version_map = service_record.get(version)
+            if version_map is None:
+                version_map = {}
+                service_record[version] = version_map
+            commit_map = version_map.get(commit)
+            if commit_map is None:
+                commit_map = {}
+                version_map[commit] = commit_map
+            build_list = commit_map.get(buildnum)
+            if build_list is None:
+                build_list = []
+                commit_map[buildnum] = build_list
 
-  def list_bom_urls(self, gcs_dir_url_prefix):
-    """Get a list of all the bom versions that exist."""
-    result = check_subprocess('gsutil ls ' + gcs_dir_url_prefix)
-    return [line for line in result.split('\n')
-            if line.startswith(gcs_dir_url_prefix) and line.endswith('.yml')]
+            build_list.append(bom_info)
 
-  def _do_command(self):
-    """Reads the list of boms, then concurrently processes them.
+    def ingest_bom(self, line):
+        """Function to ingest a single bom into the result map."""
+        bom = self.load_bom_from_url(line)
+        if not bom:
+            return
+        try:
+            if bom["version"] + ".yml" != line[line.rfind("/") + 1 :]:
+                message = 'BOM version "%s" != filename "%s"' % (bom["version"], line)
+                self.__bad_files[self.url_to_bom_name(line.strip())] = message
+                logging.warning(message)
+                raise_and_log_error(UnexpectedError(message))
+            self.analyze_bom(bom)
+        except Exception as ex:
+            self.__bad_files[self.url_to_bom_name(line.strip())] = exception_to_message(
+                ex
+            )
+            maybe_log_exception("analyze_bom", ex, action_msg="Skipping %s" % line)
 
-    Ultimately it will write out the analysis into bom_service_map.yml
-    """
-    options = self.options
-    url_prefix = 'gs://%s/bom/' % options.halyard_bom_bucket
-    if options.version_name_prefix:
-      url_prefix += options.version_name_prefix
-    logging.debug('Listing BOM urls')
-    results = self.list_bom_urls(url_prefix)
-    write_to_path('\n'.join(sorted(results)),
-                  os.path.join(self.get_output_dir(), 'bom_list.txt'))
-    result_map = self.ingest_bom_list(results)
+    def join_result_maps(self):
+        """Join the individual thread result maps into a single one.
 
-    path = os.path.join(self.get_output_dir(), 'all_bom_service_map.yml')
-    logging.info('Writing bom analysis to %s', path)
-    write_to_path(yaml.safe_dump(result_map, default_flow_style=False), path)
+        This assumes a single threaded environment.
+        """
 
-    partition_names = ['released', 'unreleased']
-    partitions = self.partition_service_map(result_map)
-    for index, data in enumerate(partitions):
-      path = os.path.join(self.get_output_dir(),
-                          partition_names[index] + '_bom_service_map.yml')
-      logging.info('Writing bom analysis to %s', path)
-      write_to_path(yaml.safe_dump(data, default_flow_style=False), path)
+        def join_buildnums(commit_buildnums, result_buildnums):
+            for buildnum, info_list in commit_buildnums.items():
+                result_info_list = result_buildnums.get(buildnum)
+                if result_info_list is None:
+                    result_info_list = []
+                    result_buildnums[buildnum] = result_info_list
+                result_info_list.extend(info_list)
+                result_info_list.sort(key=lambda info: info["bom_timestamp"])
 
-    if self.__bad_files:
-      path = os.path.join(self.get_output_dir(), 'bad_boms.txt')
-      logging.warning('Writing %d bad URLs to %s', len(self.__bad_files), path)
-      write_to_path(
-          yaml.safe_dump(self.__bad_files, default_flow_style=False),
-          path)
+        def join_commits(commit_map, result_commits):
+            for commit, commit_buildnums in commit_map.items():
+                result_buildnums = result_commits.get(commit)
+                if result_buildnums is None:
+                    result_buildnums = {}
+                    result_commits[commit] = result_buildnums
+                join_buildnums(commit_buildnums, result_buildnums)
 
-    if self.__non_standard_boms:
-      path = os.path.join(self.get_output_dir(), 'nonstandard_boms.txt')
-      logging.warning('Writing %d nonstandard boms to %s',
-                      len(self.__non_standard_boms), path)
-      write_to_path(
-          yaml.safe_dump(self.__non_standard_boms, default_flow_style=False),
-          path)
+        def join_versions(version_map, result_versions):
+            for version, commit_map in version_map.items():
+                result_commits = result_versions.get(version)
+                if result_commits is None:
+                    result_commits = {}
+                    result_versions[version] = result_commits
+                join_commits(commit_map, result_commits)
 
-    config = {
-        'halyard_bom_bucket': options.halyard_bom_bucket
-    }
-    path = os.path.join(self.get_output_dir(), 'config.yml')
-    logging.info('Writing to %s', path)
-    write_to_path(yaml.safe_dump(config, default_flow_style=False), path)
+        def join_results(thread_results, result_map):
+            for name, version_map in thread_results.items():
+                result_versions = result_map.get(name)
+                if result_versions is None:
+                    result_versions = {}
+                    result_map[name] = result_versions
+                join_versions(version_map, result_versions)
 
-  def partition_service_map(self, result_map):
-    def partition_info_list(info_list):
-      released = []
-      unreleased = []
-      for info in info_list:
-        if self.RELEASED_VERSION_MATCHER.match(info['bom_version']):
-          released.append(info)
-        else:
-          unreleased.append(info)
+        result_map = {}
+        for thread_results in self.__per_thread_result_map.values():
+            join_results(thread_results, result_map)
+        return result_map
 
-      if released:
-        # If we released this somewhere, then it isnt unreleased.
-        unreleased = []
+    def ingest_bom_list(self, bom_list):
+        """Ingest each of the boms."""
+        max_threads = 1 if self.options.one_at_a_time else 4
+        pool = ThreadPool(min(max_threads, len(bom_list)))
+        pool.map(self.ingest_bom, bom_list)
+        pool.close()
+        pool.join()
+        return self.join_result_maps()
 
-      return released, unreleased
+    def list_bom_urls(self, gcs_dir_url_prefix):
+        """Get a list of all the bom versions that exist."""
+        result = check_subprocess("gsutil ls " + gcs_dir_url_prefix)
+        return [
+            line
+            for line in result.split("\n")
+            if line.startswith(gcs_dir_url_prefix) and line.endswith(".yml")
+        ]
 
-    def partition_buildnum_map(buildnum_map):
-      released = {}
-      unreleased = {}
-      for buildnum, info_list in buildnum_map.items():
-        results = partition_info_list(info_list)
-        if results[0]:
-          released[buildnum] = results[0]
-        if results[1]:
-          unreleased[buildnum] = results[1]
-      return released, unreleased
+    def _do_command(self):
+        """Reads the list of boms, then concurrently processes them.
 
-    def partition_commit_map(commit_map):
-      released = {}
-      unreleased = {}
-      for commit, buildnum_map in commit_map.items():
-        results = partition_buildnum_map(buildnum_map)
-        if results[0]:
-          released[commit] = results[0]
-        if results[1]:
-          unreleased[commit] = results[1]
-      return released, unreleased
+        Ultimately it will write out the analysis into bom_service_map.yml
+        """
+        options = self.options
+        url_prefix = "gs://%s/bom/" % options.halyard_bom_bucket
+        if options.version_name_prefix:
+            url_prefix += options.version_name_prefix
+        logging.debug("Listing BOM urls")
+        results = self.list_bom_urls(url_prefix)
+        write_to_path(
+            "\n".join(sorted(results)),
+            os.path.join(self.get_output_dir(), "bom_list.txt"),
+        )
+        result_map = self.ingest_bom_list(results)
 
-    def partition_version_map(version_map):
-      released = {}
-      unreleased = {}
-      for version, commit_map in version_map.items():
-        results = partition_commit_map(commit_map)
-        if results[0]:
-          released[version] = results[0]
-        if results[1]:
-          unreleased[version] = results[1]
-      if not released:
-        released = None
-      if not unreleased:
-        unreleased = None
-      return released, unreleased
+        path = os.path.join(self.get_output_dir(), "all_bom_service_map.yml")
+        logging.info("Writing bom analysis to %s", path)
+        write_to_path(yaml.safe_dump(result_map, default_flow_style=False), path)
 
-    released = {}
-    unreleased = {}
-    for name, version_map in result_map.items():
-      released[name], unreleased[name] = partition_version_map(version_map)
+        partition_names = ["released", "unreleased"]
+        partitions = self.partition_service_map(result_map)
+        for index, data in enumerate(partitions):
+            path = os.path.join(
+                self.get_output_dir(), partition_names[index] + "_bom_service_map.yml"
+            )
+            logging.info("Writing bom analysis to %s", path)
+            write_to_path(yaml.safe_dump(data, default_flow_style=False), path)
 
-    return released, unreleased
+        if self.__bad_files:
+            path = os.path.join(self.get_output_dir(), "bad_boms.txt")
+            logging.warning("Writing %d bad URLs to %s", len(self.__bad_files), path)
+            write_to_path(
+                yaml.safe_dump(self.__bad_files, default_flow_style=False), path
+            )
+
+        if self.__non_standard_boms:
+            path = os.path.join(self.get_output_dir(), "nonstandard_boms.txt")
+            logging.warning(
+                "Writing %d nonstandard boms to %s", len(self.__non_standard_boms), path
+            )
+            write_to_path(
+                yaml.safe_dump(self.__non_standard_boms, default_flow_style=False), path
+            )
+
+        config = {"halyard_bom_bucket": options.halyard_bom_bucket}
+        path = os.path.join(self.get_output_dir(), "config.yml")
+        logging.info("Writing to %s", path)
+        write_to_path(yaml.safe_dump(config, default_flow_style=False), path)
+
+    def partition_service_map(self, result_map):
+        def partition_info_list(info_list):
+            released = []
+            unreleased = []
+            for info in info_list:
+                if self.RELEASED_VERSION_MATCHER.match(info["bom_version"]):
+                    released.append(info)
+                else:
+                    unreleased.append(info)
+
+            if released:
+                # If we released this somewhere, then it isnt unreleased.
+                unreleased = []
+
+            return released, unreleased
+
+        def partition_buildnum_map(buildnum_map):
+            released = {}
+            unreleased = {}
+            for buildnum, info_list in buildnum_map.items():
+                results = partition_info_list(info_list)
+                if results[0]:
+                    released[buildnum] = results[0]
+                if results[1]:
+                    unreleased[buildnum] = results[1]
+            return released, unreleased
+
+        def partition_commit_map(commit_map):
+            released = {}
+            unreleased = {}
+            for commit, buildnum_map in commit_map.items():
+                results = partition_buildnum_map(buildnum_map)
+                if results[0]:
+                    released[commit] = results[0]
+                if results[1]:
+                    unreleased[commit] = results[1]
+            return released, unreleased
+
+        def partition_version_map(version_map):
+            released = {}
+            unreleased = {}
+            for version, commit_map in version_map.items():
+                results = partition_commit_map(commit_map)
+                if results[0]:
+                    released[version] = results[0]
+                if results[1]:
+                    unreleased[version] = results[1]
+            if not released:
+                released = None
+            if not unreleased:
+                unreleased = None
+            return released, unreleased
+
+        released = {}
+        unreleased = {}
+        for name, version_map in result_map.items():
+            released[name], unreleased[name] = partition_version_map(version_map)
+
+        return released, unreleased
 
 
 class CollectBomVersionsFactory(CommandFactory):
-  def __init__(self, **kwargs):
-    super(CollectBomVersionsFactory, self).__init__(
-        'collect_bom_versions', CollectBomVersions,
-        'Find information about bom versions.', **kwargs)
+    def __init__(self, **kwargs):
+        super(CollectBomVersionsFactory, self).__init__(
+            "collect_bom_versions",
+            CollectBomVersions,
+            "Find information about bom versions.",
+            **kwargs
+        )
 
-  def init_argparser(self, parser, defaults):
-    super(CollectBomVersionsFactory, self).init_argparser(parser, defaults)
-    self.add_argument(parser, 'version_name_prefix', defaults, None,
-                      help='Prefix for bom version to collect.')
-    self.add_argument(
-        parser, 'halyard_bom_bucket', defaults, 'halconfig',
-        help='The bucket managing halyard BOMs and config profiles.')
-    self.add_argument(
-        parser, 'docker_registry', defaults, None,
-        help='The expected docker registry in boms.')
-    self.add_argument(
-        parser, 'bintray_org', defaults, None,
-        help='The expected bintray organization in boms.')
-    self.add_argument(
-        parser, 'bintray_debian_repository', defaults, None,
-        help='The expected bintray debian repository in boms.')
+    def init_argparser(self, parser, defaults):
+        super(CollectBomVersionsFactory, self).init_argparser(parser, defaults)
+        self.add_argument(
+            parser,
+            "version_name_prefix",
+            defaults,
+            None,
+            help="Prefix for bom version to collect.",
+        )
+        self.add_argument(
+            parser,
+            "halyard_bom_bucket",
+            defaults,
+            "halconfig",
+            help="The bucket managing halyard BOMs and config profiles.",
+        )
+        self.add_argument(
+            parser,
+            "docker_registry",
+            defaults,
+            None,
+            help="The expected docker registry in boms.",
+        )
+        self.add_argument(
+            parser,
+            "bintray_org",
+            defaults,
+            None,
+            help="The expected bintray organization in boms.",
+        )
+        self.add_argument(
+            parser,
+            "bintray_debian_repository",
+            defaults,
+            None,
+            help="The expected bintray debian repository in boms.",
+        )
 
 
 class CollectArtifactVersions(CommandProcessor):
-  """Locate all the existing spinnaker build artifacts.
+    """Locate all the existing spinnaker build artifacts.
 
-  Ultimately this produces files mapping all the existing artifact
-  builds for each service of a given type. It also looks for consistency
-  between the bintray jar and debian builds.
+    Ultimately this produces files mapping all the existing artifact
+    builds for each service of a given type. It also looks for consistency
+    between the bintray jar and debian builds.
 
-  Emits files:
-     <debian_repository>__versions.yml: All the debian build versions
-     <jar_repository>__versions.yml: All the jar build versions
-     <docker_registry>__versions.yml: All the container build versions
-     <config_bucket>__versions.yml: All the service-specific config build versions
-     missing_jars.yml: Bintray debian versions without a corresponding jar
-     missing_debians.yml: Bintray jar versions witout a corresponding debian
-     config.yml: The configuration values used to collect the artifacts
-  """
+    Emits files:
+       <debian_repository>__versions.yml: All the debian build versions
+       <jar_repository>__versions.yml: All the jar build versions
+       <docker_registry>__versions.yml: All the container build versions
+       <config_bucket>__versions.yml: All the service-specific config build versions
+       missing_jars.yml: Bintray debian versions without a corresponding jar
+       missing_debians.yml: Bintray jar versions witout a corresponding debian
+       config.yml: The configuration values used to collect the artifacts
+    """
 
-  def __init__(self, factory, options, **kwargs):
-    super(CollectArtifactVersions, self).__init__(
-        factory, options, **kwargs)
+    def __init__(self, factory, options, **kwargs):
+        super(CollectArtifactVersions, self).__init__(factory, options, **kwargs)
 
-    check_options_set(options,
-                      ['docker_registry', 'bintray_org',
-                       'bintray_jar_repository', 'bintray_debian_repository'])
-    user = os.environ.get('BINTRAY_USER')
-    password = os.environ.get('BINTRAY_KEY')
-    if user and password:
-      user_password = '{user}:{password}'.format(user=user, password=password)
-      encoded_auth = base64.b64encode(user_password)
-      self.__basic_auth = 'Basic %s' % encoded_auth.decode()
-    else:
-      self.__basic_auth = None
+        check_options_set(
+            options,
+            [
+                "docker_registry",
+                "bintray_org",
+                "bintray_jar_repository",
+                "bintray_debian_repository",
+            ],
+        )
+        user = os.environ.get("BINTRAY_USER")
+        password = os.environ.get("BINTRAY_KEY")
+        if user and password:
+            user_password = "{user}:{password}".format(user=user, password=password)
+            encoded_auth = base64.b64encode(user_password)
+            self.__basic_auth = "Basic %s" % encoded_auth.decode()
+        else:
+            self.__basic_auth = None
 
-  def fetch_bintray_url(self, bintray_url):
-    request = Request(bintray_url)
-    if self.__basic_auth:
-      request.add_header('Authorization', self.__basic_auth)
-    try:
-      response = urlopen(request)
-      headers = response.info()
-      payload = response.read()
-      content = json.JSONDecoder().decode(payload.decode())
-    except HTTPError as ex:
-      raise_and_log_error(
-          ResponseError('Bintray failure: {}'.format(ex),
-                        server='bintray.api'),
-          'Failed on url=%s: %s' % (bintray_url, exception_to_message(ex)))
-    except Exception as ex:
-      raise
-    return headers, content
+    def fetch_bintray_url(self, bintray_url):
+        request = Request(bintray_url)
+        if self.__basic_auth:
+            request.add_header("Authorization", self.__basic_auth)
+        try:
+            response = urlopen(request)
+            headers = response.info()
+            payload = response.read()
+            content = json.JSONDecoder().decode(payload.decode())
+        except HTTPError as ex:
+            raise_and_log_error(
+                ResponseError("Bintray failure: {}".format(ex), server="bintray.api"),
+                "Failed on url=%s: %s" % (bintray_url, exception_to_message(ex)),
+            )
+        except Exception as ex:
+            raise
+        return headers, content
 
-  def list_bintray_packages(self, subject_repo):
-    path = 'repos/%s/packages' % subject_repo
-    base_url = 'https://api.bintray.com/' + path
-    result = []
-    while True:
-      url = base_url + '?start_pos=%d' % len(result)
-      headers, content = self.fetch_bintray_url(url)
-      # logging.debug('Bintray responded with headers\n%s', headers)
-      total = headers.get('X-RangeLimit-Total', 0)
-      result.extend(['%s/%s' % (subject_repo, entry['name'])
-                     for entry in content])
-      if len(result) >= total:
-        break
-    return result
+    def list_bintray_packages(self, subject_repo):
+        path = "repos/%s/packages" % subject_repo
+        base_url = "https://api.bintray.com/" + path
+        result = []
+        while True:
+            url = base_url + "?start_pos=%d" % len(result)
+            headers, content = self.fetch_bintray_url(url)
+            # logging.debug('Bintray responded with headers\n%s', headers)
+            total = headers.get("X-RangeLimit-Total", 0)
+            result.extend(
+                ["%s/%s" % (subject_repo, entry["name"]) for entry in content]
+            )
+            if len(result) >= total:
+                break
+        return result
 
-  def query_bintray_package_versions(self, package_path):
-    path = 'packages/' + package_path
-    url = 'https://api.bintray.com/' + path
-    _, content = self.fetch_bintray_url(url)
-    # logging.debug('Bintray responded with headers\n%s', headers)
-    package_name = package_path[package_path.rfind('/') + 1:]
-    return (package_name, content['versions'])
+    def query_bintray_package_versions(self, package_path):
+        path = "packages/" + package_path
+        url = "https://api.bintray.com/" + path
+        _, content = self.fetch_bintray_url(url)
+        # logging.debug('Bintray responded with headers\n%s', headers)
+        package_name = package_path[package_path.rfind("/") + 1 :]
+        return (package_name, content["versions"])
 
-  def difference(self, versions, target):
-    missing = []
-    for version in versions:
-      if not version in target:
-        missing.append(version)
-    return missing
+    def difference(self, versions, target):
+        missing = []
+        for version in versions:
+            if not version in target:
+                missing.append(version)
+        return missing
 
-  def find_missing_jar_versions(self, jar_map, debian_map):
-    missing_jars = {}
-    prefix = 'spinnaker-'
-    for package, versions in debian_map.items():
-      if package.startswith(prefix):
-        key = package[len(prefix):]
-      if not key in jar_map:
-        key = package
-        if key == 'spinnaker-monitoring':
-          key = 'spinnaker-monitoring-daemon'
-        if not key in jar_map:
-          if key == 'spinnaker-monitoring-third-party':
-            continue
-          continue
-      missing = self.difference(versions, jar_map.get(key))
-      if missing:
-        missing_jars[key] = missing
+    def find_missing_jar_versions(self, jar_map, debian_map):
+        missing_jars = {}
+        prefix = "spinnaker-"
+        for package, versions in debian_map.items():
+            if package.startswith(prefix):
+                key = package[len(prefix) :]
+            if not key in jar_map:
+                key = package
+                if key == "spinnaker-monitoring":
+                    key = "spinnaker-monitoring-daemon"
+                if not key in jar_map:
+                    if key == "spinnaker-monitoring-third-party":
+                        continue
+                    continue
+            missing = self.difference(versions, jar_map.get(key))
+            if missing:
+                missing_jars[key] = missing
 
-    return missing_jars
+        return missing_jars
 
-  def find_missing_debian_versions(self, jar_map, debian_map):
-    missing_debians = {}
-    for package, versions in jar_map.items():
-      key = 'spinnaker-' + package
-      if not key in debian_map:
-        key = package
-        if not key in debian_map:
-          if key == 'spinnaker-monitoring':
-            key = 'spinnaker-monitoring-daemon'
-          else:
-            raise ValueError('Unknown DEBIAN "%s"' % package)
+    def find_missing_debian_versions(self, jar_map, debian_map):
+        missing_debians = {}
+        for package, versions in jar_map.items():
+            key = "spinnaker-" + package
+            if not key in debian_map:
+                key = package
+                if not key in debian_map:
+                    if key == "spinnaker-monitoring":
+                        key = "spinnaker-monitoring-daemon"
+                    else:
+                        raise ValueError('Unknown DEBIAN "%s"' % package)
 
-      missing = self.difference(versions, debian_map.get(key))
-      if missing:
-        missing_debians[key] = missing
+            missing = self.difference(versions, debian_map.get(key))
+            if missing:
+                missing_debians[key] = missing
 
-    return missing_debians
+        return missing_debians
 
-  def collect_bintray_versions(self, pool):
-    options = self.options
-    repos = [('jar', options.bintray_jar_repository),
-             ('debian', options.bintray_debian_repository)]
-    results = []
-    for repo_type, bintray_repo in repos:
-      subject_repo = '%s/%s' % (options.bintray_org, bintray_repo)
-      packages = self.list_bintray_packages(subject_repo)
-      package_versions = pool.map(self.query_bintray_package_versions, packages)
+    def collect_bintray_versions(self, pool):
+        options = self.options
+        repos = [
+            ("jar", options.bintray_jar_repository),
+            ("debian", options.bintray_debian_repository),
+        ]
+        results = []
+        for repo_type, bintray_repo in repos:
+            subject_repo = "%s/%s" % (options.bintray_org, bintray_repo)
+            packages = self.list_bintray_packages(subject_repo)
+            package_versions = pool.map(self.query_bintray_package_versions, packages)
 
-      package_map = {}
-      for name, versions in package_versions:
-        package_map[name] = versions
-      results.append(package_map)
+            package_map = {}
+            for name, versions in package_versions:
+                package_map[name] = versions
+            results.append(package_map)
 
-      path = os.path.join(
-          self.get_output_dir(),
-          '%s__%s_versions.yml' % (bintray_repo, repo_type))
-      logging.info('Writing %s versions to %s', bintray_repo, path)
-      write_to_path(yaml.safe_dump(package_map,
-                                   allow_unicode=True,
-                                   default_flow_style=False), path)
-    return results[0], results[1]
+            path = os.path.join(
+                self.get_output_dir(), "%s__%s_versions.yml" % (bintray_repo, repo_type)
+            )
+            logging.info("Writing %s versions to %s", bintray_repo, path)
+            write_to_path(
+                yaml.safe_dump(
+                    package_map, allow_unicode=True, default_flow_style=False
+                ),
+                path,
+            )
+        return results[0], results[1]
 
-  def query_gcr_image_versions(self, image):
-    options = self.options
-    command_parts = ['gcloud',
-                     '--format=json',
-                     'container images list-tags',
-                     image, '--limit 10000']
-    if options.gcb_service_account:
-      command_parts.extend(['--account', options.gcb_service_account])
-    response = check_subprocess(' '.join(command_parts), stderr=open(os.devnull, 'w'))
-    result = []
-    for version in json.JSONDecoder().decode(response):
-      result.extend(version['tags'])
-    return (image[image.rfind('/') + 1:], result)
+    def query_gcr_image_versions(self, image):
+        options = self.options
+        command_parts = [
+            "gcloud",
+            "--format=json",
+            "container images list-tags",
+            image,
+            "--limit 10000",
+        ]
+        if options.gcb_service_account:
+            command_parts.extend(["--account", options.gcb_service_account])
+        response = check_subprocess(
+            " ".join(command_parts), stderr=open(os.devnull, "w")
+        )
+        result = []
+        for version in json.JSONDecoder().decode(response):
+            result.extend(version["tags"])
+        return (image[image.rfind("/") + 1 :], result)
 
-  def collect_gcb_versions(self, pool):
-    options = self.options
-    logging.debug('Collecting GCB versions from %s', options.docker_registry)
-    command_parts = ['gcloud',
-                     '--format=json',
-                     'container images list',
-                     '--repository', options.docker_registry]
-    if options.gcb_service_account:
-      logging.debug('Using account %s', options.gcb_service_account)
-      command_parts.extend(['--account', options.gcb_service_account])
+    def collect_gcb_versions(self, pool):
+        options = self.options
+        logging.debug("Collecting GCB versions from %s", options.docker_registry)
+        command_parts = [
+            "gcloud",
+            "--format=json",
+            "container images list",
+            "--repository",
+            options.docker_registry,
+        ]
+        if options.gcb_service_account:
+            logging.debug("Using account %s", options.gcb_service_account)
+            command_parts.extend(["--account", options.gcb_service_account])
 
-    response = check_subprocess(' '.join(command_parts), stderr=open(os.devnull, 'w'))
-    images = [entry['name']
-              for entry in json.JSONDecoder().decode(response)]
-    image_versions = pool.map(self.query_gcr_image_versions, images)
+        response = check_subprocess(
+            " ".join(command_parts), stderr=open(os.devnull, "w")
+        )
+        images = [entry["name"] for entry in json.JSONDecoder().decode(response)]
+        image_versions = pool.map(self.query_gcr_image_versions, images)
 
-    image_map = {}
-    for name, versions in image_versions:
-      image_map[name] = versions
+        image_map = {}
+        for name, versions in image_versions:
+            image_map[name] = versions
 
-    path = os.path.join(
-        self.get_output_dir(),
-        options.docker_registry.replace('/', '__') + '__gcb_versions.yml')
-    logging.info('Writing %s versions to %s', options.docker_registry, path)
-    write_to_path(yaml.safe_dump(image_map,
-                                 allow_unicode=True,
-                                 default_flow_style=False), path)
-    return image_map
+        path = os.path.join(
+            self.get_output_dir(),
+            options.docker_registry.replace("/", "__") + "__gcb_versions.yml",
+        )
+        logging.info("Writing %s versions to %s", options.docker_registry, path)
+        write_to_path(
+            yaml.safe_dump(image_map, allow_unicode=True, default_flow_style=False),
+            path,
+        )
+        return image_map
 
-  def collect_gce_image_versions(self):
-    options = self.options
-    project = options.publish_gce_image_project
-    logging.debug('Collecting GCE image versions from %s', project)
-    command_parts = ['gcloud', '--format=json',
-                     'compute images list', '--project', project,
-                     '--filter spinnaker-']
-    if options.build_gce_service_account:
-      logging.debug('Using account %s', options.build_gce_service_account)
-      command_parts.extend(['--account', options.build_gce_service_account])
+    def collect_gce_image_versions(self):
+        options = self.options
+        project = options.publish_gce_image_project
+        logging.debug("Collecting GCE image versions from %s", project)
+        command_parts = [
+            "gcloud",
+            "--format=json",
+            "compute images list",
+            "--project",
+            project,
+            "--filter spinnaker-",
+        ]
+        if options.build_gce_service_account:
+            logging.debug("Using account %s", options.build_gce_service_account)
+            command_parts.extend(["--account", options.build_gce_service_account])
 
-    response = check_subprocess(' '.join(command_parts), stderr=open(os.devnull, 'w'))
-    images = [entry['name']
-              for entry in json.JSONDecoder().decode(response)]
-    image_map = {}
-    for name in images:
-      parts = name.split('-', 2)
-      if len(parts) != 3:
-        logging.warning('Skipping malformed %s', name)
-        continue
-      _, module, build_version = parts
-      parts = build_version.split('-')
-      if len(parts) != 4:
-        logging.warning('Skipping malformed %s', name)
-        continue
-      version_list = image_map.get(module, [])
-      version_list.append('{}.{}.{}-{}'.format(*parts))
-      image_map[module] = version_list
+        response = check_subprocess(
+            " ".join(command_parts), stderr=open(os.devnull, "w")
+        )
+        images = [entry["name"] for entry in json.JSONDecoder().decode(response)]
+        image_map = {}
+        for name in images:
+            parts = name.split("-", 2)
+            if len(parts) != 3:
+                logging.warning("Skipping malformed %s", name)
+                continue
+            _, module, build_version = parts
+            parts = build_version.split("-")
+            if len(parts) != 4:
+                logging.warning("Skipping malformed %s", name)
+                continue
+            version_list = image_map.get(module, [])
+            version_list.append("{}.{}.{}-{}".format(*parts))
+            image_map[module] = version_list
 
-    path = os.path.join(
-        self.get_output_dir(), project + '__gce_image_versions.yml')
-    logging.info('Writing gce image versions to %s', path)
-    write_to_path(yaml.safe_dump(image_map,
-                                 allow_unicode=True,
-                                 default_flow_style=False), path)
-    return image_map
+        path = os.path.join(self.get_output_dir(), project + "__gce_image_versions.yml")
+        logging.info("Writing gce image versions to %s", path)
+        write_to_path(
+            yaml.safe_dump(image_map, allow_unicode=True, default_flow_style=False),
+            path,
+        )
+        return image_map
 
-  def collect_config_bucket_versions(self):
-    options = self.options
-    bucket = options.halyard_bom_bucket
-    logging.debug("Collecting configs from bucket %s", bucket)
-    full_bucket_prefix = 'gs://{}/'.format(bucket)
-    command_parts = ['gsutil', 'ls', full_bucket_prefix]
+    def collect_config_bucket_versions(self):
+        options = self.options
+        bucket = options.halyard_bom_bucket
+        logging.debug("Collecting configs from bucket %s", bucket)
+        full_bucket_prefix = "gs://{}/".format(bucket)
+        command_parts = ["gsutil", "ls", full_bucket_prefix]
 
-    response = check_subprocess(' '.join(command_parts))
-    config_map = {}
-    for subdir_prefix in response.splitlines():
-      if not subdir_prefix.endswith('/'):
-        continue
+        response = check_subprocess(" ".join(command_parts))
+        config_map = {}
+        for subdir_prefix in response.splitlines():
+            if not subdir_prefix.endswith("/"):
+                continue
 
-      # Sample input line: gs://halconfig/clouddriver/
-      service_name = subdir_prefix.replace(full_bucket_prefix, "", 1).rstrip('/')
-      if service_name == 'bom':
-        continue
+            # Sample input line: gs://halconfig/clouddriver/
+            service_name = subdir_prefix.replace(full_bucket_prefix, "", 1).rstrip("/")
+            if service_name == "bom":
+                continue
 
-      command_parts = ['gsutil', 'ls', subdir_prefix]
+            command_parts = ["gsutil", "ls", subdir_prefix]
 
-      logging.debug("Collecting configs from {}".format(subdir_prefix))
+            logging.debug("Collecting configs from {}".format(subdir_prefix))
 
-      versions = check_subprocess(' '.join(command_parts))
+            versions = check_subprocess(" ".join(command_parts))
 
-      service_config_versions_list = []
-      for version_line in versions.splitlines():
-        version = version_line.replace(subdir_prefix, "", 1).rstrip('/')
-        if version.startswith('.'):
-          logging.debug("From %s to %s", version_line, version)
-        service_config_versions_list.append(version)
+            service_config_versions_list = []
+            for version_line in versions.splitlines():
+                version = version_line.replace(subdir_prefix, "", 1).rstrip("/")
+                if version.startswith("."):
+                    logging.debug("From %s to %s", version_line, version)
+                service_config_versions_list.append(version)
 
-      config_map[service_name] = service_config_versions_list
+            config_map[service_name] = service_config_versions_list
 
-    path = os.path.join(
-      self.get_output_dir(), bucket + '__config_versions.yml')
-    logging.info('Writing config versions to %s', path)
-    write_to_path(yaml.safe_dump(config_map,
-                                 allow_unicode=True,
-                                 default_flow_style=False), path)
+        path = os.path.join(self.get_output_dir(), bucket + "__config_versions.yml")
+        logging.info("Writing config versions to %s", path)
+        write_to_path(
+            yaml.safe_dump(config_map, allow_unicode=True, default_flow_style=False),
+            path,
+        )
 
-  def _do_command(self):
-    pool = ThreadPool(16)
-    bintray_jars, bintray_debians = self.collect_bintray_versions(pool)
-    self.collect_gcb_versions(pool)
-    self.collect_gce_image_versions()
-    self.collect_config_bucket_versions()
-    pool.close()
-    pool.join()
+    def _do_command(self):
+        pool = ThreadPool(16)
+        bintray_jars, bintray_debians = self.collect_bintray_versions(pool)
+        self.collect_gcb_versions(pool)
+        self.collect_gce_image_versions()
+        self.collect_config_bucket_versions()
+        pool.close()
+        pool.join()
 
-    missing_jars = self.find_missing_jar_versions(
-        bintray_jars, bintray_debians)
-    missing_debians = self.find_missing_debian_versions(
-        bintray_jars, bintray_debians)
+        missing_jars = self.find_missing_jar_versions(bintray_jars, bintray_debians)
+        missing_debians = self.find_missing_debian_versions(
+            bintray_jars, bintray_debians
+        )
 
-    options = self.options
-    for which in [(options.bintray_jar_repository, missing_jars),
-                  (options.bintray_debian_repository, missing_debians)]:
-      if not which[1]:
-        logging.info('%s is all accounted for.', which[0])
-        continue
-      path = os.path.join(self.get_output_dir(), 'missing_%s.yml' % which[0])
-      logging.info('Writing to %s', path)
-      write_to_path(
-          yaml.safe_dump(which[1], allow_unicode=True,
-                         default_flow_style=False),
-          path)
+        options = self.options
+        for which in [
+            (options.bintray_jar_repository, missing_jars),
+            (options.bintray_debian_repository, missing_debians),
+        ]:
+            if not which[1]:
+                logging.info("%s is all accounted for.", which[0])
+                continue
+            path = os.path.join(self.get_output_dir(), "missing_%s.yml" % which[0])
+            logging.info("Writing to %s", path)
+            write_to_path(
+                yaml.safe_dump(which[1], allow_unicode=True, default_flow_style=False),
+                path,
+            )
 
-    config = {
-        'bintray_org': options.bintray_org,
-        'bintray_jar_repository': options.bintray_jar_repository,
-        'bintray_debian_repository': options.bintray_debian_repository,
-        'docker_registry': options.docker_registry,
-        'googleImageProject': options.publish_gce_image_project
-    }
-    path = os.path.join(self.get_output_dir(), 'config.yml')
-    logging.info('Writing to %s', path)
-    write_to_path(yaml.safe_dump(config, default_flow_style=False), path)
+        config = {
+            "bintray_org": options.bintray_org,
+            "bintray_jar_repository": options.bintray_jar_repository,
+            "bintray_debian_repository": options.bintray_debian_repository,
+            "docker_registry": options.docker_registry,
+            "googleImageProject": options.publish_gce_image_project,
+        }
+        path = os.path.join(self.get_output_dir(), "config.yml")
+        logging.info("Writing to %s", path)
+        write_to_path(yaml.safe_dump(config, default_flow_style=False), path)
 
 
 class CollectArtifactVersionsFactory(CommandFactory):
-  def __init__(self, **kwargs):
-    super(CollectArtifactVersionsFactory, self).__init__(
-        'collect_artifact_versions', CollectArtifactVersions,
-        'Find information about artifact jar/debian/config versions.', **kwargs)
+    def __init__(self, **kwargs):
+        super(CollectArtifactVersionsFactory, self).__init__(
+            "collect_artifact_versions",
+            CollectArtifactVersions,
+            "Find information about artifact jar/debian/config versions.",
+            **kwargs
+        )
 
-  def init_argparser(self, parser, defaults):
-    super(CollectArtifactVersionsFactory, self).init_argparser(
-        parser, defaults)
-    self.add_argument(
-        parser, 'bintray_org', defaults, None,
-        help='bintray organization for the jar and debian repositories.')
-    self.add_argument(
-        parser, 'bintray_jar_repository', defaults, None,
-        help='bintray repository in the bintray_org containing published jars.')
-    self.add_argument(
-        parser, 'bintray_debian_repository', defaults, None,
-        help='bintray repository in the bintray_org containing debians.')
-    self.add_argument(
-        parser, 'version_name_prefix', defaults, None,
-        help='Prefix for bintray versions to collect.')
-    self.add_argument(
-        parser, 'gcb_service_account', defaults, None,
-        help='The service account to use when checking gcr images.')
-    self.add_argument(
-        parser, 'docker_registry', defaults, None,
-        help='The GCB service account query image versions from.')
-    self.add_argument(
-        parser, 'build_gce_service_account', defaults, None,
-        help='The service account to use with the gce project.')
-    self.add_argument(
-        parser, 'publish_gce_image_project', defaults, None,
-        help='The GCE project to collect images from.')
-    self.add_argument(
-        parser, 'halyard_bom_bucket', defaults, None,
-        help='The bucket to inspect for versioned configs.')
+    def init_argparser(self, parser, defaults):
+        super(CollectArtifactVersionsFactory, self).init_argparser(parser, defaults)
+        self.add_argument(
+            parser,
+            "bintray_org",
+            defaults,
+            None,
+            help="bintray organization for the jar and debian repositories.",
+        )
+        self.add_argument(
+            parser,
+            "bintray_jar_repository",
+            defaults,
+            None,
+            help="bintray repository in the bintray_org containing published jars.",
+        )
+        self.add_argument(
+            parser,
+            "bintray_debian_repository",
+            defaults,
+            None,
+            help="bintray repository in the bintray_org containing debians.",
+        )
+        self.add_argument(
+            parser,
+            "version_name_prefix",
+            defaults,
+            None,
+            help="Prefix for bintray versions to collect.",
+        )
+        self.add_argument(
+            parser,
+            "gcb_service_account",
+            defaults,
+            None,
+            help="The service account to use when checking gcr images.",
+        )
+        self.add_argument(
+            parser,
+            "docker_registry",
+            defaults,
+            None,
+            help="The GCB service account query image versions from.",
+        )
+        self.add_argument(
+            parser,
+            "build_gce_service_account",
+            defaults,
+            None,
+            help="The service account to use with the gce project.",
+        )
+        self.add_argument(
+            parser,
+            "publish_gce_image_project",
+            defaults,
+            None,
+            help="The GCE project to collect images from.",
+        )
+        self.add_argument(
+            parser,
+            "halyard_bom_bucket",
+            defaults,
+            None,
+            help="The bucket to inspect for versioned configs.",
+        )
 
 
 class AuditArtifactVersions(CommandProcessor):
-  """Given the collected BOMs and artifacts, separate good from bad.
+    """Given the collected BOMs and artifacts, separate good from bad.
 
-  Ultimately this determines which existing artifacts are in use and which are
-  not referenced by a bom. It also verifies the integrity of the boms with
-  regard to the existence of the artifacts they specify. It will emit files
-  that suggest which specific boms and artifacts can be deleted. The artifacts
-  in use by the boms suggested for pruning are not included in the prune list.
-  They will be nominated in the next round.
+    Ultimately this determines which existing artifacts are in use and which are
+    not referenced by a bom. It also verifies the integrity of the boms with
+    regard to the existence of the artifacts they specify. It will emit files
+    that suggest which specific boms and artifacts can be deleted. The artifacts
+    in use by the boms suggested for pruning are not included in the prune list.
+    They will be nominated in the next round.
 
-  Emits files:
-     audit_confirmed_boms.yml: All the boms that have been verified intact.
-     audit_found_<type>.yml: All the artifacts of <type> that were referenced
-         by a bom.
-     audit_missing_<type>.yml: All the artifacts of <type> that were not
-         referenced by a bom.
-     audit_unused_<type>.yml: All the artifacts of <type> that were referenced
-         by a bom but not found to actually exist. These are for documentation.
-         The audit_invalid_boms.yml file is more useful.
-     audit_invalid_boms.yml: All the boms whose integrity is suspect along with
-         the explanation as to why. Usually they are missing artifacts, but
-         there could be other reasons.
-     prune_<type>.txt The list of URLs that should be safe to delete for the
-         given <type> from a strict referential integrity standpoint. There
-         could be unanticipated uses of these artifacts.
-  """
-
-  def __init_bintray_versions_helper(self, base_path):
-    artifact_data_dir = os.path.join(base_path, 'collect_artifact_versions')
-    debian_paths = []
-    jar_paths = []
-    gcr_paths = []
-    image_paths = []
-    config_paths = []
-    for filename in os.listdir(artifact_data_dir):
-      path = os.path.join(artifact_data_dir, filename)
-      if filename.endswith('__gcb_versions.yml'):
-        gcr_paths.append(path)
-      elif filename.endswith('__jar_versions.yml'):
-        jar_paths.append(path)
-      elif filename.endswith('__debian_versions.yml'):
-        debian_paths.append(path)
-      elif filename.endswith('__gce_image_versions.yml'):
-        image_paths.append(path)
-      elif filename.endswith('__config_versions.yml'):
-        config_paths.append(path)
-
-    for name, found in [('jar', jar_paths),
-                        ('debian', debian_paths),
-                        ('gce image', image_paths),
-                        ('gcr image', gcr_paths),
-                        ('config', config_paths)]:
-      if len(found) != 1:
-        raise_and_log_error(
-            ConfigError(
-                'Expected 1 %s version files in "%s": %s' % (
-                    name, artifact_data_dir, found)))
-
-    logging.debug('Loading container image versions from "%s"', gcr_paths[0])
-    with open(gcr_paths[0], 'r') as stream:
-      self.__container_versions = yaml.safe_load(stream.read())
-    with open(jar_paths[0], 'r') as stream:
-      self.__jar_versions = yaml.safe_load(stream.read())
-    with open(debian_paths[0], 'r') as stream:
-      self.__debian_versions = yaml.safe_load(stream.read())
-    with open(image_paths[0], 'r') as stream:
-      self.__gce_image_versions = yaml.safe_load(stream.read())
-    with open(config_paths[0], 'r') as stream:
-      self.__config_versions = yaml.safe_load(stream.read())
-
-  def __extract_all_bom_versions(self, bom_map):
-    result = set([])
-    for versions in bom_map.values():
-      if not versions:
-        continue
-      for commits in versions.values():
-        for buildnum in commits.values():
-          for info_list in buildnum.values():
-            for info in info_list:
-              result.add(info['bom_version'])
-    return result
-
-  def __remove_old_bom_versions(self, min_semver, version_to_commit_boms):
-    """Remove references to older boms in collected bom info.
-
-    Args:
-      min_semver: [SemanticVersion] minimally acceptable semantic version
-      version_to_commit_boms: [dict of {commit_id, build_info}]
-         where build_info is a dictionary mapping buildnum to list of
-         bom_metadata dictionaries.
-
-    Returns:
-      copy of versions but without build_info referencing older bom_versions.
+    Emits files:
+       audit_confirmed_boms.yml: All the boms that have been verified intact.
+       audit_found_<type>.yml: All the artifacts of <type> that were referenced
+           by a bom.
+       audit_missing_<type>.yml: All the artifacts of <type> that were not
+           referenced by a bom.
+       audit_unused_<type>.yml: All the artifacts of <type> that were referenced
+           by a bom but not found to actually exist. These are for documentation.
+           The audit_invalid_boms.yml file is more useful.
+       audit_invalid_boms.yml: All the boms whose integrity is suspect along with
+           the explanation as to why. Usually they are missing artifacts, but
+           there could be other reasons.
+       prune_<type>.txt The list of URLs that should be safe to delete for the
+           given <type> from a strict referential integrity standpoint. There
+           could be unanticipated uses of these artifacts.
     """
-    def list_of_current_bom_meta(min_semver, all_bom_meta):
-      good_bom_meta = []
-      for bom_meta in all_bom_meta:
-        semver = SemanticVersion.make('ignored-' + bom_meta['bom_version'])
-        if SemanticVersion.compare(semver, min_semver) >= 0:
-          good_bom_meta.append(bom_meta)
-      return good_bom_meta
 
-    def commit_to_current_bom_meta(min_semver, build_map):
-      build_info = {}
-      for buildnum, all_bom_meta in build_map.items():
-        good_bom_meta = list_of_current_bom_meta(min_semver, all_bom_meta)
-        if good_bom_meta:
-          build_info[buildnum] = good_bom_meta
-      return build_info
+    def __init_bintray_versions_helper(self, base_path):
+        artifact_data_dir = os.path.join(base_path, "collect_artifact_versions")
+        debian_paths = []
+        jar_paths = []
+        gcr_paths = []
+        image_paths = []
+        config_paths = []
+        for filename in os.listdir(artifact_data_dir):
+            path = os.path.join(artifact_data_dir, filename)
+            if filename.endswith("__gcb_versions.yml"):
+                gcr_paths.append(path)
+            elif filename.endswith("__jar_versions.yml"):
+                jar_paths.append(path)
+            elif filename.endswith("__debian_versions.yml"):
+                debian_paths.append(path)
+            elif filename.endswith("__gce_image_versions.yml"):
+                image_paths.append(path)
+            elif filename.endswith("__config_versions.yml"):
+                config_paths.append(path)
 
-    result = {}
-    for version, commit_build_map in version_to_commit_boms.items():
-      commit_map = {}
-      for commit_id, orig_build_map in commit_build_map.items():
-        build_map = commit_to_current_bom_meta(min_semver, orig_build_map)
-        if build_map:
-          commit_map[commit_id] = build_map
-      if commit_map:
-        result[version] = commit_map
-      else:
-        logging.info(
-            'Dropping version=%s because it bom versions are all too old.',
-            version)
-    return result
+        for name, found in [
+            ("jar", jar_paths),
+            ("debian", debian_paths),
+            ("gce image", image_paths),
+            ("gcr image", gcr_paths),
+            ("config", config_paths),
+        ]:
+            if len(found) != 1:
+                raise_and_log_error(
+                    ConfigError(
+                        'Expected 1 %s version files in "%s": %s'
+                        % (name, artifact_data_dir, found)
+                    )
+                )
 
-  def __init__(self, factory, options, **kwargs):
-    if options.prune_min_buildnum_prefix is not None:
-      # Typically numeric so is interpreted as number from yaml
-      options.prune_min_buildnum_prefix = str(options.prune_min_buildnum_prefix)
+        logging.debug('Loading container image versions from "%s"', gcr_paths[0])
+        with open(gcr_paths[0], "r") as stream:
+            self.__container_versions = yaml.safe_load(stream.read())
+        with open(jar_paths[0], "r") as stream:
+            self.__jar_versions = yaml.safe_load(stream.read())
+        with open(debian_paths[0], "r") as stream:
+            self.__debian_versions = yaml.safe_load(stream.read())
+        with open(image_paths[0], "r") as stream:
+            self.__gce_image_versions = yaml.safe_load(stream.read())
+        with open(config_paths[0], "r") as stream:
+            self.__config_versions = yaml.safe_load(stream.read())
 
-    super(AuditArtifactVersions, self).__init__(factory, options, **kwargs)
-    base_path = os.path.dirname(self.get_output_dir())
-    self.__init_bintray_versions_helper(base_path)
+    def __extract_all_bom_versions(self, bom_map):
+        result = set([])
+        for versions in bom_map.values():
+            if not versions:
+                continue
+            for commits in versions.values():
+                for buildnum in commits.values():
+                    for info_list in buildnum.values():
+                        for info in info_list:
+                            result.add(info["bom_version"])
+        return result
 
-    min_version = options.min_audit_bom_version or '0.0.0'
-    min_parts = min_version.split('.')
-    if len(min_parts) < 3:
-      min_version += '.0' * (3 - len(min_parts))
-    self.__min_semver = SemanticVersion.make('ignored-' + min_version)
+    def __remove_old_bom_versions(self, min_semver, version_to_commit_boms):
+        """Remove references to older boms in collected bom info.
 
-    bom_data_dir = os.path.join(base_path, 'collect_bom_versions')
-    path = os.path.join(bom_data_dir, 'released_bom_service_map.yml')
-    check_path_exists(path, 'released bom analysis')
-    with open(path, 'r') as stream:
-      self.__all_released_boms = {}      # forever
-      self.__current_released_boms = {}  # since min_version to audit
-      for service, versions in yaml.safe_load(stream.read()).items():
-        if not versions:
-          # e.g. this service has not yet been released.
-          logging.info('No versions for service=%s', service)
-          continue
+        Args:
+          min_semver: [SemanticVersion] minimally acceptable semantic version
+          version_to_commit_boms: [dict of {commit_id, build_info}]
+             where build_info is a dictionary mapping buildnum to list of
+             bom_metadata dictionaries.
 
-        self.__all_released_boms[service] = versions
-        self.__current_released_boms[service] = versions
-        stripped_versions = self.__remove_old_bom_versions(
-            self.__min_semver, versions)
-        if stripped_versions:
-          self.__current_released_boms[service] = stripped_versions
+        Returns:
+          copy of versions but without build_info referencing older bom_versions.
+        """
 
-    path = os.path.join(bom_data_dir, 'unreleased_bom_service_map.yml')
-    check_path_exists(path, 'unreleased bom analysis')
-    with open(path, 'r') as stream:
-      self.__unreleased_boms = yaml.safe_load(stream.read())
+        def list_of_current_bom_meta(min_semver, all_bom_meta):
+            good_bom_meta = []
+            for bom_meta in all_bom_meta:
+                semver = SemanticVersion.make("ignored-" + bom_meta["bom_version"])
+                if SemanticVersion.compare(semver, min_semver) >= 0:
+                    good_bom_meta.append(bom_meta)
+            return good_bom_meta
 
-    self.__only_bad_and_invalid_boms = False
-    self.__all_bom_versions = self.__extract_all_bom_versions(
-        self.__all_released_boms)
-    self.__all_bom_versions.update(
-        self.__extract_all_bom_versions(self.__unreleased_boms))
+        def commit_to_current_bom_meta(min_semver, build_map):
+            build_info = {}
+            for buildnum, all_bom_meta in build_map.items():
+                good_bom_meta = list_of_current_bom_meta(min_semver, all_bom_meta)
+                if good_bom_meta:
+                    build_info[buildnum] = good_bom_meta
+            return build_info
 
-    self.__missing_debians = {}
-    self.__missing_jars = {}
-    self.__missing_containers = {}
-    self.__missing_images = {}
-    self.__missing_configs = {}
-    self.__found_debians = {}
-    self.__found_jars = {}
-    self.__found_containers = {}
-    self.__found_images = {}
-    self.__found_configs = {}
-    self.__unused_jars = {}
-    self.__unused_debians = {}
-    self.__unused_containers = {}
-    self.__unused_gce_images = {}
-    self.__unused_configs = {}
-    self.__invalid_boms = {}
-    self.__confirmed_boms = set([])
-    self.__prune_boms = []
-    self.__prune_jars = {}
-    self.__prune_debians = {}
-    self.__prune_containers = {}
-    self.__prune_gce_images = {}
-    self.__prune_configs = {}
-    self.__invalid_versions = {}
-
-  def audit_artifacts(self):
-    self.audit_bom_services(self.__all_released_boms, 'released')
-    self.audit_bom_services(self.__unreleased_boms, 'unreleased')
-    self.audit_package(
-        'jar', self.__jar_versions, self.__unused_jars)
-    self.audit_package(
-        'debian', self.__debian_versions, self.__unused_debians)
-    self.audit_package(
-        'container', self.__container_versions, self.__unused_containers)
-    self.audit_package(
-        'image',
-        self.__gce_image_versions, self.__unused_gce_images)
-    self.audit_package(
-        'config',
-        self.__config_versions, self.__unused_configs)
-
-    def maybe_write_log(what, data):
-      if not data:
-        return
-      path = os.path.join(self.get_output_dir(), 'audit_' + what + '.yml')
-      logging.info('Writing %s', path)
-      write_to_path(
-          yaml.safe_dump(data, allow_unicode=True, default_flow_style=False),
-          path)
-
-    confirmed_boms = self.__all_bom_versions - set(self.__invalid_boms.keys())
-    unchecked_releases = [
-        key
-        for key in self.__all_bom_versions
-        if (CollectBomVersions.RELEASED_VERSION_MATCHER.match(key)
-            and SemanticVersion.compare(SemanticVersion.make('ignored-' + key),
-                                        self.__min_semver) < 0)]
-
-    invalid_releases = {
-        key: bom
-        for key, bom in self.__invalid_boms.items()
-        if (CollectBomVersions.RELEASED_VERSION_MATCHER.match(key)
-            and SemanticVersion.compare(SemanticVersion.make('ignored-' + key),
-                                        self.__min_semver) >= 0)}
-    confirmed_releases = [
-        key
-        for key in confirmed_boms
-        if (CollectBomVersions.RELEASED_VERSION_MATCHER.match(key)
-            and SemanticVersion.compare(SemanticVersion.make('ignored-' + key),
-                                        self.__min_semver) >= 0)]
-
-    maybe_write_log('missing_debians', self.__missing_debians)
-    maybe_write_log('missing_jars', self.__missing_jars)
-    maybe_write_log('missing_containers', self.__missing_containers)
-    maybe_write_log('missing_images', self.__missing_images)
-    maybe_write_log('missing_configs', self.__missing_configs)
-    maybe_write_log('found_debians', self.__found_debians)
-    maybe_write_log('found_jars', self.__found_jars)
-    maybe_write_log('found_containers', self.__found_containers)
-    maybe_write_log('found_images', self.__found_images)
-    maybe_write_log('found_configs', self.__found_configs)
-    maybe_write_log('unused_debians', self.__unused_debians)
-    maybe_write_log('unused_jars', self.__unused_jars)
-    maybe_write_log('unused_containers', self.__unused_containers)
-    maybe_write_log('unused_images', self.__unused_gce_images)
-    maybe_write_log('unused_configs', self.__unused_configs)
-    maybe_write_log('invalid_boms', self.__invalid_boms)
-    maybe_write_log('confirmed_boms', sorted(list(confirmed_boms)))
-    maybe_write_log('confirmed_releases', sorted(list(confirmed_releases)))
-    maybe_write_log('invalid_versions', self.__invalid_versions)
-    maybe_write_log('invalid_releases', invalid_releases)
-    maybe_write_log('unchecked_releases', unchecked_releases)
-
-  def test_buildnum(self, buildver):
-    dash = buildver.rfind('-')
-    if dash < 0 or not self.options.prune_min_buildnum_prefix:
-      return True
-    buildnum = buildver[dash + 1:]
-    return buildnum < self.options.prune_min_buildnum_prefix
-
-  def determine_bom_candidates(self):
-    path = os.path.join(os.path.dirname(self.get_output_dir()),
-                        'collect_bom_versions', 'bom_list.txt')
-    candidates = []
-    with open(path, 'r') as stream:
-      for line in stream.read().split('\n'):
-        # This matches both -unvalidated and -validated BOMs
-        if line.endswith('validated.yml'):
-          continue
-        bom = CollectBomVersions.url_to_bom_name(line)
-        if not CollectBomVersions.RELEASED_VERSION_MATCHER.match(bom):
-          candidates.append(line)
-
-    return candidates
-
-  def determine_prunings(self):
-    def filter_from_candidates(candidate_version_list):
-      if self.options.prune_min_buildnum_prefix:
-        prune_buildnum = self.test_buildnum
-      else:
-        prune_buildnum = lambda ver: True
-
-      return [candidate for candidate in candidate_version_list if prune_buildnum(candidate)]
-
-    self.__prune_boms = [name for name in self.determine_bom_candidates()
-                         if self.test_buildnum(name)]
-
-    service_list = set(self.__found_debians.keys())
-    service_list.update(set(self.__found_containers.keys()))
-    for name in service_list:
-      skip_versions = self.__invalid_versions.get(name, [])
-      for unused_map, prune_map in [
-          (self.__unused_jars, self.__prune_jars),
-          (self.__unused_debians, self.__prune_debians),
-          (self.__unused_gce_images, self.__prune_gce_images),
-          (self.__unused_containers, self.__prune_containers),
-          (self.__unused_configs, self.__prune_configs)]:
-        unused_list = unused_map.get(name, None)
-        if unused_list is None:
-          unused_list = unused_map.get('spinnaker-' + name, [])
-          if not unused_list and name == 'monitoring-daemon':
-            # Some repos have 'spinnaker-monitoring', not individual components
-            unused_list = unused_map.get('spinnaker-monitoring', [])
-            if unused_list:
-              name = 'spinnaker-monitoring'
-
-        candidates = filter_from_candidates(unused_list)
-
-        # We're going to keep malformed versions. These are rare so
-        # we'll leave it to manual cleanup.
-        pruned = [version
-                  for version in candidates if not version in skip_versions]
-        if pruned:
-          prune_map[name] = sorted(pruned)
-
-  def suggest_prunings(self):
-    path = os.path.join(os.path.dirname(self.get_output_dir()),
-                        'collect_bom_versions', 'config.yml')
-    with open(path, 'r') as stream:
-      bom_config = yaml.safe_load(stream.read())
-    path = os.path.join(os.path.dirname(self.get_output_dir()),
-                        'collect_artifact_versions', 'config.yml')
-    with open(path, 'r') as stream:
-      art_config = yaml.safe_load(stream.read())
-
-    if self.__prune_boms:
-      path = os.path.join(self.get_output_dir(), 'prune_boms.txt')
-      logging.info('Writing to %s', path)
-      write_to_path('\n'.join(sorted(self.__prune_boms)), path)
-
-    jar_repo_path = 'packages/%s/%s' % (
-        art_config['bintray_org'], art_config['bintray_jar_repository'])
-    debian_repo_path = 'packages/%s/%s' % (
-        art_config['bintray_org'], art_config['bintray_debian_repository'])
-    artifact_prefix_func = {
-        'jar': lambda name: 'https://api.bintray.com/%s/%s/versions/' % (
-            jar_repo_path, name),
-        'debian': lambda name: 'https://api.bintray.com/%s/%s/versions/' % (
-            debian_repo_path,
-            name if name == 'spinnaker' else 'spinnaker-' + name),
-        'container': lambda name: '%s/%s:' % (
-            art_config['docker_registry'], name),
-        'image': lambda name: 'spinnaker-%s-' % name,
-        'config': lambda name: 'gs://%s/%s/' % (bom_config['halyard_bom_bucket'], name)
-    }
-    artifact_version_func = {
-        'jar': lambda version: version,
-        'debian': lambda version: version,
-        'container': lambda version: version,
-        'image': lambda version: version.replace('.', '-'),
-        'config': lambda version: version + "**"
-    }
-    for art_type, art_map in [('jar', self.__prune_jars),
-                              ('debian', self.__prune_debians),
-                              ('container', self.__prune_containers),
-                              ('image', self.__prune_gce_images),
-                              ('config', self.__prune_configs)]:
-      urls = []
-      for service, art_list in art_map.items():
-        prefix = artifact_prefix_func[art_type](service)
-        version_func = artifact_version_func[art_type]
-        urls.extend([prefix + version_func(version) for version in art_list])
-      if urls:
-        path = os.path.join(self.get_output_dir(), 'prune_%ss.txt' % art_type)
-        logging.info('Writing to %s', path)
-        write_to_path('\n'.join(sorted(urls)), path)
-
-  def _do_command(self):
-    self.audit_artifacts()
-    self.determine_prunings()
-    self.suggest_prunings()
-
-  def audit_container(self, service, build_version, entries):
-    if service in ['spinnaker', 'monitoring-third-party']:
-      return True  # not applicable
-
-    if service in self.__container_versions:
-      versions = self.__container_versions[service]
-    elif service in ['monitoring-daemon']:
-      versions = self.__container_versions.get('monitoring-daemon', [])
-    else:
-      versions = []
-
-    if build_version in versions:
-      holder = self.__found_containers.get(service, {})
-      holder[build_version] = entries
-      self.__found_containers[service] = holder
-      return True
-
-    holder = self.__missing_containers.get(service, {})
-    holder[build_version] = entries
-    self.__missing_containers[service] = holder
-    logging.warning('Missing %s container %s', service, build_version)
-    return False
-
-  def audit_image(self, service, build_version, entries):
-    if service in ['spinnaker',
-                   'monitoring-third-party', 'monitoring-daemon']:
-      return True  # not applicable
-
-    versions = self.__gce_image_versions.get(service, [])
-    if build_version in versions:
-      holder = self.__found_images.get(service, {})
-      holder[build_version] = entries
-      self.__found_images[service] = holder
-      return True
-
-    # 20181109: Dont audit images as these are no longer built
-    #           so are not expected anyway.
-    #
-    expect_images = False
-    if not expect_images:
-      return True
-
-    # 20181109: We're leaving this around for the time being
-    #           but it isnt reachable.
-    holder = self.__missing_images.get(service, {})
-    holder[build_version] = entries
-    self.__missing_images[service] = holder
-    logging.warning('Missing %s gce image %s', service, build_version)
-    return False
-
-  def audit_jar(self, service, build_version, entries):
-    if service in self.__jar_versions:
-      versions = self.__jar_versions[service]
-    elif service in ['monitoring-daemon', 'monitoring-third-party']:
-      versions = self.__jar_versions.get('spinnaker-monitoring', [])
-    else:
-      versions = []
-
-    if build_version in versions:
-      holder = self.__found_jars.get(service, {})
-      holder[build_version] = entries
-      self.__found_jars[service] = holder
-      return True
-
-    holder = self.__missing_jars.get(service, {})
-    holder[build_version] = entries
-    self.__missing_jars[service] = holder
-    logging.warning('Missing %s jar %s', service, build_version)
-    return False
-
-  def audit_debian(self, service, build_version, info_list):
-    versions = []
-    if service in self.__debian_versions:
-      key = service
-      versions = self.__debian_versions[service]
-    else:
-      key = 'spinnaker-' + service
-      if key in self.__debian_versions:
-        versions = self.__debian_versions[key]
-
-    if build_version in versions:
-      holder = self.__found_debians.get(service, {})
-      holder[build_version] = info_list
-      self.__found_debians[service] = holder
-      return True
-
-    holder = self.__missing_debians.get(key, {})
-    holder[build_version] = info_list
-    self.__missing_debians[key] = holder
-    logging.warning('Missing %s debian %s', key, build_version)
-    return False
-
-  def audit_config(self, service, build_version, info_list):
-    # It appears we used to also pull the 'applies to all services' config,
-    # but this folder no longer exists in the bucket, so don't validate it.
-    if service == 'spinnaker':
-      return True
-
-    versions = []
-    if service in self.__config_versions:
-      versions = self.__config_versions[service]
-    elif service in ['monitoring-third-party']:
-      versions = self.__config_versions.get('monitoring-daemon', [])
-
-    if build_version in versions:
-      holder = self.__found_configs.get(service, {})
-      holder[build_version] = info_list
-      self.__found_configs[service] = holder
-      return True
-
-    holder = self.__missing_configs.get(service, {})
-    holder[build_version] = info_list
-    self.__missing_configs[service] = holder
-    logging.warning('Missing %s configs %s', service, build_version)
-    return False
-
-  def package_in_bom_map(self, service, version, buildnum, service_map):
-    version_map = service_map.get(service)
-    if version_map is None:
-      return False
-    commit_map = version_map.get(version)
-    if commit_map is None:
-      return False
-    for _, buildnums in commit_map.items():
-      for bom_build_num in buildnums:
-        if bom_build_num.startswith(buildnum):
-          return True
-    return False
-
-  def audit_package_helper(self, package, version, buildnum, which):
-    if package in self.__all_released_boms or package in self.__unreleased_boms:
-      name = package
-    elif package.startswith('spinnaker-'):
-      name = package[package.find('-') + 1:]
-    else:
-      return False
-
-    is_released = self.package_in_bom_map(
-        name, version, buildnum, self.__all_released_boms)
-    is_unreleased = self.package_in_bom_map(
-        name, version, buildnum, self.__unreleased_boms)
-    if is_released or is_unreleased:
-      return True
-
-    data_list = which.get(package, [])
-    if buildnum:
-      data_list.append('%s-%s' % (version, buildnum))
-    else:
-      data_list.append(version)
-    which[package] = data_list
-    return False
-
-  def audit_package(self, kind, packages, which):
-    logging.info('Auditing %s packages', kind)
-    for package, versions in packages.items():
-      if package == 'halyard':
-        logging.warning('Skipping halyard.')
-        continue
-      for build_version in versions:
-        parts = build_version.split('-', 1)
-        if len(parts) == 1:
-          logging.warning('Unexpected %s version %s', package, build_version)
-          continue
-        version, buildnum = parts
-        self.audit_package_helper(package, version, buildnum, which)
-
-  def audit_bom_services(self, bom_services, title):
-    def add_invalid_boms(jar_ok, deb_ok, container_ok, image_ok, config_ok,
-                         service, version_buildnum, info_list, invalid_boms):
-      if jar_ok and deb_ok and container_ok and image_ok and config_ok:
-        return
-
-      kind_checks = [(jar_ok, 'jars'),
-                     (deb_ok, 'debs'),
-                     (container_ok, 'containers'),
-                     (image_ok, 'images'),
-                     (config_ok, 'configs')]
-      for info in info_list:
-        bom_version = info['bom_version']
-        bom_record = invalid_boms.get(bom_version, {})
-        for is_ok, kind in kind_checks:
-          if not is_ok:
-            problems = bom_record.get(kind, {})
-            problems[service] = version_buildnum
-            bom_record[kind] = problems
-        invalid_boms[bom_version] = bom_record
-
-    def audit_service(service, versions):
-      for version, commits in versions.items():
-        for _, buildnums in commits.items():
-          for buildnum, info_list in buildnums.items():
-            version_buildnum = '%s-%s' % (version, buildnum)
-            if service in ['monitoring-daemon', 'monitoring-third-party', 'deck']:
-              # Uses debians, but not jars so missing jars is ok.
-              jar_ok = True
+        result = {}
+        for version, commit_build_map in version_to_commit_boms.items():
+            commit_map = {}
+            for commit_id, orig_build_map in commit_build_map.items():
+                build_map = commit_to_current_bom_meta(min_semver, orig_build_map)
+                if build_map:
+                    commit_map[commit_id] = build_map
+            if commit_map:
+                result[version] = commit_map
             else:
-              jar_ok = self.audit_jar(service, version_buildnum, info_list)
-            deb_ok = self.audit_debian(service, version_buildnum, info_list)
-            gcr_ok = self.audit_container(service, version_buildnum, info_list)
-            image_ok = self.audit_image(service, version_buildnum, info_list)
-            config_ok = self.audit_config(service, version_buildnum, info_list)
+                logging.info(
+                    "Dropping version=%s because it bom versions are all too old.",
+                    version,
+                )
+        return result
 
-            add_invalid_boms(jar_ok, deb_ok, gcr_ok, image_ok, config_ok,
-                             service, version_buildnum,
-                             info_list, self.__invalid_boms)
+    def __init__(self, factory, options, **kwargs):
+        if options.prune_min_buildnum_prefix is not None:
+            # Typically numeric so is interpreted as number from yaml
+            options.prune_min_buildnum_prefix = str(options.prune_min_buildnum_prefix)
 
-    logging.debug('Auditing %s BOMs', title)
-    for service, versions in bom_services.items():
-      if not versions:
-        logging.debug('No versions for %s', service)
-        continue
-      audit_service(service, versions)
+        super(AuditArtifactVersions, self).__init__(factory, options, **kwargs)
+        base_path = os.path.dirname(self.get_output_dir())
+        self.__init_bintray_versions_helper(base_path)
+
+        min_version = options.min_audit_bom_version or "0.0.0"
+        min_parts = min_version.split(".")
+        if len(min_parts) < 3:
+            min_version += ".0" * (3 - len(min_parts))
+        self.__min_semver = SemanticVersion.make("ignored-" + min_version)
+
+        bom_data_dir = os.path.join(base_path, "collect_bom_versions")
+        path = os.path.join(bom_data_dir, "released_bom_service_map.yml")
+        check_path_exists(path, "released bom analysis")
+        with open(path, "r") as stream:
+            self.__all_released_boms = {}  # forever
+            self.__current_released_boms = {}  # since min_version to audit
+            for service, versions in yaml.safe_load(stream.read()).items():
+                if not versions:
+                    # e.g. this service has not yet been released.
+                    logging.info("No versions for service=%s", service)
+                    continue
+
+                self.__all_released_boms[service] = versions
+                self.__current_released_boms[service] = versions
+                stripped_versions = self.__remove_old_bom_versions(
+                    self.__min_semver, versions
+                )
+                if stripped_versions:
+                    self.__current_released_boms[service] = stripped_versions
+
+        path = os.path.join(bom_data_dir, "unreleased_bom_service_map.yml")
+        check_path_exists(path, "unreleased bom analysis")
+        with open(path, "r") as stream:
+            self.__unreleased_boms = yaml.safe_load(stream.read())
+
+        self.__only_bad_and_invalid_boms = False
+        self.__all_bom_versions = self.__extract_all_bom_versions(
+            self.__all_released_boms
+        )
+        self.__all_bom_versions.update(
+            self.__extract_all_bom_versions(self.__unreleased_boms)
+        )
+
+        self.__missing_debians = {}
+        self.__missing_jars = {}
+        self.__missing_containers = {}
+        self.__missing_images = {}
+        self.__missing_configs = {}
+        self.__found_debians = {}
+        self.__found_jars = {}
+        self.__found_containers = {}
+        self.__found_images = {}
+        self.__found_configs = {}
+        self.__unused_jars = {}
+        self.__unused_debians = {}
+        self.__unused_containers = {}
+        self.__unused_gce_images = {}
+        self.__unused_configs = {}
+        self.__invalid_boms = {}
+        self.__confirmed_boms = set([])
+        self.__prune_boms = []
+        self.__prune_jars = {}
+        self.__prune_debians = {}
+        self.__prune_containers = {}
+        self.__prune_gce_images = {}
+        self.__prune_configs = {}
+        self.__invalid_versions = {}
+
+    def audit_artifacts(self):
+        self.audit_bom_services(self.__all_released_boms, "released")
+        self.audit_bom_services(self.__unreleased_boms, "unreleased")
+        self.audit_package("jar", self.__jar_versions, self.__unused_jars)
+        self.audit_package("debian", self.__debian_versions, self.__unused_debians)
+        self.audit_package(
+            "container", self.__container_versions, self.__unused_containers
+        )
+        self.audit_package("image", self.__gce_image_versions, self.__unused_gce_images)
+        self.audit_package("config", self.__config_versions, self.__unused_configs)
+
+        def maybe_write_log(what, data):
+            if not data:
+                return
+            path = os.path.join(self.get_output_dir(), "audit_" + what + ".yml")
+            logging.info("Writing %s", path)
+            write_to_path(
+                yaml.safe_dump(data, allow_unicode=True, default_flow_style=False), path
+            )
+
+        confirmed_boms = self.__all_bom_versions - set(self.__invalid_boms.keys())
+        unchecked_releases = [
+            key
+            for key in self.__all_bom_versions
+            if (
+                CollectBomVersions.RELEASED_VERSION_MATCHER.match(key)
+                and SemanticVersion.compare(
+                    SemanticVersion.make("ignored-" + key), self.__min_semver
+                )
+                < 0
+            )
+        ]
+
+        invalid_releases = {
+            key: bom
+            for key, bom in self.__invalid_boms.items()
+            if (
+                CollectBomVersions.RELEASED_VERSION_MATCHER.match(key)
+                and SemanticVersion.compare(
+                    SemanticVersion.make("ignored-" + key), self.__min_semver
+                )
+                >= 0
+            )
+        }
+        confirmed_releases = [
+            key
+            for key in confirmed_boms
+            if (
+                CollectBomVersions.RELEASED_VERSION_MATCHER.match(key)
+                and SemanticVersion.compare(
+                    SemanticVersion.make("ignored-" + key), self.__min_semver
+                )
+                >= 0
+            )
+        ]
+
+        maybe_write_log("missing_debians", self.__missing_debians)
+        maybe_write_log("missing_jars", self.__missing_jars)
+        maybe_write_log("missing_containers", self.__missing_containers)
+        maybe_write_log("missing_images", self.__missing_images)
+        maybe_write_log("missing_configs", self.__missing_configs)
+        maybe_write_log("found_debians", self.__found_debians)
+        maybe_write_log("found_jars", self.__found_jars)
+        maybe_write_log("found_containers", self.__found_containers)
+        maybe_write_log("found_images", self.__found_images)
+        maybe_write_log("found_configs", self.__found_configs)
+        maybe_write_log("unused_debians", self.__unused_debians)
+        maybe_write_log("unused_jars", self.__unused_jars)
+        maybe_write_log("unused_containers", self.__unused_containers)
+        maybe_write_log("unused_images", self.__unused_gce_images)
+        maybe_write_log("unused_configs", self.__unused_configs)
+        maybe_write_log("invalid_boms", self.__invalid_boms)
+        maybe_write_log("confirmed_boms", sorted(list(confirmed_boms)))
+        maybe_write_log("confirmed_releases", sorted(list(confirmed_releases)))
+        maybe_write_log("invalid_versions", self.__invalid_versions)
+        maybe_write_log("invalid_releases", invalid_releases)
+        maybe_write_log("unchecked_releases", unchecked_releases)
+
+    def test_buildnum(self, buildver):
+        dash = buildver.rfind("-")
+        if dash < 0 or not self.options.prune_min_buildnum_prefix:
+            return True
+        buildnum = buildver[dash + 1 :]
+        return buildnum < self.options.prune_min_buildnum_prefix
+
+    def determine_bom_candidates(self):
+        path = os.path.join(
+            os.path.dirname(self.get_output_dir()),
+            "collect_bom_versions",
+            "bom_list.txt",
+        )
+        candidates = []
+        with open(path, "r") as stream:
+            for line in stream.read().split("\n"):
+                # This matches both -unvalidated and -validated BOMs
+                if line.endswith("validated.yml"):
+                    continue
+                bom = CollectBomVersions.url_to_bom_name(line)
+                if not CollectBomVersions.RELEASED_VERSION_MATCHER.match(bom):
+                    candidates.append(line)
+
+        return candidates
+
+    def determine_prunings(self):
+        def filter_from_candidates(candidate_version_list):
+            if self.options.prune_min_buildnum_prefix:
+                prune_buildnum = self.test_buildnum
+            else:
+                prune_buildnum = lambda ver: True
+
+            return [
+                candidate
+                for candidate in candidate_version_list
+                if prune_buildnum(candidate)
+            ]
+
+        self.__prune_boms = [
+            name for name in self.determine_bom_candidates() if self.test_buildnum(name)
+        ]
+
+        service_list = set(self.__found_debians.keys())
+        service_list.update(set(self.__found_containers.keys()))
+        for name in service_list:
+            skip_versions = self.__invalid_versions.get(name, [])
+            for unused_map, prune_map in [
+                (self.__unused_jars, self.__prune_jars),
+                (self.__unused_debians, self.__prune_debians),
+                (self.__unused_gce_images, self.__prune_gce_images),
+                (self.__unused_containers, self.__prune_containers),
+                (self.__unused_configs, self.__prune_configs),
+            ]:
+                unused_list = unused_map.get(name, None)
+                if unused_list is None:
+                    unused_list = unused_map.get("spinnaker-" + name, [])
+                    if not unused_list and name == "monitoring-daemon":
+                        # Some repos have 'spinnaker-monitoring', not individual components
+                        unused_list = unused_map.get("spinnaker-monitoring", [])
+                        if unused_list:
+                            name = "spinnaker-monitoring"
+
+                candidates = filter_from_candidates(unused_list)
+
+                # We're going to keep malformed versions. These are rare so
+                # we'll leave it to manual cleanup.
+                pruned = [
+                    version for version in candidates if not version in skip_versions
+                ]
+                if pruned:
+                    prune_map[name] = sorted(pruned)
+
+    def suggest_prunings(self):
+        path = os.path.join(
+            os.path.dirname(self.get_output_dir()), "collect_bom_versions", "config.yml"
+        )
+        with open(path, "r") as stream:
+            bom_config = yaml.safe_load(stream.read())
+        path = os.path.join(
+            os.path.dirname(self.get_output_dir()),
+            "collect_artifact_versions",
+            "config.yml",
+        )
+        with open(path, "r") as stream:
+            art_config = yaml.safe_load(stream.read())
+
+        if self.__prune_boms:
+            path = os.path.join(self.get_output_dir(), "prune_boms.txt")
+            logging.info("Writing to %s", path)
+            write_to_path("\n".join(sorted(self.__prune_boms)), path)
+
+        jar_repo_path = "packages/%s/%s" % (
+            art_config["bintray_org"],
+            art_config["bintray_jar_repository"],
+        )
+        debian_repo_path = "packages/%s/%s" % (
+            art_config["bintray_org"],
+            art_config["bintray_debian_repository"],
+        )
+        artifact_prefix_func = {
+            "jar": lambda name: "https://api.bintray.com/%s/%s/versions/"
+            % (jar_repo_path, name),
+            "debian": lambda name: "https://api.bintray.com/%s/%s/versions/"
+            % (debian_repo_path, name if name == "spinnaker" else "spinnaker-" + name),
+            "container": lambda name: "%s/%s:" % (art_config["docker_registry"], name),
+            "image": lambda name: "spinnaker-%s-" % name,
+            "config": lambda name: "gs://%s/%s/"
+            % (bom_config["halyard_bom_bucket"], name),
+        }
+        artifact_version_func = {
+            "jar": lambda version: version,
+            "debian": lambda version: version,
+            "container": lambda version: version,
+            "image": lambda version: version.replace(".", "-"),
+            "config": lambda version: version + "**",
+        }
+        for art_type, art_map in [
+            ("jar", self.__prune_jars),
+            ("debian", self.__prune_debians),
+            ("container", self.__prune_containers),
+            ("image", self.__prune_gce_images),
+            ("config", self.__prune_configs),
+        ]:
+            urls = []
+            for service, art_list in art_map.items():
+                prefix = artifact_prefix_func[art_type](service)
+                version_func = artifact_version_func[art_type]
+                urls.extend([prefix + version_func(version) for version in art_list])
+            if urls:
+                path = os.path.join(self.get_output_dir(), "prune_%ss.txt" % art_type)
+                logging.info("Writing to %s", path)
+                write_to_path("\n".join(sorted(urls)), path)
+
+    def _do_command(self):
+        self.audit_artifacts()
+        self.determine_prunings()
+        self.suggest_prunings()
+
+    def audit_container(self, service, build_version, entries):
+        if service in ["spinnaker", "monitoring-third-party"]:
+            return True  # not applicable
+
+        if service in self.__container_versions:
+            versions = self.__container_versions[service]
+        elif service in ["monitoring-daemon"]:
+            versions = self.__container_versions.get("monitoring-daemon", [])
+        else:
+            versions = []
+
+        if build_version in versions:
+            holder = self.__found_containers.get(service, {})
+            holder[build_version] = entries
+            self.__found_containers[service] = holder
+            return True
+
+        holder = self.__missing_containers.get(service, {})
+        holder[build_version] = entries
+        self.__missing_containers[service] = holder
+        logging.warning("Missing %s container %s", service, build_version)
+        return False
+
+    def audit_image(self, service, build_version, entries):
+        if service in ["spinnaker", "monitoring-third-party", "monitoring-daemon"]:
+            return True  # not applicable
+
+        versions = self.__gce_image_versions.get(service, [])
+        if build_version in versions:
+            holder = self.__found_images.get(service, {})
+            holder[build_version] = entries
+            self.__found_images[service] = holder
+            return True
+
+        # 20181109: Dont audit images as these are no longer built
+        #           so are not expected anyway.
+        #
+        expect_images = False
+        if not expect_images:
+            return True
+
+        # 20181109: We're leaving this around for the time being
+        #           but it isnt reachable.
+        holder = self.__missing_images.get(service, {})
+        holder[build_version] = entries
+        self.__missing_images[service] = holder
+        logging.warning("Missing %s gce image %s", service, build_version)
+        return False
+
+    def audit_jar(self, service, build_version, entries):
+        if service in self.__jar_versions:
+            versions = self.__jar_versions[service]
+        elif service in ["monitoring-daemon", "monitoring-third-party"]:
+            versions = self.__jar_versions.get("spinnaker-monitoring", [])
+        else:
+            versions = []
+
+        if build_version in versions:
+            holder = self.__found_jars.get(service, {})
+            holder[build_version] = entries
+            self.__found_jars[service] = holder
+            return True
+
+        holder = self.__missing_jars.get(service, {})
+        holder[build_version] = entries
+        self.__missing_jars[service] = holder
+        logging.warning("Missing %s jar %s", service, build_version)
+        return False
+
+    def audit_debian(self, service, build_version, info_list):
+        versions = []
+        if service in self.__debian_versions:
+            key = service
+            versions = self.__debian_versions[service]
+        else:
+            key = "spinnaker-" + service
+            if key in self.__debian_versions:
+                versions = self.__debian_versions[key]
+
+        if build_version in versions:
+            holder = self.__found_debians.get(service, {})
+            holder[build_version] = info_list
+            self.__found_debians[service] = holder
+            return True
+
+        holder = self.__missing_debians.get(key, {})
+        holder[build_version] = info_list
+        self.__missing_debians[key] = holder
+        logging.warning("Missing %s debian %s", key, build_version)
+        return False
+
+    def audit_config(self, service, build_version, info_list):
+        # It appears we used to also pull the 'applies to all services' config,
+        # but this folder no longer exists in the bucket, so don't validate it.
+        if service == "spinnaker":
+            return True
+
+        versions = []
+        if service in self.__config_versions:
+            versions = self.__config_versions[service]
+        elif service in ["monitoring-third-party"]:
+            versions = self.__config_versions.get("monitoring-daemon", [])
+
+        if build_version in versions:
+            holder = self.__found_configs.get(service, {})
+            holder[build_version] = info_list
+            self.__found_configs[service] = holder
+            return True
+
+        holder = self.__missing_configs.get(service, {})
+        holder[build_version] = info_list
+        self.__missing_configs[service] = holder
+        logging.warning("Missing %s configs %s", service, build_version)
+        return False
+
+    def package_in_bom_map(self, service, version, buildnum, service_map):
+        version_map = service_map.get(service)
+        if version_map is None:
+            return False
+        commit_map = version_map.get(version)
+        if commit_map is None:
+            return False
+        for _, buildnums in commit_map.items():
+            for bom_build_num in buildnums:
+                if bom_build_num.startswith(buildnum):
+                    return True
+        return False
+
+    def audit_package_helper(self, package, version, buildnum, which):
+        if package in self.__all_released_boms or package in self.__unreleased_boms:
+            name = package
+        elif package.startswith("spinnaker-"):
+            name = package[package.find("-") + 1 :]
+        else:
+            return False
+
+        is_released = self.package_in_bom_map(
+            name, version, buildnum, self.__all_released_boms
+        )
+        is_unreleased = self.package_in_bom_map(
+            name, version, buildnum, self.__unreleased_boms
+        )
+        if is_released or is_unreleased:
+            return True
+
+        data_list = which.get(package, [])
+        if buildnum:
+            data_list.append("%s-%s" % (version, buildnum))
+        else:
+            data_list.append(version)
+        which[package] = data_list
+        return False
+
+    def audit_package(self, kind, packages, which):
+        logging.info("Auditing %s packages", kind)
+        for package, versions in packages.items():
+            if package == "halyard":
+                logging.warning("Skipping halyard.")
+                continue
+            for build_version in versions:
+                parts = build_version.split("-", 1)
+                if len(parts) == 1:
+                    logging.warning("Unexpected %s version %s", package, build_version)
+                    continue
+                version, buildnum = parts
+                self.audit_package_helper(package, version, buildnum, which)
+
+    def audit_bom_services(self, bom_services, title):
+        def add_invalid_boms(
+            jar_ok,
+            deb_ok,
+            container_ok,
+            image_ok,
+            config_ok,
+            service,
+            version_buildnum,
+            info_list,
+            invalid_boms,
+        ):
+            if jar_ok and deb_ok and container_ok and image_ok and config_ok:
+                return
+
+            kind_checks = [
+                (jar_ok, "jars"),
+                (deb_ok, "debs"),
+                (container_ok, "containers"),
+                (image_ok, "images"),
+                (config_ok, "configs"),
+            ]
+            for info in info_list:
+                bom_version = info["bom_version"]
+                bom_record = invalid_boms.get(bom_version, {})
+                for is_ok, kind in kind_checks:
+                    if not is_ok:
+                        problems = bom_record.get(kind, {})
+                        problems[service] = version_buildnum
+                        bom_record[kind] = problems
+                invalid_boms[bom_version] = bom_record
+
+        def audit_service(service, versions):
+            for version, commits in versions.items():
+                for _, buildnums in commits.items():
+                    for buildnum, info_list in buildnums.items():
+                        version_buildnum = "%s-%s" % (version, buildnum)
+                        if service in [
+                            "monitoring-daemon",
+                            "monitoring-third-party",
+                            "deck",
+                        ]:
+                            # Uses debians, but not jars so missing jars is ok.
+                            jar_ok = True
+                        else:
+                            jar_ok = self.audit_jar(
+                                service, version_buildnum, info_list
+                            )
+                        deb_ok = self.audit_debian(service, version_buildnum, info_list)
+                        gcr_ok = self.audit_container(
+                            service, version_buildnum, info_list
+                        )
+                        image_ok = self.audit_image(
+                            service, version_buildnum, info_list
+                        )
+                        config_ok = self.audit_config(
+                            service, version_buildnum, info_list
+                        )
+
+                        add_invalid_boms(
+                            jar_ok,
+                            deb_ok,
+                            gcr_ok,
+                            image_ok,
+                            config_ok,
+                            service,
+                            version_buildnum,
+                            info_list,
+                            self.__invalid_boms,
+                        )
+
+        logging.debug("Auditing %s BOMs", title)
+        for service, versions in bom_services.items():
+            if not versions:
+                logging.debug("No versions for %s", service)
+                continue
+            audit_service(service, versions)
 
 
 class AuditArtifactVersionsFactory(CommandFactory):
-  def __init__(self, **kwargs):
-    super(AuditArtifactVersionsFactory, self).__init__(
-        'audit_artifact_versions', AuditArtifactVersions,
-        'Audit artifact versions in BOMs and vice-versa', **kwargs)
+    def __init__(self, **kwargs):
+        super(AuditArtifactVersionsFactory, self).__init__(
+            "audit_artifact_versions",
+            AuditArtifactVersions,
+            "Audit artifact versions in BOMs and vice-versa",
+            **kwargs
+        )
 
-  def init_argparser(self, parser, defaults):
-    super(AuditArtifactVersionsFactory, self).init_argparser(parser, defaults)
-    self.add_argument(parser, 'min_audit_bom_version', defaults, None,
-                      help='Minimum released bom version to audit.')
-    self.add_argument(
-        parser, 'prune_min_buildnum_prefix', defaults, None,
-        help='Only suggest pruning artifacts with a smaller build number.'
-        ' This is actually just a string, not a number so is a string compare.')
+    def init_argparser(self, parser, defaults):
+        super(AuditArtifactVersionsFactory, self).init_argparser(parser, defaults)
+        self.add_argument(
+            parser,
+            "min_audit_bom_version",
+            defaults,
+            None,
+            help="Minimum released bom version to audit.",
+        )
+        self.add_argument(
+            parser,
+            "prune_min_buildnum_prefix",
+            defaults,
+            None,
+            help="Only suggest pruning artifacts with a smaller build number."
+            " This is actually just a string, not a number so is a string compare.",
+        )
+
 
 def register_commands(registry, subparsers, defaults):
-  CollectBomVersionsFactory().register(registry, subparsers, defaults)
-  CollectArtifactVersionsFactory().register(registry, subparsers, defaults)
-  AuditArtifactVersionsFactory().register(registry, subparsers, defaults)
+    CollectBomVersionsFactory().register(registry, subparsers, defaults)
+    CollectArtifactVersionsFactory().register(registry, subparsers, defaults)
+    AuditArtifactVersionsFactory().register(registry, subparsers, defaults)

--- a/dev/buildtool/inspection_commands.py
+++ b/dev/buildtool/inspection_commands.py
@@ -566,7 +566,7 @@ class CollectArtifactVersions(CommandProcessor):
     def difference(self, versions, target):
         missing = []
         for version in versions:
-            if not version in target:
+            if version not in target:
                 missing.append(version)
         return missing
 
@@ -576,11 +576,11 @@ class CollectArtifactVersions(CommandProcessor):
         for package, versions in debian_map.items():
             if package.startswith(prefix):
                 key = package[len(prefix) :]
-            if not key in jar_map:
+            if key not in jar_map:
                 key = package
                 if key == "spinnaker-monitoring":
                     key = "spinnaker-monitoring-daemon"
-                if not key in jar_map:
+                if key not in jar_map:
                     if key == "spinnaker-monitoring-third-party":
                         continue
                     continue
@@ -594,9 +594,9 @@ class CollectArtifactVersions(CommandProcessor):
         missing_debians = {}
         for package, versions in jar_map.items():
             key = "spinnaker-" + package
-            if not key in debian_map:
+            if key not in debian_map:
                 key = package
-                if not key in debian_map:
+                if key not in debian_map:
                     if key == "spinnaker-monitoring":
                         key = "spinnaker-monitoring-daemon"
                     else:
@@ -1240,7 +1240,7 @@ class AuditArtifactVersions(CommandProcessor):
                 # We're going to keep malformed versions. These are rare so
                 # we'll leave it to manual cleanup.
                 pruned = [
-                    version for version in candidates if not version in skip_versions
+                    version for version in candidates if version not in skip_versions
                 ]
                 if pruned:
                     prune_map[name] = sorted(pruned)

--- a/dev/buildtool/inspection_commands.py
+++ b/dev/buildtool/inspection_commands.py
@@ -129,7 +129,7 @@ class CollectBomVersions(CommandProcessor):
         return os.path.splitext(name)[0]
 
     def __init__(self, factory, options, **kwargs):
-        if options.bintray_org is None != options.bintray_debian_repository is None:
+        if (options.bintray_org is None) is not (options.bintray_debian_repository is None):
             raise_and_log_error(
                 ConfigError(
                     'Either neither or both "bintray_org"'

--- a/dev/buildtool/inspection_commands.py
+++ b/dev/buildtool/inspection_commands.py
@@ -84,7 +84,7 @@ def my_unicode_representer(self, data):
   return self.represent_str(data.encode('utf-8'))
 
 if sys.version_info[0] == 2:
-  yaml.representer.Representer.add_representer(unicode, my_unicode_representer)
+  yaml.representer.Representer.add_representer(str, my_unicode_representer)
 
 yaml.Dumper.ignore_aliases = lambda *args: True
 

--- a/dev/buildtool/metrics.py
+++ b/dev/buildtool/metrics.py
@@ -22,56 +22,73 @@ from buildtool.influxdb_metrics import InfluxDbMetricsRegistry
 
 
 class MetricsManager(object):
-  """Acts as factory for specialized BaseMetricsRegistry singleton."""
+    """Acts as factory for specialized BaseMetricsRegistry singleton."""
 
-  __metrics_registry = None
+    __metrics_registry = None
 
-  @staticmethod
-  def singleton():
-    """Returns the BaseMetricsRegistry once startup_metrics is called."""
-    if MetricsManager.__metrics_registry is None:
-      raise Exception('startup_metrics was not called.')
-    return MetricsManager.__metrics_registry
+    @staticmethod
+    def singleton():
+        """Returns the BaseMetricsRegistry once startup_metrics is called."""
+        if MetricsManager.__metrics_registry is None:
+            raise Exception("startup_metrics was not called.")
+        return MetricsManager.__metrics_registry
 
-  @staticmethod
-  def init_argument_parser(parser, defaults):
-    """Init argparser with metrics-related options."""
-    InMemoryMetricsRegistry.init_argument_parser(parser, defaults)
-    InfluxDbMetricsRegistry.init_argument_parser(parser, defaults)
-    add_parser_argument(
-        parser, 'monitoring_enabled', defaults, False, type=bool,
-        help='Enable monitoring to stackdriver.')
-    add_parser_argument(
-        parser, 'monitoring_flush_frequency', defaults, 15,
-        help='Frequency at which to push metrics in seconds.')
-    add_parser_argument(
-        parser, 'monitoring_system', defaults, 'file',
-        choices=['file', 'influxdb'],
-        help='Where to store metrics.')
-    add_parser_argument(
-        parser, 'monitoring_context_labels', defaults, None,
-        help='A comma-separated list of additional name=value'
-             ' labels to add to each event to associate them together.'
-             ' (e.g. version=release-1.2.x)')
+    @staticmethod
+    def init_argument_parser(parser, defaults):
+        """Init argparser with metrics-related options."""
+        InMemoryMetricsRegistry.init_argument_parser(parser, defaults)
+        InfluxDbMetricsRegistry.init_argument_parser(parser, defaults)
+        add_parser_argument(
+            parser,
+            "monitoring_enabled",
+            defaults,
+            False,
+            type=bool,
+            help="Enable monitoring to stackdriver.",
+        )
+        add_parser_argument(
+            parser,
+            "monitoring_flush_frequency",
+            defaults,
+            15,
+            help="Frequency at which to push metrics in seconds.",
+        )
+        add_parser_argument(
+            parser,
+            "monitoring_system",
+            defaults,
+            "file",
+            choices=["file", "influxdb"],
+            help="Where to store metrics.",
+        )
+        add_parser_argument(
+            parser,
+            "monitoring_context_labels",
+            defaults,
+            None,
+            help="A comma-separated list of additional name=value"
+            " labels to add to each event to associate them together."
+            " (e.g. version=release-1.2.x)",
+        )
 
-  @staticmethod
-  def startup_metrics(options):
-    """Startup metrics module with concrete system."""
-    monitoring_systems = {
-        'file': InMemoryMetricsRegistry,
-        'influxdb': InfluxDbMetricsRegistry
-    }
-    klas = monitoring_systems[options.monitoring_system]
-    logging.debug('Initializing monitoring with system="%s"', klas.__name__)
-    MetricsManager.__metrics_registry = klas(options)
-    if options.monitoring_enabled and options.monitoring_flush_frequency > 0:
-      MetricsManager.__metrics_registry.start_pusher_thread()
-    return MetricsManager.__metrics_registry
+    @staticmethod
+    def startup_metrics(options):
+        """Startup metrics module with concrete system."""
+        monitoring_systems = {
+            "file": InMemoryMetricsRegistry,
+            "influxdb": InfluxDbMetricsRegistry,
+        }
+        klas = monitoring_systems[options.monitoring_system]
+        logging.debug('Initializing monitoring with system="%s"', klas.__name__)
+        MetricsManager.__metrics_registry = klas(options)
+        if options.monitoring_enabled and options.monitoring_flush_frequency > 0:
+            MetricsManager.__metrics_registry.start_pusher_thread()
+        return MetricsManager.__metrics_registry
 
-  @staticmethod
-  def shutdown_metrics():
-    """Write final metrics out to metrics server."""
-    registry = MetricsManager.singleton()
-    registry.stop_pusher_thread()
-    registry.flush_updated_metrics()
-    registry.flush_final_metrics()
+    @staticmethod
+    def shutdown_metrics():
+        """Write final metrics out to metrics server."""
+        registry = MetricsManager.singleton()
+        registry.stop_pusher_thread()
+        registry.flush_updated_metrics()
+        registry.flush_final_metrics()

--- a/dev/buildtool/repository_command.py
+++ b/dev/buildtool/repository_command.py
@@ -17,199 +17,232 @@
 import logging
 
 # pylint: disable=relative-import
-from buildtool import (
-    CommandProcessor,
-    CommandFactory,
-    maybe_log_exception)
+from buildtool import CommandProcessor, CommandFactory, maybe_log_exception
 
 
 def _do_call_do_repository(repository, command):
-  """Run the command's _do_repository on the given repository.
+    """Run the command's _do_repository on the given repository.
 
-  This will track the invocation and its outcome.
-  """
-  # pylint: disable=protected-access
-  logging.info('%s processing %s', command.name, repository.name)
-  try:
-    metric_labels = command.determine_metric_labels()
-    metric_labels['repository'] = repository.name
-    result = command.metrics.track_and_time_call(
-        'RunRepositoryCommand',
-        metric_labels, command.metrics.default_determine_outcome_labels,
-        command._do_repository_wrapper, repository)
-    logging.info('%s finished %s', command.name, repository.name)
-    return result
-  except Exception as ex:
-    maybe_log_exception(
-        '{command} on repo={repo}'.format(
-            command=command.name, repo=repository.name),
-        ex)
-    raise
+    This will track the invocation and its outcome.
+    """
+    # pylint: disable=protected-access
+    logging.info("%s processing %s", command.name, repository.name)
+    try:
+        metric_labels = command.determine_metric_labels()
+        metric_labels["repository"] = repository.name
+        result = command.metrics.track_and_time_call(
+            "RunRepositoryCommand",
+            metric_labels,
+            command.metrics.default_determine_outcome_labels,
+            command._do_repository_wrapper,
+            repository,
+        )
+        logging.info("%s finished %s", command.name, repository.name)
+        return result
+    except Exception as ex:
+        maybe_log_exception(
+            "{command} on repo={repo}".format(
+                command=command.name, repo=repository.name
+            ),
+            ex,
+        )
+        raise
 
 
 class RepositoryCommandProcessor(CommandProcessor):
-  """And abstract command processor that run a command for each repository.
+    """And abstract command processor that run a command for each repository.
 
-  Derived classes should override _do_repository() rather than _do_command().
-  """
-
-  @property
-  def bom(self):
-    """Return the bom, if one is bound."""
-    return self.__scm.bom
-
-  @property
-  def git(self):
-    return self.__scm.git
-
-  @property
-  def scm(self):
-    return self.__scm
-
-  @property
-  def source_code_manager(self):
-    return self.__scm
-
-  @property
-  def source_repositories(self):
-    if self.__source_repositories is None:
-      self.__source_repositories = self.filter_repositories(
-          self.__scm.determine_source_repositories())
-    return self.__source_repositories
-
-  def __init__(self, factory, options, **kwargs):
-    source_repo_names = kwargs.pop('source_repository_names', None)
-    max_threads = kwargs.pop('max_threads', 64)
-    if options.one_at_a_time:
-      logging.debug('Limiting %s to one thread.', factory.name)
-      max_threads = 1
-
-    super(RepositoryCommandProcessor, self).__init__(
-        factory, options, **kwargs)
-    self.__scm = factory.make_scm(options, self.get_input_dir(),
-                                  max_threads=max_threads)
-
-    self.__source_repositories = None
-    if source_repo_names:
-      # filter needs the options, so this is after our super init call.
-      if self.options.exclude_repositories:
-        exclude_names = self.options.exclude_repositories.split(',')
-      else:
-        exclude_names = []
-      if self.options.only_repositories:
-        only_names = self.options.only_repositories.split(',')
-      else:
-        only_names = source_repo_names
-      self.__source_repositories = self.filter_repositories(
-          [self.__scm.make_repository_spec(name)
-           for name in source_repo_names
-           if name in only_names and name not in exclude_names])
-
-  def ensure_local_repository(self, repository):
-    """Prepare the repository.git_dir."""
-    self.__scm.ensure_local_repository(repository)
-
-  def filter_repositories(self, source_repositories):
-    """Filter a list of source_repositories using option constraints."""
-    # pylint: disable=unused-argument
-    if not (self.options.only_repositories
-            or self.options.exclude_repositories):
-      return source_repositories
-
-    if self.options.only_repositories:
-      restrict_filter = self.options.only_repositories.split(',')
-    else:
-      restrict_filter = []
-
-    if self.options.exclude_repositories:
-      exclude_filter = self.options.exclude_repositories.split(',')
-    else:
-      exclude_filter = []
-
-    if not restrict_filter and exclude_filter:
-      restrict_filter = [repo.name for repo in source_repositories]
-    return [repository for repository in source_repositories
-            if ((not restrict_filter or repository.name in restrict_filter)
-                and not repository.name in exclude_filter)]
-
-  def _do_command(self):
-    """Implements CommandProcessor interface.
-
-    Derived classes should instead implement _do_repository to operate
-    on individual repositories.
-
-    They can also implement _do_preprocess or _do_postprocess to inject
-    behavior before processing any repositories or after processing all them.
+    Derived classes should override _do_repository() rather than _do_command().
     """
-    self._do_preprocess()
-    result_dict = self.__scm.foreach_source_repository(
-        self.source_repositories, _do_call_do_repository, self)
-    return self._do_postprocess(result_dict)
 
-  def _do_preprocess(self):
-    """Prepares the command with any pre-requisites that can be factored out."""
-    pass
+    @property
+    def bom(self):
+        """Return the bom, if one is bound."""
+        return self.__scm.bom
 
-  def _do_postprocess(self, result_dict):
-    """Perform any post-process after all the repos have been processed.
+    @property
+    def git(self):
+        return self.__scm.git
 
-    Args:
-      result_dict: [dict] The result of the foreach_source_repository call.
+    @property
+    def scm(self):
+        return self.__scm
 
-    Returns:
-      The final result for the command.
-    """
-    return result_dict
+    @property
+    def source_code_manager(self):
+        return self.__scm
 
-  def _do_repository_wrapper(self, repository):
-    """Internal method doing some setup work before calling do repository.
+    @property
+    def source_repositories(self):
+        if self.__source_repositories is None:
+            self.__source_repositories = self.filter_repositories(
+                self.__scm.determine_source_repositories()
+            )
+        return self.__source_repositories
 
-    This is for instrumentation purposes.
-    """
-    if self._do_can_skip_repository(repository):
-      self.metrics.inc_counter(
-          'SkipRepositoryCommand',
-          {'command': self.name, 'repository': repository.name})
-      logging.debug('Skipping repository %s', repository.name)
-      return None
+    def __init__(self, factory, options, **kwargs):
+        source_repo_names = kwargs.pop("source_repository_names", None)
+        max_threads = kwargs.pop("max_threads", 64)
+        if options.one_at_a_time:
+            logging.debug("Limiting %s to one thread.", factory.name)
+            max_threads = 1
 
-    self.ensure_local_repository(repository)
-    return self._do_repository(repository)
+        super(RepositoryCommandProcessor, self).__init__(factory, options, **kwargs)
+        self.__scm = factory.make_scm(
+            options, self.get_input_dir(), max_threads=max_threads
+        )
 
-  def _do_can_skip_repository(self, repository):
-    """Perform a check to see if the command can skip this repository.
+        self.__source_repositories = None
+        if source_repo_names:
+            # filter needs the options, so this is after our super init call.
+            if self.options.exclude_repositories:
+                exclude_names = self.options.exclude_repositories.split(",")
+            else:
+                exclude_names = []
+            if self.options.only_repositories:
+                only_names = self.options.only_repositories.split(",")
+            else:
+                only_names = source_repo_names
+            self.__source_repositories = self.filter_repositories(
+                [
+                    self.__scm.make_repository_spec(name)
+                    for name in source_repo_names
+                    if name in only_names and name not in exclude_names
+                ]
+            )
 
-    This is called prior to ensure_local_repository.
-    """
-    return False
+    def ensure_local_repository(self, repository):
+        """Prepare the repository.git_dir."""
+        self.__scm.ensure_local_repository(repository)
 
-  def _do_repository(self, repository):
-    """This should be overriden to implement actual behavior."""
-    raise NotImplementedError(
-        '%s._do_repository(%r)' % (self.__class__.__name__, repository.name))
+    def filter_repositories(self, source_repositories):
+        """Filter a list of source_repositories using option constraints."""
+        # pylint: disable=unused-argument
+        if not (self.options.only_repositories or self.options.exclude_repositories):
+            return source_repositories
+
+        if self.options.only_repositories:
+            restrict_filter = self.options.only_repositories.split(",")
+        else:
+            restrict_filter = []
+
+        if self.options.exclude_repositories:
+            exclude_filter = self.options.exclude_repositories.split(",")
+        else:
+            exclude_filter = []
+
+        if not restrict_filter and exclude_filter:
+            restrict_filter = [repo.name for repo in source_repositories]
+        return [
+            repository
+            for repository in source_repositories
+            if (
+                (not restrict_filter or repository.name in restrict_filter)
+                and not repository.name in exclude_filter
+            )
+        ]
+
+    def _do_command(self):
+        """Implements CommandProcessor interface.
+
+        Derived classes should instead implement _do_repository to operate
+        on individual repositories.
+
+        They can also implement _do_preprocess or _do_postprocess to inject
+        behavior before processing any repositories or after processing all them.
+        """
+        self._do_preprocess()
+        result_dict = self.__scm.foreach_source_repository(
+            self.source_repositories, _do_call_do_repository, self
+        )
+        return self._do_postprocess(result_dict)
+
+    def _do_preprocess(self):
+        """Prepares the command with any pre-requisites that can be factored out."""
+        pass
+
+    def _do_postprocess(self, result_dict):
+        """Perform any post-process after all the repos have been processed.
+
+        Args:
+          result_dict: [dict] The result of the foreach_source_repository call.
+
+        Returns:
+          The final result for the command.
+        """
+        return result_dict
+
+    def _do_repository_wrapper(self, repository):
+        """Internal method doing some setup work before calling do repository.
+
+        This is for instrumentation purposes.
+        """
+        if self._do_can_skip_repository(repository):
+            self.metrics.inc_counter(
+                "SkipRepositoryCommand",
+                {"command": self.name, "repository": repository.name},
+            )
+            logging.debug("Skipping repository %s", repository.name)
+            return None
+
+        self.ensure_local_repository(repository)
+        return self._do_repository(repository)
+
+    def _do_can_skip_repository(self, repository):
+        """Perform a check to see if the command can skip this repository.
+
+        This is called prior to ensure_local_repository.
+        """
+        return False
+
+    def _do_repository(self, repository):
+        """This should be overriden to implement actual behavior."""
+        raise NotImplementedError(
+            "%s._do_repository(%r)" % (self.__class__.__name__, repository.name)
+        )
 
 
 class RepositoryCommandFactory(CommandFactory):
-  def __init__(self, name, factory_method, description, scm_factory,
-               *factory_method_pos_args, **factory_method_kwargs):
-    super(RepositoryCommandFactory, self).__init__(
-        name, factory_method, description,
-        *factory_method_pos_args, **factory_method_kwargs)
-    self.__scm_factory = scm_factory
+    def __init__(
+        self,
+        name,
+        factory_method,
+        description,
+        scm_factory,
+        *factory_method_pos_args,
+        **factory_method_kwargs
+    ):
+        super(RepositoryCommandFactory, self).__init__(
+            name,
+            factory_method,
+            description,
+            *factory_method_pos_args,
+            **factory_method_kwargs
+        )
+        self.__scm_factory = scm_factory
 
-  def make_scm(self, options, root_source_dir, **kwargs):
-    """Create the SourceCodeManager for this command."""
-    return self.__scm_factory(options, root_source_dir, **kwargs)
+    def make_scm(self, options, root_source_dir, **kwargs):
+        """Create the SourceCodeManager for this command."""
+        return self.__scm_factory(options, root_source_dir, **kwargs)
 
-  def init_argparser(self, parser, defaults):
-    """Hook for derived classes to override to add their specific arguments."""
-    super(RepositoryCommandFactory, self).init_argparser(parser, defaults)
-    self.__scm_factory.add_parser_args(parser, defaults)
-    self.add_argument(parser, 'only_repositories', defaults, None,
-                      help='Limit the command to the specified repositories.'
-                      ' This is a list of comma-separated repository names.')
-    self.add_argument(
-        parser, 'exclude_repositories', defaults, None,
-        help='Do not apply the command to the specified repositories.'
-        ' This is a list of comma-separated repository names.'
-        ' This flag is intended for temporary use to bypass broken repos.')
+    def init_argparser(self, parser, defaults):
+        """Hook for derived classes to override to add their specific arguments."""
+        super(RepositoryCommandFactory, self).init_argparser(parser, defaults)
+        self.__scm_factory.add_parser_args(parser, defaults)
+        self.add_argument(
+            parser,
+            "only_repositories",
+            defaults,
+            None,
+            help="Limit the command to the specified repositories."
+            " This is a list of comma-separated repository names.",
+        )
+        self.add_argument(
+            parser,
+            "exclude_repositories",
+            defaults,
+            None,
+            help="Do not apply the command to the specified repositories."
+            " This is a list of comma-separated repository names."
+            " This flag is intended for temporary use to bypass broken repos.",
+        )

--- a/dev/buildtool/repository_command.py
+++ b/dev/buildtool/repository_command.py
@@ -138,7 +138,7 @@ class RepositoryCommandProcessor(CommandProcessor):
             for repository in source_repositories
             if (
                 (not restrict_filter or repository.name in restrict_filter)
-                and not repository.name in exclude_filter
+                and repository.name not in exclude_filter
             )
         ]
 

--- a/dev/buildtool/scm.py
+++ b/dev/buildtool/scm.py
@@ -29,246 +29,263 @@ import yaml
 from buildtool import (
     GitRepositorySpec,
     GitRunner,
-
     add_parser_argument,
     check_kwargs_empty,
     raise_and_log_error,
     write_to_path,
-    UnexpectedError)
+    UnexpectedError,
+)
 
 
-class SourceInfo(
-    collections.namedtuple('SourceInfo', ['build_number', 'summary'])):
-  """Basic things about the state of a source repository."""
+class SourceInfo(collections.namedtuple("SourceInfo", ["build_number", "summary"])):
+    """Basic things about the state of a source repository."""
 
-  def to_build_version(self):
-    """Return the version name which is a git tag on the repository."""
-    return self.summary.version
+    def to_build_version(self):
+        """Return the version name which is a git tag on the repository."""
+        return self.summary.version
 
 
 class RepositoryWorker(object):
-  """A picklable callable for passing to inter-process mappers."""
-  # pylint: disable=too-few-public-methods
+    """A picklable callable for passing to inter-process mappers."""
 
-  def __init__(self, fn, *pargs, **kwargs):
-    """ Constructor
+    # pylint: disable=too-few-public-methods
 
-    Args:
-      fn: [callable] might need to be picklable depending on use case.
-         The first argument to fn should be a SourceRepository which will
-         be injected by the call() method.
-      pargs: [list] additional positional args required by fn
-      kwargs: [kwargs] keyword args to passthrough to fn
-    """
-    self.__fn = fn
-    self.__pargs = pargs
-    self.__kwargs = kwargs
+    def __init__(self, fn, *pargs, **kwargs):
+        """Constructor
 
-  def __call__(self, repository):
-    """Call the bound function with the repository plus bound args."""
-    name = repository.name
-    return name, self.__fn(repository, *self.__pargs, **self.__kwargs)
+        Args:
+          fn: [callable] might need to be picklable depending on use case.
+             The first argument to fn should be a SourceRepository which will
+             be injected by the call() method.
+          pargs: [list] additional positional args required by fn
+          kwargs: [kwargs] keyword args to passthrough to fn
+        """
+        self.__fn = fn
+        self.__pargs = pargs
+        self.__kwargs = kwargs
+
+    def __call__(self, repository):
+        """Call the bound function with the repository plus bound args."""
+        name = repository.name
+        return name, self.__fn(repository, *self.__pargs, **self.__kwargs)
 
 
 class SpinnakerSourceCodeManager(object):
-  """Helper class for managing spinnaker source code repositories."""
+    """Helper class for managing spinnaker source code repositories."""
 
-  AUTO = '_auto_'
+    AUTO = "_auto_"
 
-  @staticmethod
-  def add_parser_args(parser, defaults):
-    """Add standard parser arguments used by SourceCodeManager."""
-    if hasattr(parser, 'added_scm'):
-      return
-    parser.added_scm = True
-    GitRunner.add_parser_args(parser, defaults)
-    add_parser_argument(parser, 'github_upstream_owner',
-                        defaults, 'spinnaker',
-                        help='The standard upstream repository owner.')
+    @staticmethod
+    def add_parser_args(parser, defaults):
+        """Add standard parser arguments used by SourceCodeManager."""
+        if hasattr(parser, "added_scm"):
+            return
+        parser.added_scm = True
+        GitRunner.add_parser_args(parser, defaults)
+        add_parser_argument(
+            parser,
+            "github_upstream_owner",
+            defaults,
+            "spinnaker",
+            help="The standard upstream repository owner.",
+        )
 
-  @property
-  def git(self):
-    return self.__git
+    @property
+    def git(self):
+        return self.__git
 
-  @property
-  def options(self):
-    return self.__options
+    @property
+    def options(self):
+        return self.__options
 
-  @property
-  def root_source_dir(self):
-    """The base directory for all the source repositories.
+    @property
+    def root_source_dir(self):
+        """The base directory for all the source repositories.
 
-    Each repository will be a child directory of this path.
-    """
-    return self.__root_source_dir
+        Each repository will be a child directory of this path.
+        """
+        return self.__root_source_dir
 
-  def __init__(self, options, root_source_dir, **kwargs):
-    self.__max_threads = kwargs.pop('max_threads', 100)
-    self.__add_upstream = kwargs.pop('attach_upstream', False)
-    check_kwargs_empty(kwargs)
+    def __init__(self, options, root_source_dir, **kwargs):
+        self.__max_threads = kwargs.pop("max_threads", 100)
+        self.__add_upstream = kwargs.pop("attach_upstream", False)
+        check_kwargs_empty(kwargs)
 
-    self.__options = options
-    self.__git = GitRunner(options)
-    self.__root_source_dir = root_source_dir
+        self.__options = options
+        self.__git = GitRunner(options)
+        self.__root_source_dir = root_source_dir
 
-  def service_name_to_repository_name(self, service_name):
-    if service_name == 'monitoring-daemon':
-      return 'spinnaker-monitoring'
-    return service_name
+    def service_name_to_repository_name(self, service_name):
+        if service_name == "monitoring-daemon":
+            return "spinnaker-monitoring"
+        return service_name
 
-  def repository_name_to_service_name(self, repository_name):
-    if repository_name == 'spinnaker-monitoring':
-      return 'monitoring-daemon'
-    return repository_name
+    def repository_name_to_service_name(self, repository_name):
+        if repository_name == "spinnaker-monitoring":
+            return "monitoring-daemon"
+        return repository_name
 
-  def ensure_repository(self, repository):
-    raise NotImplementedError(self.__class__.__name__)
+    def ensure_repository(self, repository):
+        raise NotImplementedError(self.__class__.__name__)
 
-  def check_repository_is_current(self, repository):
-    raise NotImplementedError(self.__class__.__name__)
+    def check_repository_is_current(self, repository):
+        raise NotImplementedError(self.__class__.__name__)
 
-  def determine_build_number(self, repository):
-    raise NotImplementedError(self.__class__.__name__)
+    def determine_build_number(self, repository):
+        raise NotImplementedError(self.__class__.__name__)
 
-  def determine_origin(self, name):
-    """Determine the origin URL for the given repository name."""
-    raise NotImplementedError(self.__class__.__name__)
+    def determine_origin(self, name):
+        """Determine the origin URL for the given repository name."""
+        raise NotImplementedError(self.__class__.__name__)
 
-  def make_repository_spec(self, name, **kwargs):
-    """Create GitRepositorySpec based on the name and configuration.
+    def make_repository_spec(self, name, **kwargs):
+        """Create GitRepositorySpec based on the name and configuration.
 
-    Args:
-      git_dir: if supplied then use it, otherwise default under the root path.
-      origin: if supplied then use it, even if None. Otherwise default
-      upstream: if supplied then use it, even if None. Otherwise default.
-      kwargs: Additional repository attributes
-    """
-    git_dir = kwargs.pop('git_dir', os.path.join(self.__root_source_dir, name))
-    origin = kwargs.pop('origin', self.AUTO)
-    upstream = kwargs.pop('upstream', self.AUTO)
+        Args:
+          git_dir: if supplied then use it, otherwise default under the root path.
+          origin: if supplied then use it, even if None. Otherwise default
+          upstream: if supplied then use it, even if None. Otherwise default.
+          kwargs: Additional repository attributes
+        """
+        git_dir = kwargs.pop("git_dir", os.path.join(self.__root_source_dir, name))
+        origin = kwargs.pop("origin", self.AUTO)
+        upstream = kwargs.pop("upstream", self.AUTO)
 
-    if origin == self.AUTO:
-      origin = self.determine_origin(name)
+        if origin == self.AUTO:
+            origin = self.determine_origin(name)
 
-    if os.path.exists(git_dir):
-      logging.info('Confirming existing %s matches expectations', git_dir)
-      existing = self.__git.determine_git_repository_spec(git_dir)
-      if existing.origin not in [origin, self.__git.determine_pull_url(origin)]:
+        if os.path.exists(git_dir):
+            logging.info("Confirming existing %s matches expectations", git_dir)
+            existing = self.__git.determine_git_repository_spec(git_dir)
+            if existing.origin not in [origin, self.__git.determine_pull_url(origin)]:
+                raise_and_log_error(
+                    UnexpectedError(
+                        'Repository "{dir}" origin="{have}" expected="{want}"'.format(
+                            dir=git_dir, have=existing.origin, want=origin
+                        )
+                    )
+                )
+
+        if upstream == self.AUTO:
+            upstream = self.determine_upstream_url(name)
+
+        return GitRepositorySpec(
+            name, origin=origin, upstream=upstream, git_dir=git_dir, **kwargs
+        )
+
+    def determine_upstream_url(self, name):
+        upstream_owner = (
+            self.__options.github_upstream_owner if name not in ("citest") else "google"
+        )
+        return "https://github.com/{upstream}/{name}".format(
+            upstream=upstream_owner, name=name
+        )
+
+    def ensure_git_path(self, repository, **kwargs):
+        """Make sure the repository is checked out.
+
+        Normally one would use ensure_repository which also ensures the metadata
+        is cached. However repositories that are not version controlled in the
+        normal way (e.g. spinnaker.io) dont use the metadata so the
+        assumptions in ensure_repository are not applicable.
+
+        Returns: The build number to use
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def ensure_local_repository(self, repository, commit=None):
+        """Make sure local repository directory exists, and make it so if not."""
+        git_dir = repository.git_dir
+        have_git_dir = os.path.exists(git_dir)
+
+        if have_git_dir:
+            self.ensure_repository(repository)
+            self.check_repository_is_current(repository)
+        else:
+            self.ensure_git_path(repository)
+
+    def refresh_source_info(self, repository, build_number):
+        """Extract the source info from repository and cache with build number.
+
+        We associate the build number because the different builds
+        (debian, container, etc) need to have the same builder number so that the
+        eventual BOM is consitent. Since we dont build everything at once, we'll
+        need to remember it.
+
+        We extract out the repository summary info, particularly the commit it is
+        at, to ensure that future operations are consistent and operating on the
+        same commit.
+        """
+        summary = self.__git.collect_repository_summary(repository.git_dir)
+        expect_build_number = (
+            self.__options.build_number
+            if hasattr(self.__options, "build_number")
+            else build_number
+        )
+        info = SourceInfo(expect_build_number, summary)
+
+        filename = repository.name + "-meta.yml"
+        dir_path = os.path.join(self.__options.output_dir, "source_info")
+        cache_path = os.path.join(dir_path, filename)
+        logging.debug(
+            "Refreshing source info for %s and caching to %s for buildnum=%s",
+            repository.name,
+            cache_path,
+            build_number,
+        )
+        write_to_path(info.summary.to_yaml(), cache_path)
+        return info
+
+    def foreach_source_repository(self, all_repos, call_function, *posargs, **kwargs):
+        """Call the function on each of the SourceRepository instances."""
+        worker = RepositoryWorker(call_function, *posargs, **kwargs)
+        num_threads = min(self.__max_threads, len(all_repos))
+        if num_threads > 1:
+            pool = ThreadPool(num_threads)
+            logging.info(
+                "Mapping %d/%s", len(all_repos), [repo.name for repo in all_repos]
+            )
+            try:
+                raw_list = pool.map(worker, all_repos)
+                result = {name: value for name, value in raw_list}
+            except Exception:
+                logging.error("Map caught exception")
+                pool.close()
+                pool.join()
+                raise
+            logging.info("Finished mapping")
+            pool.close()
+            pool.join()
+        else:
+            # If we have only one thread, skip the pool
+            # this is primarily to make debugging easier.
+            result = {
+                repository.name: worker(repository)[1] for repository in all_repos
+            }
+        return result
+
+    def push_to_origin_if_not_upstream(self, repository, branch):
+        """Push the local repository back to the origin, but not upstream."""
+        git_dir = repository.git_dir
+        origin = repository.origin
+        upstream = repository.upstream_or_none()
+        if upstream is None:
+            logging.warning(
+                "Skipping push origin %s because upstream is None.", repository.name
+            )
+            return
+        if origin == upstream:
+            logging.warning(
+                "Skipping push origin %s because origin is upstream.", repository.name
+            )
+            return
+        self.__git.push_branch_to_origin(git_dir, branch)
+
+    def determine_source_repositories(self):
+        """Determine which repositories are available to this SCM."""
         raise_and_log_error(
             UnexpectedError(
-                'Repository "{dir}" origin="{have}" expected="{want}"'.format(
-                    dir=git_dir, have=existing.origin, want=origin)))
-
-    if upstream == self.AUTO:
-      upstream = self.determine_upstream_url(name)
-
-    return GitRepositorySpec(
-        name, origin=origin, upstream=upstream, git_dir=git_dir, **kwargs)
-
-  def determine_upstream_url(self, name):
-    upstream_owner = (self.__options.github_upstream_owner
-                      if name not in ('citest')
-                      else 'google')
-    return 'https://github.com/{upstream}/{name}'.format(
-        upstream=upstream_owner, name=name)
-
-  def ensure_git_path(self, repository, **kwargs):
-    """Make sure the repository is checked out.
-
-    Normally one would use ensure_repository which also ensures the metadata
-    is cached. However repositories that are not version controlled in the
-    normal way (e.g. spinnaker.io) dont use the metadata so the
-    assumptions in ensure_repository are not applicable.
-
-    Returns: The build number to use
-    """
-    raise NotImplementedError(self.__class__.__name__)
-
-  def ensure_local_repository(self, repository, commit=None):
-    """Make sure local repository directory exists, and make it so if not."""
-    git_dir = repository.git_dir
-    have_git_dir = os.path.exists(git_dir)
-
-    if have_git_dir:
-      self.ensure_repository(repository)
-      self.check_repository_is_current(repository)
-    else:
-      self.ensure_git_path(repository)
-
-  def refresh_source_info(self, repository, build_number):
-    """Extract the source info from repository and cache with build number.
-
-    We associate the build number because the different builds
-    (debian, container, etc) need to have the same builder number so that the
-    eventual BOM is consitent. Since we dont build everything at once, we'll
-    need to remember it.
-
-    We extract out the repository summary info, particularly the commit it is
-    at, to ensure that future operations are consistent and operating on the
-    same commit.
-    """
-    summary = self.__git.collect_repository_summary(repository.git_dir)
-    expect_build_number = (self.__options.build_number
-                           if hasattr(self.__options, 'build_number')
-                           else build_number)
-    info = SourceInfo(expect_build_number, summary)
-
-    filename = repository.name + '-meta.yml'
-    dir_path = os.path.join(self.__options.output_dir, 'source_info')
-    cache_path = os.path.join(dir_path, filename)
-    logging.debug(
-        'Refreshing source info for %s and caching to %s for buildnum=%s',
-        repository.name, cache_path, build_number)
-    write_to_path(info.summary.to_yaml(), cache_path)
-    return info
-
-  def foreach_source_repository(
-      self, all_repos, call_function, *posargs, **kwargs):
-    """Call the function on each of the SourceRepository instances."""
-    worker = RepositoryWorker(call_function, *posargs, **kwargs)
-    num_threads = min(self.__max_threads, len(all_repos))
-    if num_threads > 1:
-      pool = ThreadPool(num_threads)
-      logging.info('Mapping %d/%s',
-                   len(all_repos), [repo.name for repo in all_repos])
-      try:
-        raw_list = pool.map(worker, all_repos)
-        result = {name: value for name, value in raw_list}
-      except Exception:
-        logging.error('Map caught exception')
-        pool.close()
-        pool.join()
-        raise
-      logging.info('Finished mapping')
-      pool.close()
-      pool.join()
-    else:
-      # If we have only one thread, skip the pool
-      # this is primarily to make debugging easier.
-      result = {
-          repository.name: worker(repository)[1]
-          for repository in all_repos
-      }
-    return result
-
-  def push_to_origin_if_not_upstream(self, repository, branch):
-    """Push the local repository back to the origin, but not upstream."""
-    git_dir = repository.git_dir
-    origin = repository.origin
-    upstream = repository.upstream_or_none()
-    if upstream is None:
-      logging.warning('Skipping push origin %s because upstream is None.',
-                      repository.name)
-      return
-    if origin == upstream:
-      logging.warning('Skipping push origin %s because origin is upstream.',
-                      repository.name)
-      return
-    self.__git.push_branch_to_origin(git_dir, branch)
-
-  def determine_source_repositories(self):
-    """Determine which repositories are available to this SCM."""
-    raise_and_log_error(
-        UnexpectedError(self.__class__.__name__
-                        + ': Should only be applicable to BomSCM',
-                        cause='NotReachable'))
+                self.__class__.__name__ + ": Should only be applicable to BomSCM",
+                cause="NotReachable",
+            )
+        )

--- a/dev/buildtool/source_commands.py
+++ b/dev/buildtool/source_commands.py
@@ -26,90 +26,118 @@ from buildtool import (
     BranchSourceCodeManager,
     RepositoryCommandFactory,
     RepositoryCommandProcessor,
-
     raise_and_log_error,
-    ConfigError)
+    ConfigError,
+)
 
 
 class FetchSourceCommand(RepositoryCommandProcessor):
-  """Implements the fetch_source command."""
+    """Implements the fetch_source command."""
 
-  def __init__(self, factory, options):
-    """Implements CommandProcessor interface."""
+    def __init__(self, factory, options):
+        """Implements CommandProcessor interface."""
 
-    all_names = list(SPINNAKER_BOM_REPOSITORY_NAMES)
-    all_names.append(SPINNAKER_HALYARD_REPOSITORY_NAME)
-    all_names.extend(SPINNAKER_PROCESS_REPOSITORY_NAMES)
-    super(FetchSourceCommand, self).__init__(
-        factory, options, source_repository_names=all_names)
+        all_names = list(SPINNAKER_BOM_REPOSITORY_NAMES)
+        all_names.append(SPINNAKER_HALYARD_REPOSITORY_NAME)
+        all_names.extend(SPINNAKER_PROCESS_REPOSITORY_NAMES)
+        super(FetchSourceCommand, self).__init__(
+            factory, options, source_repository_names=all_names
+        )
 
-  def ensure_local_repository(self, repository):
-    """Implements RepositoryCommandProcessor interface."""
-    options = self.options
-    if os.path.exists(repository.git_dir):
-      if options.delete_existing:
-        logging.warning('Deleting existing %s', repository.git_dir)
-        shutil.rmtree(repository.git_dir)
-      elif options.skip_existing:
-        logging.debug('Skipping existing %s', repository.git_dir)
-      else:
-        raise_and_log_error(
-            ConfigError('"{dir}" already exists.'
-                        ' Enable "skip_existing" or "delete_existing".'
-                        .format(dir=repository.git_dir)))
-    super(FetchSourceCommand, self).ensure_local_repository(repository)
+    def ensure_local_repository(self, repository):
+        """Implements RepositoryCommandProcessor interface."""
+        options = self.options
+        if os.path.exists(repository.git_dir):
+            if options.delete_existing:
+                logging.warning("Deleting existing %s", repository.git_dir)
+                shutil.rmtree(repository.git_dir)
+            elif options.skip_existing:
+                logging.debug("Skipping existing %s", repository.git_dir)
+            else:
+                raise_and_log_error(
+                    ConfigError(
+                        '"{dir}" already exists.'
+                        ' Enable "skip_existing" or "delete_existing".'.format(
+                            dir=repository.git_dir
+                        )
+                    )
+                )
+        super(FetchSourceCommand, self).ensure_local_repository(repository)
 
-  def _do_repository(self, repository):
-    """Implements RepositoryCommandProcessor interface."""
-    pass
+    def _do_repository(self, repository):
+        """Implements RepositoryCommandProcessor interface."""
+        pass
 
 
 class FetchSourceCommandFactory(RepositoryCommandFactory):
-  def __init__(self):
-    super(FetchSourceCommandFactory, self).__init__(
-        'fetch_source', FetchSourceCommand,
-        'Clone or refresh the local git repositories from the origin.',
-        BranchSourceCodeManager)
+    def __init__(self):
+        super(FetchSourceCommandFactory, self).__init__(
+            "fetch_source",
+            FetchSourceCommand,
+            "Clone or refresh the local git repositories from the origin.",
+            BranchSourceCodeManager,
+        )
 
-  def init_argparser(self, parser, defaults):
-    super(FetchSourceCommandFactory, self).init_argparser(parser, defaults)
-    self.add_argument(
-        parser, 'build_number', defaults, DEFAULT_BUILD_NUMBER,
-        help='The build number is used when generating artifacts.')
-    self.add_argument(
-        parser, 'delete_existing', defaults, False, type=bool,
-        help='Force a new clone by removing existing directories if present.')
-    self.add_argument(
-        parser, 'skip_existing', defaults, False, type=bool,
-        help='Ignore directories that are already present.')
+    def init_argparser(self, parser, defaults):
+        super(FetchSourceCommandFactory, self).init_argparser(parser, defaults)
+        self.add_argument(
+            parser,
+            "build_number",
+            defaults,
+            DEFAULT_BUILD_NUMBER,
+            help="The build number is used when generating artifacts.",
+        )
+        self.add_argument(
+            parser,
+            "delete_existing",
+            defaults,
+            False,
+            type=bool,
+            help="Force a new clone by removing existing directories if present.",
+        )
+        self.add_argument(
+            parser,
+            "skip_existing",
+            defaults,
+            False,
+            type=bool,
+            help="Ignore directories that are already present.",
+        )
 
 
 class ExtractSourceInfoCommand(RepositoryCommandProcessor):
-  """Get the Git metadata for each repository, and associate a build number."""
-  def _do_repository(self, repository):
-    """Implements RepositoryCommandProcessor interface."""
-    self.source_code_manager.refresh_source_info(
-        repository, self.options.build_number)
+    """Get the Git metadata for each repository, and associate a build number."""
+
+    def _do_repository(self, repository):
+        """Implements RepositoryCommandProcessor interface."""
+        self.source_code_manager.refresh_source_info(
+            repository, self.options.build_number
+        )
 
 
 class ExtractSourceInfoCommandFactory(RepositoryCommandFactory):
-  """Associates the current build number with each repository."""
+    """Associates the current build number with each repository."""
 
-  def __init__(self):
-    super(ExtractSourceInfoCommandFactory, self).__init__(
-        'extract_source_info', ExtractSourceInfoCommand,
-        'Get the repository metadata and establish a build number.',
-        BranchSourceCodeManager,
-        source_repository_names=SPINNAKER_BOM_REPOSITORY_NAMES)
+    def __init__(self):
+        super(ExtractSourceInfoCommandFactory, self).__init__(
+            "extract_source_info",
+            ExtractSourceInfoCommand,
+            "Get the repository metadata and establish a build number.",
+            BranchSourceCodeManager,
+            source_repository_names=SPINNAKER_BOM_REPOSITORY_NAMES,
+        )
 
-  def init_argparser(self, parser, defaults):
-    super(ExtractSourceInfoCommandFactory, self).init_argparser(
-        parser, defaults)
-    self.add_argument(
-        parser, 'build_number', defaults, DEFAULT_BUILD_NUMBER,
-        help='The build number is used when generating artifacts.')
+    def init_argparser(self, parser, defaults):
+        super(ExtractSourceInfoCommandFactory, self).init_argparser(parser, defaults)
+        self.add_argument(
+            parser,
+            "build_number",
+            defaults,
+            DEFAULT_BUILD_NUMBER,
+            help="The build number is used when generating artifacts.",
+        )
 
 
 def register_commands(registry, subparsers, defaults):
-  ExtractSourceInfoCommandFactory().register(registry, subparsers, defaults)
-  FetchSourceCommandFactory().register(registry, subparsers, defaults)
+    ExtractSourceInfoCommandFactory().register(registry, subparsers, defaults)
+    FetchSourceCommandFactory().register(registry, subparsers, defaults)

--- a/dev/buildtool/spinnaker_commands.py
+++ b/dev/buildtool/spinnaker_commands.py
@@ -429,7 +429,7 @@ class PublishSpinnakerCommand(CommandProcessor):
         )
 
         prior_version = get_prior_version(spinnaker_version)
-        if prior_version != None:
+        if prior_version is not None:
             self.__hal.deprecate_spinnaker_release(prior_version)
 
         logging.info("Publishing changelog")

--- a/dev/buildtool/spinnaker_commands.py
+++ b/dev/buildtool/spinnaker_commands.py
@@ -21,10 +21,10 @@ import subprocess
 import yaml
 
 try:
-  from urllib2 import urlopen, HTTPError
+    from urllib2 import urlopen, HTTPError
 except ImportError:
-  from urllib.request import urlopen
-  from urllib.error import HTTPError
+    from urllib.request import urlopen
+    from urllib.error import HTTPError
 
 from buildtool import (
     SPINNAKER_BOM_REPOSITORY_NAMES,
@@ -39,335 +39,423 @@ from buildtool import (
     RepositoryCommandProcessor,
     GitRunner,
     HalRunner,
-
     exception_to_message,
     check_options_set,
     check_subprocess,
     write_to_path,
     raise_and_log_error,
-    ConfigError)
+    ConfigError,
+)
 
 from buildtool.changelog_commands import PublishChangelogFactory
 
 
 class InitiateReleaseBranchFactory(RepositoryCommandFactory):
-  def __init__(self, **kwargs):
-    repo_names = list(SPINNAKER_BOM_REPOSITORY_NAMES)
-    repo_names.extend(SPINNAKER_PROCESS_REPOSITORY_NAMES)
-    repo_names.extend(SPIN_REPOSITORY_NAMES)
-    repo_names.append(SPINNAKER_IO_REPOSITORY_NAME)
-    super(InitiateReleaseBranchFactory, self).__init__(
-        'new_release_branch', InitiateReleaseBranchCommand,
-        'Create a new spinnaker release branch in each of the repos.',
-        BranchSourceCodeManager,
-        source_repository_names=repo_names,
-        **kwargs)
+    def __init__(self, **kwargs):
+        repo_names = list(SPINNAKER_BOM_REPOSITORY_NAMES)
+        repo_names.extend(SPINNAKER_PROCESS_REPOSITORY_NAMES)
+        repo_names.extend(SPIN_REPOSITORY_NAMES)
+        repo_names.append(SPINNAKER_IO_REPOSITORY_NAME)
+        super(InitiateReleaseBranchFactory, self).__init__(
+            "new_release_branch",
+            InitiateReleaseBranchCommand,
+            "Create a new spinnaker release branch in each of the repos.",
+            BranchSourceCodeManager,
+            source_repository_names=repo_names,
+            **kwargs
+        )
 
-  def init_argparser(self, parser, defaults):
-    GitRunner.add_parser_args(parser, defaults)
-    GitRunner.add_publishing_parser_args(parser, defaults)
-    super(InitiateReleaseBranchFactory, self).init_argparser(parser, defaults)
-    self.add_argument(
-        parser, 'skip_existing', defaults, False, type=bool,
-        help='Leave the existing tag if found in a repository.')
-    self.add_argument(
-        parser, 'delete_existing', defaults, False, type=bool,
-        help='Delete the existing tag if found in a repository.')
-    self.add_argument(
-        parser, 'spinnaker_version', defaults, None,
-        help='The version branch name should be "release-<num>.<num>.x"')
+    def init_argparser(self, parser, defaults):
+        GitRunner.add_parser_args(parser, defaults)
+        GitRunner.add_publishing_parser_args(parser, defaults)
+        super(InitiateReleaseBranchFactory, self).init_argparser(parser, defaults)
+        self.add_argument(
+            parser,
+            "skip_existing",
+            defaults,
+            False,
+            type=bool,
+            help="Leave the existing tag if found in a repository.",
+        )
+        self.add_argument(
+            parser,
+            "delete_existing",
+            defaults,
+            False,
+            type=bool,
+            help="Delete the existing tag if found in a repository.",
+        )
+        self.add_argument(
+            parser,
+            "spinnaker_version",
+            defaults,
+            None,
+            help='The version branch name should be "release-<num>.<num>.x"',
+        )
 
 
 class InitiateReleaseBranchCommand(RepositoryCommandProcessor):
-  def __init__(self, factory, options, **kwargs):
-    super(InitiateReleaseBranchCommand, self).__init__(
-        factory, options, **kwargs)
-    check_options_set(options, ['spinnaker_version'])
-    self.__git = GitRunner(options)
+    def __init__(self, factory, options, **kwargs):
+        super(InitiateReleaseBranchCommand, self).__init__(factory, options, **kwargs)
+        check_options_set(options, ["spinnaker_version"])
+        self.__git = GitRunner(options)
 
-  def _do_repository(self, repository):
-    git_dir = repository.git_dir
-    branch = self.options.spinnaker_version
+    def _do_repository(self, repository):
+        git_dir = repository.git_dir
+        branch = self.options.spinnaker_version
 
-    logging.debug('Checking for branch="%s" in "%s"', branch, git_dir)
-    remote_branches = [
-        line.strip()
-        for line in self.__git.check_run(git_dir, 'branch -r').split('\n')]
+        logging.debug('Checking for branch="%s" in "%s"', branch, git_dir)
+        remote_branches = [
+            line.strip()
+            for line in self.__git.check_run(git_dir, "branch -r").split("\n")
+        ]
 
-    if 'origin/' + branch in remote_branches:
-      if self.options.skip_existing:
-        logging.info('Branch "%s" already exists in "%s" -- skip',
-                     branch, repository.origin)
-        return
-      elif self.options.delete_existing:
-        logging.warning('Branch "%s" already exists in "%s" -- delete',
-                        branch, repository.origin)
-        self.__git.delete_branch_on_origin(git_dir, branch)
-      else:
-        raise_and_log_error(
-            ConfigError(
-                'Branch "{branch}" already exists in "{repo}"'.format(
-                    branch=branch, repo=repository.name),
-                cause='branch_exists'))
+        if "origin/" + branch in remote_branches:
+            if self.options.skip_existing:
+                logging.info(
+                    'Branch "%s" already exists in "%s" -- skip',
+                    branch,
+                    repository.origin,
+                )
+                return
+            elif self.options.delete_existing:
+                logging.warning(
+                    'Branch "%s" already exists in "%s" -- delete',
+                    branch,
+                    repository.origin,
+                )
+                self.__git.delete_branch_on_origin(git_dir, branch)
+            else:
+                raise_and_log_error(
+                    ConfigError(
+                        'Branch "{branch}" already exists in "{repo}"'.format(
+                            branch=branch, repo=repository.name
+                        ),
+                        cause="branch_exists",
+                    )
+                )
 
-    logging.info('Creating and pushing branch "%s" to "%s"',
-                 branch, repository.origin)
-    self.__git.check_run(git_dir, 'checkout -b ' + branch)
-    self.__git.push_branch_to_origin(git_dir, branch)
+        logging.info(
+            'Creating and pushing branch "%s" to "%s"', branch, repository.origin
+        )
+        self.__git.check_run(git_dir, "checkout -b " + branch)
+        self.__git.push_branch_to_origin(git_dir, branch)
 
 
 class PublishSpinnakerFactory(CommandFactory):
-  """"Implements the publish_spinnaker command."""
-  def __init__(self):
-    super(PublishSpinnakerFactory, self).__init__(
-        'publish_spinnaker', PublishSpinnakerCommand,
-        'Publish a spinnaker release')
+    """ "Implements the publish_spinnaker command."""
 
-  def init_argparser(self, parser, defaults):
-    super(PublishSpinnakerFactory, self).init_argparser(parser, defaults)
-    HalRunner.add_parser_args(parser, defaults)
-    GitRunner.add_parser_args(parser, defaults)
-    GitRunner.add_publishing_parser_args(parser, defaults)
-    PublishChangelogFactory().init_argparser(parser, defaults)
+    def __init__(self):
+        super(PublishSpinnakerFactory, self).__init__(
+            "publish_spinnaker", PublishSpinnakerCommand, "Publish a spinnaker release"
+        )
 
-    self.add_argument(
-        parser, 'spinnaker_release_alias', defaults, None,
-        help='The spinnaker version alias to publish as.')
-    self.add_argument(
-        parser, 'halyard_bom_bucket', defaults, 'halconfig',
-        help='The bucket manaing halyard BOMs and config profiles.')
-    self.add_argument(
-        parser, 'bom_version', defaults, None,
-        help='The existing bom version usef for this release.')
-    self.add_argument(
-        parser, 'min_halyard_version', defaults, None,
-        help='The minimum halyard version required.')
+    def init_argparser(self, parser, defaults):
+        super(PublishSpinnakerFactory, self).init_argparser(parser, defaults)
+        HalRunner.add_parser_args(parser, defaults)
+        GitRunner.add_parser_args(parser, defaults)
+        GitRunner.add_publishing_parser_args(parser, defaults)
+        PublishChangelogFactory().init_argparser(parser, defaults)
+
+        self.add_argument(
+            parser,
+            "spinnaker_release_alias",
+            defaults,
+            None,
+            help="The spinnaker version alias to publish as.",
+        )
+        self.add_argument(
+            parser,
+            "halyard_bom_bucket",
+            defaults,
+            "halconfig",
+            help="The bucket manaing halyard BOMs and config profiles.",
+        )
+        self.add_argument(
+            parser,
+            "bom_version",
+            defaults,
+            None,
+            help="The existing bom version usef for this release.",
+        )
+        self.add_argument(
+            parser,
+            "min_halyard_version",
+            defaults,
+            None,
+            help="The minimum halyard version required.",
+        )
+
 
 class GetNextPatchParametersCommandFactory(CommandFactory):
-  """"Implements the get_next_patch_parameters command."""
-  def __init__(self):
-    super(GetNextPatchParametersCommandFactory, self).__init__(
-        'get_next_patch_parameters', GetNextPatchParametersCommand,
-        'Get the parameters for the next patch release.')
+    """ "Implements the get_next_patch_parameters command."""
 
-  def init_argparser(self, parser, defaults):
-    super(GetNextPatchParametersCommandFactory, self).init_argparser(parser, defaults)
+    def __init__(self):
+        super(GetNextPatchParametersCommandFactory, self).__init__(
+            "get_next_patch_parameters",
+            GetNextPatchParametersCommand,
+            "Get the parameters for the next patch release.",
+        )
 
-    self.add_argument(
-        parser, 'major_minor_version', defaults, None,
-        help='The major/minor version of Spinnaker we are patching (ex: 1.18).')
+    def init_argparser(self, parser, defaults):
+        super(GetNextPatchParametersCommandFactory, self).init_argparser(
+            parser, defaults
+        )
+
+        self.add_argument(
+            parser,
+            "major_minor_version",
+            defaults,
+            None,
+            help="The major/minor version of Spinnaker we are patching (ex: 1.18).",
+        )
+
 
 class GetNextPatchParametersCommand(CommandProcessor):
-  """"Implements the get_next_patch_parameters command."""
+    """ "Implements the get_next_patch_parameters command."""
 
-  def __init__(self, factory, options, **kwargs):
-    super(GetNextPatchParametersCommand, self).__init__(factory, options, **kwargs)
-    check_options_set(options, [
-      'major_minor_version',
-    ])
+    def __init__(self, factory, options, **kwargs):
+        super(GetNextPatchParametersCommand, self).__init__(factory, options, **kwargs)
+        check_options_set(
+            options,
+            [
+                "major_minor_version",
+            ],
+        )
 
-  def _do_command(self):
-    """Implements CommandProcessor interface."""
-    options = self.options
+    def _do_command(self):
+        """Implements CommandProcessor interface."""
+        options = self.options
 
-    current_version_details = self._find_matching_version(options.major_minor_version)
-    result = {
-      'bom_version': 'release-{version}.x-latest-validated'.format(version=options.major_minor_version),
-      'spinnaker_version': get_next_version(current_version_details['version']),
-      'min_halyard_version': current_version_details['minimumHalyardVersion'],
-      'spinnaker_release_alias': current_version_details['alias'],
-      'changelog_gist_url': current_version_details['changelog']
-    }
-    self._output_as_property_file(result)
+        current_version_details = self._find_matching_version(
+            options.major_minor_version
+        )
+        result = {
+            "bom_version": "release-{version}.x-latest-validated".format(
+                version=options.major_minor_version
+            ),
+            "spinnaker_version": get_next_version(current_version_details["version"]),
+            "min_halyard_version": current_version_details["minimumHalyardVersion"],
+            "spinnaker_release_alias": current_version_details["alias"],
+            "changelog_gist_url": current_version_details["changelog"],
+        }
+        self._output_as_property_file(result)
 
-  def _output_as_property_file(self, result):
-    for key, value in result.items():
-      print('{key}={value}'.format(key=key.upper(), value=value))
+    def _output_as_property_file(self, result):
+        for key, value in result.items():
+            print("{key}={value}".format(key=key.upper(), value=value))
 
-  def _find_matching_version(self, major_minor_version):
-    versions = self._get_versions()
-    version_filter = lambda v : get_major_minor_version(v.get('version')) == major_minor_version
-    try:
-      return next(v for v in versions if version_filter(v))
-    except StopIteration:
-      raise_and_log_error(
-          ConfigError(
-              'There are no active Spinnaker versions for version {branch}.'.format(branch=major_minor_version),
-              cause='IncorrectVersion'))
+    def _find_matching_version(self, major_minor_version):
+        versions = self._get_versions()
+        version_filter = (
+            lambda v: get_major_minor_version(v.get("version")) == major_minor_version
+        )
+        try:
+            return next(v for v in versions if version_filter(v))
+        except StopIteration:
+            raise_and_log_error(
+                ConfigError(
+                    "There are no active Spinnaker versions for version {branch}.".format(
+                        branch=major_minor_version
+                    ),
+                    cause="IncorrectVersion",
+                )
+            )
 
-  def _get_versions(self):
-   version_data = check_subprocess('gsutil cat gs://halconfig/versions.yml', stderr=subprocess.PIPE)
-   versions = yaml.safe_load(version_data).get('versions')
-   return versions
+    def _get_versions(self):
+        version_data = check_subprocess(
+            "gsutil cat gs://halconfig/versions.yml", stderr=subprocess.PIPE
+        )
+        versions = yaml.safe_load(version_data).get("versions")
+        return versions
+
 
 class PublishSpinnakerCommand(CommandProcessor):
-  """"Implements the publish_spinnaker command."""
-  # pylint: disable=too-few-public-methods
+    """ "Implements the publish_spinnaker command."""
 
-  def __init__(self, factory, options, **kwargs):
-    super(PublishSpinnakerCommand, self).__init__(factory, options, **kwargs)
-    check_options_set(options, [
-        'spinnaker_version',
-        'spinnaker_release_alias',
-        'bom_version',
-        'changelog_gist_url',
-        'github_owner',
-        'min_halyard_version'
-    ])
+    # pylint: disable=too-few-public-methods
 
-    major, minor, _ = self.options.spinnaker_version.split('.')
-    self.__branch = 'release-{major}.{minor}.x'.format(
-        major=major, minor=minor)
+    def __init__(self, factory, options, **kwargs):
+        super(PublishSpinnakerCommand, self).__init__(factory, options, **kwargs)
+        check_options_set(
+            options,
+            [
+                "spinnaker_version",
+                "spinnaker_release_alias",
+                "bom_version",
+                "changelog_gist_url",
+                "github_owner",
+                "min_halyard_version",
+            ],
+        )
 
-    options_copy = copy.copy(options)
-    self.__bom_scm = BomSourceCodeManager(options_copy, self.get_input_dir())
-    self.__hal = HalRunner(options)
-    self.__git = GitRunner(options)
-    self.__hal.check_property(
-        'spinnaker.config.input.bucket', options.halyard_bom_bucket)
-    if options.only_repositories:
-      self.__only_repositories = options.only_repositories.split(',')
-    else:
-      self.__only_repositories = []
+        major, minor, _ = self.options.spinnaker_version.split(".")
+        self.__branch = "release-{major}.{minor}.x".format(major=major, minor=minor)
 
-    options_copy.git_branch = self.__branch
-    self.__branch_scm = BranchSourceCodeManager(
-        options_copy, self.get_input_dir())
-
-  def push_branches_and_tags(self, bom):
-    """Update the release branches and tags in each of the BOM repositires."""
-    logging.info('Tagging each of the BOM service repos')
-
-    bom_scm = self.__bom_scm
-    branch_scm = self.__branch_scm
-
-    # Run in two passes so we dont push anything if we hit a problem
-    # in the tagging pass. Since we are spread against multiple repositiories,
-    # we cannot do this atomically. The two passes gives us more protection
-    # from a partial push due to errors in a repo.
-    names_to_push = set([])
-    for which in ['tag', 'push']:
-      for name, spec in bom['services'].items():
-        if name in ['monitoring-third-party', 'defaultArtifact']:
-          # Ignore this, it is redundant to monitoring-daemon
-          continue
-        if name == 'monitoring-daemon':
-          name = 'spinnaker-monitoring'
-        if self.__only_repositories and name not in self.__only_repositories:
-          logging.debug('Skipping %s because of --only_repositories', name)
-          continue
-        if spec is None:
-          logging.warning('HAVE bom.services.%s = None', name)
-          continue
-
-        repository = bom_scm.make_repository_spec(name)
-        bom_scm.ensure_local_repository(repository)
-        version = bom_scm.determine_repository_version(repository)
-        if which == 'tag':
-          added = self.__branch_and_tag_repository(
-              repository, self.__branch, version)
-          if added:
-            names_to_push.add(name)
+        options_copy = copy.copy(options)
+        self.__bom_scm = BomSourceCodeManager(options_copy, self.get_input_dir())
+        self.__hal = HalRunner(options)
+        self.__git = GitRunner(options)
+        self.__hal.check_property(
+            "spinnaker.config.input.bucket", options.halyard_bom_bucket
+        )
+        if options.only_repositories:
+            self.__only_repositories = options.only_repositories.split(",")
         else:
-          self.__push_branch_and_maybe_tag_repository(
-              repository, self.__branch, version, name in names_to_push)
+            self.__only_repositories = []
 
-  def __already_have_tag(self, repository, tag):
-    """Determine if we already have the tag in the repository."""
-    git_dir = repository.git_dir
-    existing_commit = self.__git.query_commit_at_tag(git_dir, tag)
-    if not existing_commit:
-      return False
-    want_commit = self.__git.query_local_repository_commit_id(git_dir)
-    if want_commit == existing_commit:
-      logging.debug('Already have "%s" at %s', tag, want_commit)
-      return True
+        options_copy.git_branch = self.__branch
+        self.__branch_scm = BranchSourceCodeManager(options_copy, self.get_input_dir())
 
-    raise_and_log_error(
-        ConfigError(
-            '"{tag}" already exists in "{repo}" at commit {have}, not {want}'
-            .format(tag=tag, repo=git_dir,
-                    have=existing_commit, want=want_commit)))
-    return False  # not reached
+    def push_branches_and_tags(self, bom):
+        """Update the release branches and tags in each of the BOM repositires."""
+        logging.info("Tagging each of the BOM service repos")
 
-  def __branch_and_tag_repository(self, repository, branch, version):
-    """Create a branch and/or version tag in the repository, if needed."""
-    tag = 'version-' + version
-    if self.__already_have_tag(repository, tag):
-      return False
+        bom_scm = self.__bom_scm
+        branch_scm = self.__branch_scm
 
-    self.__git.check_run(repository.git_dir, 'tag ' + tag)
-    return True
+        # Run in two passes so we dont push anything if we hit a problem
+        # in the tagging pass. Since we are spread against multiple repositiories,
+        # we cannot do this atomically. The two passes gives us more protection
+        # from a partial push due to errors in a repo.
+        names_to_push = set([])
+        for which in ["tag", "push"]:
+            for name, spec in bom["services"].items():
+                if name in ["monitoring-third-party", "defaultArtifact"]:
+                    # Ignore this, it is redundant to monitoring-daemon
+                    continue
+                if name == "monitoring-daemon":
+                    name = "spinnaker-monitoring"
+                if self.__only_repositories and name not in self.__only_repositories:
+                    logging.debug("Skipping %s because of --only_repositories", name)
+                    continue
+                if spec is None:
+                    logging.warning("HAVE bom.services.%s = None", name)
+                    continue
 
-  def __push_branch_and_maybe_tag_repository(self, repository, branch, version,
-                                             also_tag):
-    """Push the branch and version tag to the origin."""
-    tag = 'version-' + version
-    self.__git.push_branch_to_origin(repository.git_dir, branch)
-    if also_tag:
-      self.__git.push_tag_to_origin(repository.git_dir, tag)
-    else:
-      logging.info('%s was already tagged with "%s" -- skip',
-                   repository.git_dir, tag)
+                repository = bom_scm.make_repository_spec(name)
+                bom_scm.ensure_local_repository(repository)
+                version = bom_scm.determine_repository_version(repository)
+                if which == "tag":
+                    added = self.__branch_and_tag_repository(
+                        repository, self.__branch, version
+                    )
+                    if added:
+                        names_to_push.add(name)
+                else:
+                    self.__push_branch_and_maybe_tag_repository(
+                        repository, self.__branch, version, name in names_to_push
+                    )
 
-  def _do_command(self):
-    """Implements CommandProcessor interface."""
-    options = self.options
-    spinnaker_version = options.spinnaker_version
-    options_copy = copy.copy(options)
-    options_copy.git_branch = 'master'  # push to master in spinnaker.io
-    publish_changelog_command = PublishChangelogFactory().make_command(
-        options_copy)
-    changelog_gist_url = options.changelog_gist_url
+    def __already_have_tag(self, repository, tag):
+        """Determine if we already have the tag in the repository."""
+        git_dir = repository.git_dir
+        existing_commit = self.__git.query_commit_at_tag(git_dir, tag)
+        if not existing_commit:
+            return False
+        want_commit = self.__git.query_local_repository_commit_id(git_dir)
+        if want_commit == existing_commit:
+            logging.debug('Already have "%s" at %s', tag, want_commit)
+            return True
 
-    # Make sure changelog exists already.
-    # If it does not then fail.
-    try:
-      logging.debug('Verifying changelog ready at %s', changelog_gist_url)
-      urlopen(changelog_gist_url)
-    except HTTPError:
-      logging.error(exception_to_message)
-      raise_and_log_error(
-          ConfigError(
-              'Changelog gist "{url}" must exist before publising a release.'
-              .format(url=changelog_gist_url),
-              cause='ChangelogMissing'))
+        raise_and_log_error(
+            ConfigError(
+                '"{tag}" already exists in "{repo}" at commit {have}, not {want}'.format(
+                    tag=tag, repo=git_dir, have=existing_commit, want=want_commit
+                )
+            )
+        )
+        return False  # not reached
 
-    bom = self.__hal.retrieve_bom_version(self.options.bom_version)
-    bom['version'] = spinnaker_version
-    bom_path = os.path.join(self.get_output_dir(), spinnaker_version + '.yml')
-    write_to_path(yaml.safe_dump(bom, default_flow_style=False), bom_path)
-    self.__hal.publish_bom_path(bom_path)
-    self.push_branches_and_tags(bom)
+    def __branch_and_tag_repository(self, repository, branch, version):
+        """Create a branch and/or version tag in the repository, if needed."""
+        tag = "version-" + version
+        if self.__already_have_tag(repository, tag):
+            return False
 
-    self.__hal.publish_spinnaker_release(
-        spinnaker_version, options.spinnaker_release_alias, changelog_gist_url,
-        options.min_halyard_version)
+        self.__git.check_run(repository.git_dir, "tag " + tag)
+        return True
 
-    prior_version = get_prior_version(spinnaker_version)
-    if prior_version != None:
-      self.__hal.deprecate_spinnaker_release(prior_version)
+    def __push_branch_and_maybe_tag_repository(
+        self, repository, branch, version, also_tag
+    ):
+        """Push the branch and version tag to the origin."""
+        tag = "version-" + version
+        self.__git.push_branch_to_origin(repository.git_dir, branch)
+        if also_tag:
+            self.__git.push_tag_to_origin(repository.git_dir, tag)
+        else:
+            logging.info(
+                '%s was already tagged with "%s" -- skip', repository.git_dir, tag
+            )
 
-    logging.info('Publishing changelog')
-    publish_changelog_command()
+    def _do_command(self):
+        """Implements CommandProcessor interface."""
+        options = self.options
+        spinnaker_version = options.spinnaker_version
+        options_copy = copy.copy(options)
+        options_copy.git_branch = "master"  # push to master in spinnaker.io
+        publish_changelog_command = PublishChangelogFactory().make_command(options_copy)
+        changelog_gist_url = options.changelog_gist_url
+
+        # Make sure changelog exists already.
+        # If it does not then fail.
+        try:
+            logging.debug("Verifying changelog ready at %s", changelog_gist_url)
+            urlopen(changelog_gist_url)
+        except HTTPError:
+            logging.error(exception_to_message)
+            raise_and_log_error(
+                ConfigError(
+                    'Changelog gist "{url}" must exist before publising a release.'.format(
+                        url=changelog_gist_url
+                    ),
+                    cause="ChangelogMissing",
+                )
+            )
+
+        bom = self.__hal.retrieve_bom_version(self.options.bom_version)
+        bom["version"] = spinnaker_version
+        bom_path = os.path.join(self.get_output_dir(), spinnaker_version + ".yml")
+        write_to_path(yaml.safe_dump(bom, default_flow_style=False), bom_path)
+        self.__hal.publish_bom_path(bom_path)
+        self.push_branches_and_tags(bom)
+
+        self.__hal.publish_spinnaker_release(
+            spinnaker_version,
+            options.spinnaker_release_alias,
+            changelog_gist_url,
+            options.min_halyard_version,
+        )
+
+        prior_version = get_prior_version(spinnaker_version)
+        if prior_version != None:
+            self.__hal.deprecate_spinnaker_release(prior_version)
+
+        logging.info("Publishing changelog")
+        publish_changelog_command()
+
 
 def get_prior_version(version):
-  major, minor, patch = version.split('.')
-  patch = int(patch)
-  if patch == 0:
-    return None
-  return '.'.join([major, minor, str(patch - 1)])
+    major, minor, patch = version.split(".")
+    patch = int(patch)
+    if patch == 0:
+        return None
+    return ".".join([major, minor, str(patch - 1)])
+
 
 def get_next_version(version):
-  major, minor, patch = version.split('.')
-  patch = int(patch)
-  return '.'.join([major, minor, str(patch + 1)])
+    major, minor, patch = version.split(".")
+    patch = int(patch)
+    return ".".join([major, minor, str(patch + 1)])
+
 
 def get_major_minor_version(version):
-  major, minor, _ = version.split('.')
-  return '{major}.{minor}'.format(major=major, minor=minor)
+    major, minor, _ = version.split(".")
+    return "{major}.{minor}".format(major=major, minor=minor)
+
 
 def register_commands(registry, subparsers, defaults):
-  InitiateReleaseBranchFactory().register(registry, subparsers, defaults)
-  PublishSpinnakerFactory().register(registry, subparsers, defaults)
-  GetNextPatchParametersCommandFactory().register(registry, subparsers, defaults)
+    InitiateReleaseBranchFactory().register(registry, subparsers, defaults)
+    PublishSpinnakerFactory().register(registry, subparsers, defaults)
+    GetNextPatchParametersCommandFactory().register(registry, subparsers, defaults)

--- a/dev/buildtool/subprocess_support.py
+++ b/dev/buildtool/subprocess_support.py
@@ -28,7 +28,8 @@ from buildtool import (
     log_timestring,
     raise_and_log_error,
     timedelta_string,
-    ExecutionError)
+    ExecutionError,
+)
 
 from buildtool.base_metrics import BaseMetricsRegistry
 
@@ -36,206 +37,215 @@ from buildtool.base_metrics import BaseMetricsRegistry
 # Directory where error logfiles are copied to.
 # This is exposed so it can be configured externally since
 # this module does not offer encapsulated configuration.
-ERROR_LOGFILE_DIR = 'errors'
+ERROR_LOGFILE_DIR = "errors"
+
 
 def start_subprocess(cmd, stream=None, stdout=None, stderr=None, echo=False, **kwargs):
-  """Starts a subprocess and returns handle to it."""
-  split_cmd = shlex.split(cmd)
-  actual_command = cmd if kwargs.get('shell') else split_cmd
+    """Starts a subprocess and returns handle to it."""
+    split_cmd = shlex.split(cmd)
+    actual_command = cmd if kwargs.get("shell") else split_cmd
 
-  log_level = logging.INFO if echo else logging.DEBUG
-  extra_log_info = ''
-  if 'cwd' in kwargs:
-    extra_log_info += ' in cwd="%s"' % kwargs['cwd']
-  logging.log(log_level, 'Running %s%s...', repr(cmd), extra_log_info)
+    log_level = logging.INFO if echo else logging.DEBUG
+    extra_log_info = ""
+    if "cwd" in kwargs:
+        extra_log_info += ' in cwd="%s"' % kwargs["cwd"]
+    logging.log(log_level, "Running %s%s...", repr(cmd), extra_log_info)
 
-  start_date = datetime.datetime.now()
-  if stream:
-    stream.write(u'{time} Spawning {cmd!r}{extra}\n----\n\n'.format(
-        time=log_timestring(now=start_date), cmd=cmd, extra=extra_log_info))
-    stream.flush()
+    start_date = datetime.datetime.now()
+    if stream:
+        stream.write(
+            "{time} Spawning {cmd!r}{extra}\n----\n\n".format(
+                time=log_timestring(now=start_date), cmd=cmd, extra=extra_log_info
+            )
+        )
+        stream.flush()
 
-  process = subprocess.Popen(
-      actual_command,
-      close_fds=True,
-      stdout=stdout or subprocess.PIPE,
-      stderr=stderr or subprocess.STDOUT,
-      **kwargs)
-  logging.log(log_level, 'Running %s as pid %s', split_cmd[0], process.pid)
-  process.start_date = start_date
+    process = subprocess.Popen(
+        actual_command,
+        close_fds=True,
+        stdout=stdout or subprocess.PIPE,
+        stderr=stderr or subprocess.STDOUT,
+        **kwargs
+    )
+    logging.log(log_level, "Running %s as pid %s", split_cmd[0], process.pid)
+    process.start_date = start_date
 
-  time.sleep(0) # yield this thread
-  return process
+    time.sleep(0)  # yield this thread
+    return process
 
 
 def wait_subprocess(process, stream=None, echo=False, postprocess_hook=None):
-  """Waits for subprocess to finish and returns (final status, stdout).
+    """Waits for subprocess to finish and returns (final status, stdout).
 
-  This will also consume the remaining output to return it.
+    This will also consume the remaining output to return it.
 
-  Returns:
-    Process exit code, stdout remaining in process prior to this invocation.
-    Any previously read output from the process will not be included.
-  """
-  text_lines = []
-  if process.stdout is not None:
-    # stdout isnt going to another stream; collect it from the pipe.
-    for raw_line in iter(process.stdout.readline, ''):
-      if not raw_line:
-        break
-      decoded_line = raw_line.decode(encoding='utf-8')
-      text_lines.append(decoded_line)
-      if stream:
-        stream.write(decoded_line)
+    Returns:
+      Process exit code, stdout remaining in process prior to this invocation.
+      Any previously read output from the process will not be included.
+    """
+    text_lines = []
+    if process.stdout is not None:
+        # stdout isnt going to another stream; collect it from the pipe.
+        for raw_line in iter(process.stdout.readline, ""):
+            if not raw_line:
+                break
+            decoded_line = raw_line.decode(encoding="utf-8")
+            text_lines.append(decoded_line)
+            if stream:
+                stream.write(decoded_line)
+                stream.flush()
+
+    if process.stderr is not None:
+        log_level = logging.INFO if echo else logging.DEBUG
+        # stderr isn't going to another file handle; log it
+        for raw_line in iter(process.stderr.readline, ""):
+            decoded_line = raw_line.decode(encoding="utf-8").rstrip("\n")
+            logging.log(
+                log_level, "PID %s wrote to stderr: %s", process.pid, decoded_line
+            )
+
+    process.wait()
+    if stream is None and process.stdout is not None:
+        # Close stdout pipe if we didnt give a stream.
+        # Otherwise caller owns the stream.
+        process.stdout.close()
+
+    if hasattr(process, "start_date"):
+        end_date = datetime.datetime.now()
+        delta_time_str = timedelta_string(end_date - process.start_date)
+    else:
+        delta_time_str = "UNKNOWN"
+
+    returncode = process.returncode
+    stdout = "".join(text_lines)
+
+    if stream:
+        stream.write(
+            "\n\n----\n{time} Spawned process completed"
+            " with returncode {returncode} in {delta_time}.\n".format(
+                time=log_timestring(now=end_date),
+                returncode=returncode,
+                delta_time=delta_time_str,
+            )
+        )
         stream.flush()
 
-  if process.stderr is not None:
-    log_level = logging.INFO if echo else logging.DEBUG
-    # stderr isn't going to another file handle; log it
-    for raw_line in iter(process.stderr.readline, ''):
-      decoded_line = raw_line.decode(encoding='utf-8').rstrip('\n')
-      logging.log(log_level, 'PID %s wrote to stderr: %s', process.pid, decoded_line)
+    if echo:
+        logging.info("%s returned %d with output:\n%s", process.pid, returncode, stdout)
+    logging.debug(
+        "Finished %s with returncode=%d in %s", process.pid, returncode, delta_time_str
+    )
 
-   
-  process.wait()
-  if stream is None and process.stdout is not None:
-    # Close stdout pipe if we didnt give a stream.
-    # Otherwise caller owns the stream.
-    process.stdout.close()
+    if postprocess_hook:
+        postprocess_hook(returncode, stdout)
 
-  if hasattr(process, 'start_date'):
-    end_date = datetime.datetime.now()
-    delta_time_str = timedelta_string(end_date - process.start_date)
-  else:
-    delta_time_str = 'UNKNOWN'
-
-  returncode = process.returncode
-  stdout = ''.join(text_lines)
-
-  if stream:
-    stream.write(
-        u'\n\n----\n{time} Spawned process completed'
-        u' with returncode {returncode} in {delta_time}.\n'
-        .format(time=log_timestring(now=end_date), returncode=returncode,
-                delta_time=delta_time_str))
-    stream.flush()
-
-  if echo:
-    logging.info('%s returned %d with output:\n%s',
-                 process.pid, returncode, stdout)
-  logging.debug('Finished %s with returncode=%d in %s',
-                process.pid, returncode, delta_time_str)
-
-  if postprocess_hook:
-    postprocess_hook(returncode, stdout)
-
-  return returncode, stdout.strip()
+    return returncode, stdout.strip()
 
 
 def run_subprocess(cmd, stream=None, echo=False, **kwargs):
-  """Returns retcode, stdout."""
-  postprocess_hook = kwargs.pop('postprocess_hook', None)
-  process = start_subprocess(cmd, stream=stream, echo=echo, **kwargs)
-  return wait_subprocess(process, stream=stream, echo=echo,
-                         postprocess_hook=postprocess_hook)
+    """Returns retcode, stdout."""
+    postprocess_hook = kwargs.pop("postprocess_hook", None)
+    process = start_subprocess(cmd, stream=stream, echo=echo, **kwargs)
+    return wait_subprocess(
+        process, stream=stream, echo=echo, postprocess_hook=postprocess_hook
+    )
 
 
 def check_subprocess(cmd, stream=None, **kwargs):
-  """Run_subprocess and raise CalledProcessError if it fails."""
-  # pylint: disable=inconsistent-return-statements
-  embed_errors = kwargs.pop('embed_errors', True)
-  retcode, stdout = run_subprocess(cmd, stream=stream, **kwargs)
-  if retcode == 0:
-    return stdout.strip()
+    """Run_subprocess and raise CalledProcessError if it fails."""
+    # pylint: disable=inconsistent-return-statements
+    embed_errors = kwargs.pop("embed_errors", True)
+    retcode, stdout = run_subprocess(cmd, stream=stream, **kwargs)
+    if retcode == 0:
+        return stdout.strip()
 
-  if embed_errors:
-    log_embedded_output(logging.ERROR, 'command output', stdout)
-    logging.error('Command failed. See embedded output above.')
-  else:
-    lines = stdout.split('\n')
-    if len(lines) > 30:
-      lines = lines[-30:]
-    log_embedded_output(logging.ERROR,
-                        'Command failed with last %d lines' % len(lines),
-                        '\n'.join(lines))
+    if embed_errors:
+        log_embedded_output(logging.ERROR, "command output", stdout)
+        logging.error("Command failed. See embedded output above.")
+    else:
+        lines = stdout.split("\n")
+        if len(lines) > 30:
+            lines = lines[-30:]
+        log_embedded_output(
+            logging.ERROR,
+            "Command failed with last %d lines" % len(lines),
+            "\n".join(lines),
+        )
 
-  program = os.path.basename(shlex.split(cmd)[0])
-  raise_and_log_error(ExecutionError(program + ' failed.', program=program))
+    program = os.path.basename(shlex.split(cmd)[0])
+    raise_and_log_error(ExecutionError(program + " failed.", program=program))
 
 
 def check_subprocess_sequence(cmd_list, stream=None, **kwargs):
-  """Run multiple commands until one fails.
+    """Run multiple commands until one fails.
 
-  Returns:
-    A list of each result in sequence if all succeeded.
-  """
-  response = []
-  for one in cmd_list:
-    response.append(check_subprocess(one, stream=stream, **kwargs))
-  return response
+    Returns:
+      A list of each result in sequence if all succeeded.
+    """
+    response = []
+    for one in cmd_list:
+        response.append(check_subprocess(one, stream=stream, **kwargs))
+    return response
 
 
 def run_subprocess_sequence(cmd_list, stream=None, **kwargs):
-  """Run multiple commands until one fails.
+    """Run multiple commands until one fails.
 
-  Returns:
-    A list of (code, output) tuples for each result in sequence.
-  """
-  response = []
-  for one in cmd_list:
-    response.append(run_subprocess(one, stream=stream, **kwargs))
-  return response
+    Returns:
+      A list of (code, output) tuples for each result in sequence.
+    """
+    response = []
+    for one in cmd_list:
+        response.append(run_subprocess(one, stream=stream, **kwargs))
+    return response
 
 
 def check_subprocesses_to_logfile(what, logfile, cmds, append=False, **kwargs):
-  """Wrapper around check_subprocess that logs output to a logfile.
+    """Wrapper around check_subprocess that logs output to a logfile.
 
-  Args:
-    what: [string] For logging purposes, what is the command for.
-    logfile: [path] The logfile to write to.
-    cmds: [list of string] A list of commands to run.
-    append: [boolean] Open the log file as append if true, write new default.
-    kwargs: [kwargs] Additional keyword arguments to pass to check_subprocess.
-  """
-  mode = 'a' if append else 'w'
-  how = 'Appending' if append else 'Logging'
-  logging.info('%s %s to %s', how, what, logfile)
-  ensure_dir_exists(os.path.dirname(logfile))
-  with io.open(logfile, mode, encoding='utf-8') as stream:
-    try:
-      check_subprocess_sequence(
-          cmds, stream=stream, embed_errors=False, **kwargs)
-    except Exception as ex:
-      logging.error('%s failed. Log file [%s] follows:', what, logfile)
-      import traceback
-      traceback.print_exc()
+    Args:
+      what: [string] For logging purposes, what is the command for.
+      logfile: [path] The logfile to write to.
+      cmds: [list of string] A list of commands to run.
+      append: [boolean] Open the log file as append if true, write new default.
+      kwargs: [kwargs] Additional keyword arguments to pass to check_subprocess.
+    """
+    mode = "a" if append else "w"
+    how = "Appending" if append else "Logging"
+    logging.info("%s %s to %s", how, what, logfile)
+    ensure_dir_exists(os.path.dirname(logfile))
+    with io.open(logfile, mode, encoding="utf-8") as stream:
+        try:
+            check_subprocess_sequence(cmds, stream=stream, embed_errors=False, **kwargs)
+        except Exception as ex:
+            logging.error("%s failed. Log file [%s] follows:", what, logfile)
+            import traceback
 
-      with io.open(logfile, 'r', encoding='utf-8') as readagain:
-        output = readagain.read()
-        log_embedded_output(logging.ERROR, logfile, output)
-      logging.error('Caught exception %s\n%s failed. See embedded logfile above',
-                    ex, what)
+            traceback.print_exc()
 
-      ensure_dir_exists(ERROR_LOGFILE_DIR)
-      error_path = os.path.join('errors', os.path.basename(logfile))
-      logging.info('Copying error log file to %s', error_path)
-      with io.open(error_path, 'w', encoding='utf-8') as f:
-        f.write(output);
-        f.write(u'\n--------\n')
-        f.write(u'Exeception caught in parent process:\n%s' % ex)
+            with io.open(logfile, "r", encoding="utf-8") as readagain:
+                output = readagain.read()
+                log_embedded_output(logging.ERROR, logfile, output)
+            logging.error(
+                "Caught exception %s\n%s failed. See embedded logfile above", ex, what
+            )
 
-      raise
+            ensure_dir_exists(ERROR_LOGFILE_DIR)
+            error_path = os.path.join("errors", os.path.basename(logfile))
+            logging.info("Copying error log file to %s", error_path)
+            with io.open(error_path, "w", encoding="utf-8") as f:
+                f.write(output)
+                f.write("\n--------\n")
+                f.write("Exeception caught in parent process:\n%s" % ex)
+
+            raise
 
 
 def determine_subprocess_outcome_labels(result, labels):
-  """For determining outcome labels when timing calls to subprocesses."""
-  if result is None:
-    return BaseMetricsRegistry.default_determine_outcome_labels(
-        result, labels)
-  outcome_labels = dict(labels)
-  retcode, _ = result
-  outcome_labels.update({
-      'success': retcode == 0,
-      'exception_type': 'BadExitCode'
-  })
-  return outcome_labels
+    """For determining outcome labels when timing calls to subprocesses."""
+    if result is None:
+        return BaseMetricsRegistry.default_determine_outcome_labels(result, labels)
+    outcome_labels = dict(labels)
+    retcode, _ = result
+    outcome_labels.update({"success": retcode == 0, "exception_type": "BadExitCode"})
+    return outcome_labels

--- a/dev/buildtool/util.py
+++ b/dev/buildtool/util.py
@@ -24,94 +24,94 @@ import socket
 # The build number to use if not otherwise explicitly specified
 # Usually build numbers are obtained from the BOM file or --build_number
 # However sometimes this isnt the case (e.g. generating the BOM).
-DEFAULT_BUILD_NUMBER = str(os.environ.get(
-    'BUILD_NUMBER', '{:%Y%m%d%H%M%S}'.format(datetime.datetime.utcnow())))
+DEFAULT_BUILD_NUMBER = str(
+    os.environ.get("BUILD_NUMBER", "{:%Y%m%d%H%M%S}".format(datetime.datetime.utcnow()))
+)
 
 
 def add_parser_argument(parser, name, defaults, default_value, **kwargs):
-  """Helper function for adding parser.add_argument with a default value.
+    """Helper function for adding parser.add_argument with a default value.
 
-  Args:
-    name: [string] The argument name is assumed optional, without '--' prefix.
-    defaults: [string] Dictionary of default value overrides keyed by name.
-    default_value: [any] The default value if not overriden.
-    kwargs: [kwargs] Additional kwargs for parser.add_argument
-  """
-  arg_type = kwargs.get('type')
-  if arg_type == bool:
-    kwargs['type'] = lambda value: str(value).lower() != 'false'
+    Args:
+      name: [string] The argument name is assumed optional, without '--' prefix.
+      defaults: [string] Dictionary of default value overrides keyed by name.
+      default_value: [any] The default value if not overriden.
+      kwargs: [kwargs] Additional kwargs for parser.add_argument
+    """
+    arg_type = kwargs.get("type")
+    if arg_type == bool:
+        kwargs["type"] = lambda value: str(value).lower() != "false"
 
-  parser.add_argument(
-      '--%s' % name, default=defaults.get(name, default_value),
-      **kwargs)
+    parser.add_argument(
+        "--%s" % name, default=defaults.get(name, default_value), **kwargs
+    )
 
 
-def unused_port(interface='localhost'):
-  """Return an unused port number on localhost."""
-  sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-  sock.bind((interface, 0))
-  port = sock.getsockname()[1]
-  sock.close()
-  return port
+def unused_port(interface="localhost"):
+    """Return an unused port number on localhost."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind((interface, 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
 
 
 def log_timestring(now=None):
-  """Returns timestamp as date time string in logging format."""
-  now = now or datetime.datetime.now()
+    """Returns timestamp as date time string in logging format."""
+    now = now or datetime.datetime.now()
 
-  return '{:%Y-%m-%d %H:%M:%S}'.format(now)
+    return "{:%Y-%m-%d %H:%M:%S}".format(now)
 
 
 def timedelta_string(delta):
-  """Returns a string indicating the time duration.
+    """Returns a string indicating the time duration.
 
-  Args:
-    delta: [datetime.timedelta] The time difference
-  """
-  delta_secs = int(delta.total_seconds())
-  delta_mins = delta_secs // 60
-  delta_hours = (delta_mins // 60 % 24)
-  delta_days = delta.days
+    Args:
+      delta: [datetime.timedelta] The time difference
+    """
+    delta_secs = int(delta.total_seconds())
+    delta_mins = delta_secs // 60
+    delta_hours = delta_mins // 60 % 24
+    delta_days = delta.days
 
-  day_str = '' if not delta_days else ('days=%d + ' % delta_days)
-  delta_mins = delta_mins % 60
-  delta_secs = delta_secs % 60
+    day_str = "" if not delta_days else ("days=%d + " % delta_days)
+    delta_mins = delta_mins % 60
+    delta_secs = delta_secs % 60
 
-  if delta_hours or day_str:
-    return day_str + '%02d:%02d:%02d' % (delta_hours, delta_mins, delta_secs)
-  if delta_mins:
-    return '%02d:%02d' % (delta_mins, delta_secs)
-  return '%d.%03d secs' % (delta_secs, delta.microseconds // 1000)
+    if delta_hours or day_str:
+        return day_str + "%02d:%02d:%02d" % (delta_hours, delta_mins, delta_secs)
+    if delta_mins:
+        return "%02d:%02d" % (delta_mins, delta_secs)
+    return "%d.%03d secs" % (delta_secs, delta.microseconds // 1000)
 
 
-def log_embedded_output(log_level, title, output, line_prefix='    >>>  '):
-  """Helper function that logs an output stream from another process."""
-  newline_indent = '\n' + line_prefix
-  logfile_lines = output.replace('\r', '\n').split('\n')
-  logging.log(
-      log_level,
-      '%s:%s%s',
-      title, newline_indent, newline_indent.join(logfile_lines))
+def log_embedded_output(log_level, title, output, line_prefix="    >>>  "):
+    """Helper function that logs an output stream from another process."""
+    newline_indent = "\n" + line_prefix
+    logfile_lines = output.replace("\r", "\n").split("\n")
+    logging.log(
+        log_level, "%s:%s%s", title, newline_indent, newline_indent.join(logfile_lines)
+    )
 
 
 def ensure_dir_exists(path):
-  """Ensure a directory exists, creating it if not."""
-  try:
-    os.makedirs(path)
-  except OSError:
-    if not os.path.exists(path):
-      raise
+    """Ensure a directory exists, creating it if not."""
+    try:
+        os.makedirs(path)
+    except OSError:
+        if not os.path.exists(path):
+            raise
 
 
 def write_to_path(content, path):
-  """Write the given content to the file specified by the <path>.
+    """Write the given content to the file specified by the <path>.
 
-  This will create the parent directory if needed.
-  """
-  ensure_dir_exists(os.path.dirname(os.path.abspath(path)))
-  if isinstance(content, str):
-    with open(path, 'w') as f:
-      f.write(content)
-  else:
-    with io.open(path, 'w', encoding='utf-8') as f:
-      f.write(content)
+    This will create the parent directory if needed.
+    """
+    ensure_dir_exists(os.path.dirname(os.path.abspath(path)))
+    if isinstance(content, str):
+        with open(path, "w") as f:
+            f.write(content)
+    else:
+        with io.open(path, "w", encoding="utf-8") as f:
+            f.write(content)

--- a/dev/iap_generate_google_auth_token.py
+++ b/dev/iap_generate_google_auth_token.py
@@ -32,88 +32,108 @@ import requests_toolbelt
 from google.auth.transport.requests import Request
 
 
-OAUTH_TOKEN_URI = 'https://www.googleapis.com/oauth2/v4/token'
-IAM_SCOPE = 'https://www.googleapis.com/auth/iam'
+OAUTH_TOKEN_URI = "https://www.googleapis.com/oauth2/v4/token"
+IAM_SCOPE = "https://www.googleapis.com/auth/iam"
 
 
-def __make_service_account_credentials(client_id, service_account_file=None, impersonate_service_account_email=None):
-  if service_account_file:
-    bootstrap_credentials = google.oauth2.service_account.Credentials.from_service_account_file(service_account_file)
-  else:
-    bootstrap_credentials, _ = google.auth.default(scopes=[IAM_SCOPE])
+def __make_service_account_credentials(
+    client_id, service_account_file=None, impersonate_service_account_email=None
+):
+    if service_account_file:
+        bootstrap_credentials = (
+            google.oauth2.service_account.Credentials.from_service_account_file(
+                service_account_file
+            )
+        )
+    else:
+        bootstrap_credentials, _ = google.auth.default(scopes=[IAM_SCOPE])
 
-  if impersonate_service_account_email:
-    bootstrap_credentials = google.auth.impersonated_credentials.Credentials(
-        source_credentials=bootstrap_credentials,
-        target_principal=impersonate_service_account_email,
-        target_scopes=[IAM_SCOPE],
-        lifetime=60)
+    if impersonate_service_account_email:
+        bootstrap_credentials = google.auth.impersonated_credentials.Credentials(
+            source_credentials=bootstrap_credentials,
+            target_principal=impersonate_service_account_email,
+            target_scopes=[IAM_SCOPE],
+            lifetime=60,
+        )
 
-  if isinstance(bootstrap_credentials,
-                google.oauth2.credentials.Credentials):
-    raise Exception('generate_auth_token is only supported for service '
-                    'accounts.')
-  elif isinstance(bootstrap_credentials,
-                  google.auth.app_engine.Credentials):
-    requests_toolbelt.adapters.appengine.monkeypatch()
+    if isinstance(bootstrap_credentials, google.oauth2.credentials.Credentials):
+        raise Exception(
+            "generate_auth_token is only supported for service " "accounts."
+        )
+    elif isinstance(bootstrap_credentials, google.auth.app_engine.Credentials):
+        requests_toolbelt.adapters.appengine.monkeypatch()
 
-  if impersonate_service_account_email:
-    signer_email = impersonate_service_account_email
-  else:
-    signer_email = bootstrap_credentials.service_account_email
+    if impersonate_service_account_email:
+        signer_email = impersonate_service_account_email
+    else:
+        signer_email = bootstrap_credentials.service_account_email
 
-  if impersonate_service_account_email or isinstance(bootstrap_credentials,
-      google.auth.compute_engine.credentials.Credentials):
-    signer = google.auth.iam.Signer(
-        Request(), bootstrap_credentials, signer_email)
-  else:
-    signer = bootstrap_credentials.signer
+    if impersonate_service_account_email or isinstance(
+        bootstrap_credentials, google.auth.compute_engine.credentials.Credentials
+    ):
+        signer = google.auth.iam.Signer(Request(), bootstrap_credentials, signer_email)
+    else:
+        signer = bootstrap_credentials.signer
 
-  return google.oauth2.service_account.Credentials(
-      signer, signer_email, token_uri=OAUTH_TOKEN_URI, additional_claims={
-          'target_audience': client_id
-      })
+    return google.oauth2.service_account.Credentials(
+        signer,
+        signer_email,
+        token_uri=OAUTH_TOKEN_URI,
+        additional_claims={"target_audience": client_id},
+    )
+
 
 def __get_token_from_credentials(service_account_credentials):
-  service_account_jwt = (
-      service_account_credentials._make_authorization_grant_assertion())
-  request = google.auth.transport.requests.Request()
-  body = {
-    'assertion': service_account_jwt,
-    'grant_type': google.oauth2._client._JWT_GRANT_TYPE,
-  }
-  token_response = google.oauth2._client._token_endpoint_request(
-      request, OAUTH_TOKEN_URI, body)
-  return token_response['id_token']
+    service_account_jwt = (
+        service_account_credentials._make_authorization_grant_assertion()
+    )
+    request = google.auth.transport.requests.Request()
+    body = {
+        "assertion": service_account_jwt,
+        "grant_type": google.oauth2._client._JWT_GRANT_TYPE,
+    }
+    token_response = google.oauth2._client._token_endpoint_request(
+        request, OAUTH_TOKEN_URI, body
+    )
+    return token_response["id_token"]
 
 
-def generate_auth_token(client_id, service_account_file=None, impersonate_service_account_email=None):
-  """Generates an auth token to make requests to an IAP-protected endpoint.
+def generate_auth_token(
+    client_id, service_account_file=None, impersonate_service_account_email=None
+):
+    """Generates an auth token to make requests to an IAP-protected endpoint.
 
-  Args:
-    client_id: The client ID used by IAP to generate the token.
-    service_account_file: [string] The path to a credentials file for a service
-       account that can be used to generate the token. If service_account_file
-       is None, the service account used will be based on the Application
-       Default Credentials.
-    impersonate_service_account_email: [string] The service account name (email)
-       to impersonate to request the bearer token. If
-       impersonate_service_account_email is None, no service account will be
-       impersonated.
-  """
-  service_account_credentials =__make_service_account_credentials(client_id, service_account_file, impersonate_service_account_email)
-  return __get_token_from_credentials(service_account_credentials)
+    Args:
+      client_id: The client ID used by IAP to generate the token.
+      service_account_file: [string] The path to a credentials file for a service
+         account that can be used to generate the token. If service_account_file
+         is None, the service account used will be based on the Application
+         Default Credentials.
+      impersonate_service_account_email: [string] The service account name (email)
+         to impersonate to request the bearer token. If
+         impersonate_service_account_email is None, no service account will be
+         impersonated.
+    """
+    service_account_credentials = __make_service_account_credentials(
+        client_id, service_account_file, impersonate_service_account_email
+    )
+    return __get_token_from_credentials(service_account_credentials)
+
 
 def get_service_account_email(service_account_file=None):
-  """Parse a service account email from a service_account_file or ADC.
+    """Parse a service account email from a service_account_file or ADC.
 
-  Args:
-    service_account_file: [string] The path to a credentials file for a service
-       account. If service_account_file is None, the service account used will
-       be based on the Application Default Credentials.
-  """
-  if service_account_file:
-    credentials = google.oauth2.service_account.Credentials.from_service_account_file(service_account_file)
-  else:
-    credentials, _ = google.auth.default(scopes=[IAM_SCOPE])
-  return credentials.service_account_email
+    Args:
+      service_account_file: [string] The path to a credentials file for a service
+         account. If service_account_file is None, the service account used will
+         be based on the Application Default Credentials.
+    """
+    if service_account_file:
+        credentials = (
+            google.oauth2.service_account.Credentials.from_service_account_file(
+                service_account_file
+            )
+        )
+    else:
+        credentials, _ = google.auth.default(scopes=[IAM_SCOPE])
+    return credentials.service_account_email

--- a/dev/iap_generate_google_auth_token.py
+++ b/dev/iap_generate_google_auth_token.py
@@ -26,7 +26,7 @@ import google.auth.iam
 import google.auth.impersonated_credentials
 import google.oauth2.credentials
 import google.oauth2.service_account
-import requests
+import requests_toolbelt
 
 
 from google.auth.transport.requests import Request

--- a/dev/publish_halyard.py
+++ b/dev/publish_halyard.py
@@ -66,7 +66,7 @@ class HalyardPublisher(object):
     """
     bucket_uri = self.__hal_nightly_bucket_uri
     local_bucket_name = os.path.basename(bucket_uri)
-    print 'cloning: {0}'.format(self.__halyard_repo_uri)
+    print('cloning: {0}'.format(self.__halyard_repo_uri))
     check_run_quick('git clone {0}'.format(self.__halyard_repo_uri))
 
     # Read the Halyard nightly bucket file.

--- a/dev/publish_halyard.py
+++ b/dev/publish_halyard.py
@@ -43,212 +43,290 @@ from spinnaker.run import check_run_quick
 
 
 class HalyardPublisher(object):
-  """Publishes a nightly version of Halyard to be a stable version.
-  """
+    """Publishes a nightly version of Halyard to be a stable version."""
 
-  def __init__(self, options, build_number=None):
-    self.__annotator = None
-    self.__build_number = build_number or '{:%Y%m%d%H%M%S}'.format(datetime.datetime.utcnow())
-    self.__github_publisher = options.github_publisher
-    self.__hal_nightly_bucket_uri = options.hal_nightly_bucket_uri
-    self.__halyard_repo_uri = options.halyard_repo_uri
-    self.__nightly_version = options.nightly_version
-    self.__options = options
-    self.__patch_release = options.patch_release
-    self.__stable_branch = ''
-    self.__stable_version = options.stable_version
-    self.__stable_version_tag = ''
-    self.__docs_repo_name = options.docs_repo_name
-    self.__docs_repo_owner = options.docs_repo_owner
+    def __init__(self, options, build_number=None):
+        self.__annotator = None
+        self.__build_number = build_number or "{:%Y%m%d%H%M%S}".format(
+            datetime.datetime.utcnow()
+        )
+        self.__github_publisher = options.github_publisher
+        self.__hal_nightly_bucket_uri = options.hal_nightly_bucket_uri
+        self.__halyard_repo_uri = options.halyard_repo_uri
+        self.__nightly_version = options.nightly_version
+        self.__options = options
+        self.__patch_release = options.patch_release
+        self.__stable_branch = ""
+        self.__stable_version = options.stable_version
+        self.__stable_version_tag = ""
+        self.__docs_repo_name = options.docs_repo_name
+        self.__docs_repo_owner = options.docs_repo_owner
 
-  def __checkout_halyard_repo(self):
-    """Clones the Halyard git repo at the commit at which we built the nightly version.
-    """
-    bucket_uri = self.__hal_nightly_bucket_uri
-    local_bucket_name = os.path.basename(bucket_uri)
-    print('cloning: {0}'.format(self.__halyard_repo_uri))
-    check_run_quick('git clone {0}'.format(self.__halyard_repo_uri))
+    def __checkout_halyard_repo(self):
+        """Clones the Halyard git repo at the commit at which we built the nightly version."""
+        bucket_uri = self.__hal_nightly_bucket_uri
+        local_bucket_name = os.path.basename(bucket_uri)
+        print("cloning: {0}".format(self.__halyard_repo_uri))
+        check_run_quick("git clone {0}".format(self.__halyard_repo_uri))
 
-    # Read the Halyard nightly bucket file.
-    print ('Fetching Halyard nightly build info from {0}. Writing locally to {1}.'
-           .format(bucket_uri, local_bucket_name))
-    if not os.path.exists(local_bucket_name):
-        os.mkdir(local_bucket_name)
-    check_run_quick('gsutil rsync -r -d {remote_uri} {local_bucket}'
-                    .format(remote_uri=bucket_uri, local_bucket=local_bucket_name))
-    nightly_commit_file = '{0}/nightly-version-commits.yml'.format(local_bucket_name)
-    nightly_commit_dict = {}
-    with open(nightly_commit_file, 'r') as ncf:
-      nightly_commit_dict = yaml.safe_load(ncf.read())
+        # Read the Halyard nightly bucket file.
+        print(
+            "Fetching Halyard nightly build info from {0}. Writing locally to {1}.".format(
+                bucket_uri, local_bucket_name
+            )
+        )
+        if not os.path.exists(local_bucket_name):
+            os.mkdir(local_bucket_name)
+        check_run_quick(
+            "gsutil rsync -r -d {remote_uri} {local_bucket}".format(
+                remote_uri=bucket_uri, local_bucket=local_bucket_name
+            )
+        )
+        nightly_commit_file = "{0}/nightly-version-commits.yml".format(
+            local_bucket_name
+        )
+        nightly_commit_dict = {}
+        with open(nightly_commit_file, "r") as ncf:
+            nightly_commit_dict = yaml.safe_load(ncf.read())
 
-    # Check Halyard out at the correct commit.
-    commit_to_build = nightly_commit_dict.get(self.__nightly_version, None)
-    if not commit_to_build:
-      raise ValueError('No commit hash recorded in {bucket} for Halyard nightly version {nightly}, exiting.'
-                       .format(bucket=bucket_uri, nightly=self.__nightly_version))
-    print ('Checking out Halyard from {0} repo at commit {1}.'
-           .format(self.__halyard_repo_uri, commit_to_build))
-    check_run_quick('git -C halyard checkout {0}'.format(commit_to_build))
+        # Check Halyard out at the correct commit.
+        commit_to_build = nightly_commit_dict.get(self.__nightly_version, None)
+        if not commit_to_build:
+            raise ValueError(
+                "No commit hash recorded in {bucket} for Halyard nightly version {nightly}, exiting.".format(
+                    bucket=bucket_uri, nightly=self.__nightly_version
+                )
+            )
+        print(
+            "Checking out Halyard from {0} repo at commit {1}.".format(
+                self.__halyard_repo_uri, commit_to_build
+            )
+        )
+        check_run_quick("git -C halyard checkout {0}".format(commit_to_build))
 
-  def __update_versions_tracking_file(self):
-    """Updates the global versions.yml tracking file to point at the new
-    version of Halyard.
-    """
-    check_run_quick('hal admin publish latest-halyard {}'
-                    .format(self.__stable_version))
+    def __update_versions_tracking_file(self):
+        """Updates the global versions.yml tracking file to point at the new
+        version of Halyard.
+        """
+        check_run_quick(
+            "hal admin publish latest-halyard {}".format(self.__stable_version)
+        )
 
-  def __tag_halyard_repo(self):
-    """Tags the Halyard repo with a tag derived from --stable_version.
-    """
-    self.__stable_version_tag = self.__stable_version
-    if not self.__stable_version_tag.startswith('version-'):
-      self.__stable_version_tag = 'version-' + self.__stable_version_tag
-    self.__annotator = Annotator(self.__options, path='halyard', next_tag=self.__stable_version_tag)
-    self.__annotator.parse_git_tree()
-    self.__annotator.tag_head()
-    self.__annotator.delete_unwanted_tags()
+    def __tag_halyard_repo(self):
+        """Tags the Halyard repo with a tag derived from --stable_version."""
+        self.__stable_version_tag = self.__stable_version
+        if not self.__stable_version_tag.startswith("version-"):
+            self.__stable_version_tag = "version-" + self.__stable_version_tag
+        self.__annotator = Annotator(
+            self.__options, path="halyard", next_tag=self.__stable_version_tag
+        )
+        self.__annotator.parse_git_tree()
+        self.__annotator.tag_head()
+        self.__annotator.delete_unwanted_tags()
 
-  def __build_halyard(self):
-    """Builds a Halyard debian with distribution as 'trusty-stable'.
-    """
-    jarRepo = self.__options.jar_repo
-    parts = self.__options.bintray_repo.split('/')
-    if len(parts) != 2:
-      raise ValueError(
-          'Expected --bintray_repo to be in the form <owner>/<repo>')
-    org, packageRepo = parts[0], parts[1]
-    bintray_key = os.environ['BINTRAY_KEY']
-    bintray_user = os.environ['BINTRAY_USER']
-    extra_args = [
-      '--debug',
-      '-Prelease.useLastTag=true',
-      '-PbintrayPackageBuildNumber={number}'.format(
-        number=self.__build_number),
-      '-PbintrayOrg="{org}"'.format(org=org),
-      '-PbintrayPackageRepo="{repo}"'.format(repo=packageRepo),
-      '-PbintrayJarRepo="{jarRepo}"'.format(jarRepo=jarRepo),
-      '-PbintrayKey="{key}"'.format(key=bintray_key),
-      '-PbintrayUser="{user}"'.format(user=bintray_user),
-      '-PbintrayPackageDebDistribution=trusty-stable'
-    ]
+    def __build_halyard(self):
+        """Builds a Halyard debian with distribution as 'trusty-stable'."""
+        jarRepo = self.__options.jar_repo
+        parts = self.__options.bintray_repo.split("/")
+        if len(parts) != 2:
+            raise ValueError("Expected --bintray_repo to be in the form <owner>/<repo>")
+        org, packageRepo = parts[0], parts[1]
+        bintray_key = os.environ["BINTRAY_KEY"]
+        bintray_user = os.environ["BINTRAY_USER"]
+        extra_args = [
+            "--debug",
+            "-Prelease.useLastTag=true",
+            "-PbintrayPackageBuildNumber={number}".format(number=self.__build_number),
+            '-PbintrayOrg="{org}"'.format(org=org),
+            '-PbintrayPackageRepo="{repo}"'.format(repo=packageRepo),
+            '-PbintrayJarRepo="{jarRepo}"'.format(jarRepo=jarRepo),
+            '-PbintrayKey="{key}"'.format(key=bintray_key),
+            '-PbintrayUser="{user}"'.format(user=bintray_user),
+            "-PbintrayPackageDebDistribution=trusty-stable",
+        ]
 
-    cmds = [
-      './gradlew {extra} candidate'.format(extra=' '.join(extra_args))
-    ]
-    run_shell_and_log(cmds, 'halyard-debian-build.log', cwd='halyard')
+        cmds = ["./gradlew {extra} candidate".format(extra=" ".join(extra_args))]
+        run_shell_and_log(cmds, "halyard-debian-build.log", cwd="halyard")
 
-  def __push_halyard_tag_and_branch(self):
-    """Pushes a stable branch and git version tag to --github_publisher's Halyard repository.
-    """
-    major, minor, _ = self.__stable_version.split('.')
-    self.__stable_branch = format_stable_branch(major, minor)
+    def __push_halyard_tag_and_branch(self):
+        """Pushes a stable branch and git version tag to --github_publisher's Halyard repository."""
+        major, minor, _ = self.__stable_version.split(".")
+        self.__stable_branch = format_stable_branch(major, minor)
 
-    if self.__patch_release:
-      check_run_quick('git -C halyard checkout {0}'.format(self.__stable_branch))
-    else:
-      # Create new release branch.
-      check_run_quick('git -C halyard checkout -b {0}'.format(self.__stable_branch))
+        if self.__patch_release:
+            check_run_quick("git -C halyard checkout {0}".format(self.__stable_branch))
+        else:
+            # Create new release branch.
+            check_run_quick(
+                "git -C halyard checkout -b {0}".format(self.__stable_branch)
+            )
 
-    repo_to_push = 'git@github.com:{owner}/halyard.git'.format(owner=self.__github_publisher)
-    check_run_quick('git -C halyard remote add release {url}'
-                    .format(url=repo_to_push))
+        repo_to_push = "git@github.com:{owner}/halyard.git".format(
+            owner=self.__github_publisher
+        )
+        check_run_quick(
+            "git -C halyard remote add release {url}".format(url=repo_to_push)
+        )
 
-    print ('Pushing Halyard stable branch {branch} to {repo}'
-           .format(branch=self.__stable_branch, repo=repo_to_push))
-    check_run_quick('git -C halyard push release {branch}'.format(branch=self.__stable_branch))
+        print(
+            "Pushing Halyard stable branch {branch} to {repo}".format(
+                branch=self.__stable_branch, repo=repo_to_push
+            )
+        )
+        check_run_quick(
+            "git -C halyard push release {branch}".format(branch=self.__stable_branch)
+        )
 
-    print ('Pushing Halyard stable version tag {tag} to {repo}'
-           .format(tag=self.__stable_version_tag, repo=self.__halyard_repo_uri))
-    check_run_quick('git -C halyard push release {tag}'.format(tag=self.__stable_version_tag))
+        print(
+            "Pushing Halyard stable version tag {tag} to {repo}".format(
+                tag=self.__stable_version_tag, repo=self.__halyard_repo_uri
+            )
+        )
+        check_run_quick(
+            "git -C halyard push release {tag}".format(tag=self.__stable_version_tag)
+        )
 
-  def __generate_halyard_docs(self):
-    """Builds Halyard's CLI, which writes the new documentation locally to halyard/docs/commands.md
-    """
-    check_run_quick('git -C halyard rev-parse HEAD | xargs git -C halyard checkout ;')
-    cmds = [
-      'make'
-    ]
-    run_shell_and_log(cmds, 'halyard-generate-docs.log', cwd='halyard/halyard-cli')
+    def __generate_halyard_docs(self):
+        """Builds Halyard's CLI, which writes the new documentation locally to halyard/docs/commands.md"""
+        check_run_quick(
+            "git -C halyard rev-parse HEAD | xargs git -C halyard checkout ;"
+        )
+        cmds = ["make"]
+        run_shell_and_log(cmds, "halyard-generate-docs.log", cwd="halyard/halyard-cli")
 
-  def __publish_halyard_docs(self):
-    """ Formats Halyard's documentation, then pushes to Spinnaker's documentation repository.
-    """
-    docs_source = 'halyard/docs/commands.md'
-    docs_target = '{repo_name}/reference/halyard/commands.md'.format(repo_name=self.__docs_repo_name)
+    def __publish_halyard_docs(self):
+        """Formats Halyard's documentation, then pushes to Spinnaker's documentation repository."""
+        docs_source = "halyard/docs/commands.md"
+        docs_target = "{repo_name}/reference/halyard/commands.md".format(
+            repo_name=self.__docs_repo_name
+        )
 
-    repo_uri = 'git@github.com:{repo_owner}/{repo_name}'.format(repo_owner=self.__docs_repo_owner,
-                                                                repo_name=self.__docs_repo_name)
-    check_run_quick('git clone {repo_uri}'.format(repo_uri=repo_uri))
+        repo_uri = "git@github.com:{repo_owner}/{repo_name}".format(
+            repo_owner=self.__docs_repo_owner, repo_name=self.__docs_repo_name
+        )
+        check_run_quick("git clone {repo_uri}".format(repo_uri=repo_uri))
 
-    with open(docs_source, 'r') as source:
-      with open(docs_target, 'w') as target:
-        header = '\n'.join([
-          '---',
-          'layout: single',
-          'title:  "Commands"',
-          'sidebar:',
-          '  nav: reference',
-          '---',
-          '',
-          'Published: {}'.format(datetime
-              .datetime
-              .utcnow()
-              .strftime('%Y-%m-%d %H:%M:%S')),
-          '',
-        ])
-        target.write(header + source.read())
+        with open(docs_source, "r") as source:
+            with open(docs_target, "w") as target:
+                header = "\n".join(
+                    [
+                        "---",
+                        "layout: single",
+                        'title:  "Commands"',
+                        "sidebar:",
+                        "  nav: reference",
+                        "---",
+                        "",
+                        "Published: {}".format(
+                            datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+                        ),
+                        "",
+                    ]
+                )
+                target.write(header + source.read())
 
-    commit_message = 'docs(halyard): {version}'.format(version=self.__stable_version)
-    check_run_quick('git -C {repo_name} add reference/halyard/commands.md'.format(repo_name=self.__docs_repo_name))
-    check_run_quick('git -C {repo_name} commit -m "{message}"'
-                    .format(repo_name=self.__docs_repo_name, message=commit_message))
-    check_run_quick('git -C {repo_name} push origin master'.format(repo_name=self.__docs_repo_name))
+        commit_message = "docs(halyard): {version}".format(
+            version=self.__stable_version
+        )
+        check_run_quick(
+            "git -C {repo_name} add reference/halyard/commands.md".format(
+                repo_name=self.__docs_repo_name
+            )
+        )
+        check_run_quick(
+            'git -C {repo_name} commit -m "{message}"'.format(
+                repo_name=self.__docs_repo_name, message=commit_message
+            )
+        )
+        check_run_quick(
+            "git -C {repo_name} push origin master".format(
+                repo_name=self.__docs_repo_name
+            )
+        )
 
-  def publish_stable_halyard(self):
-    self.__checkout_halyard_repo()
-    self.__tag_halyard_repo()
-    self.__build_halyard()
-    self.__push_halyard_tag_and_branch()
-    self.__generate_halyard_docs()
-    self.__publish_halyard_docs()
-    self.__update_versions_tracking_file()
+    def publish_stable_halyard(self):
+        self.__checkout_halyard_repo()
+        self.__tag_halyard_repo()
+        self.__build_halyard()
+        self.__push_halyard_tag_and_branch()
+        self.__generate_halyard_docs()
+        self.__publish_halyard_docs()
+        self.__update_versions_tracking_file()
 
-  @classmethod
-  def init_argument_parser(cls, parser):
-    """Initialize command-line arguments."""
-    parser.add_argument('--bintray_repo', default='',
-                        help='Publish to this bintray repo.\n'
-                        'This requires BINTRAY_USER and BINTRAY_KEY are set.')
-    parser.add_argument('--github_publisher', default='', required=True,
-                        help="The owner of the remote repo the branch and tag are pushed to.")
-    parser.add_argument('--hal_nightly_bucket_uri', default='',
-                        help='The URI of the Halyard nightly build bucket.')
-    parser.add_argument('--halyard_repo_uri', default='', required=True,
-                        help='The ssh uri of the Halyard repo to build the stable release from.')
-    parser.add_argument('--jar_repo', default='',
-                        help='Publish produced jars to this repo.\n'
-                        'This requires BINTRAY_USER and BINTRAY_KEY are set.')
-    parser.add_argument('--nightly_version', default='', required=True,
-                        help='The nightly version of Halyard that we are promoting.')
-    parser.add_argument('--patch_release', default=False, action='store_true',
-                        help='Make a patch release.')
-    parser.add_argument('--stable_version', default='', required=True,
-                        help='The stable version we are publishing the chosen nightly Halyard version as.')
-    parser.add_argument('--docs_repo_name', default='spinnaker.io', required=True,
-                        help="The name of the Spinnaker docs repository")
-    parser.add_argument('--docs_repo_owner', default='spinnaker', required=True,
-                        help="The owner of the Spinnaker docs repository")
-    # Initialize parser for composed Annotator.
-    Annotator.init_argument_parser(parser)
+    @classmethod
+    def init_argument_parser(cls, parser):
+        """Initialize command-line arguments."""
+        parser.add_argument(
+            "--bintray_repo",
+            default="",
+            help="Publish to this bintray repo.\n"
+            "This requires BINTRAY_USER and BINTRAY_KEY are set.",
+        )
+        parser.add_argument(
+            "--github_publisher",
+            default="",
+            required=True,
+            help="The owner of the remote repo the branch and tag are pushed to.",
+        )
+        parser.add_argument(
+            "--hal_nightly_bucket_uri",
+            default="",
+            help="The URI of the Halyard nightly build bucket.",
+        )
+        parser.add_argument(
+            "--halyard_repo_uri",
+            default="",
+            required=True,
+            help="The ssh uri of the Halyard repo to build the stable release from.",
+        )
+        parser.add_argument(
+            "--jar_repo",
+            default="",
+            help="Publish produced jars to this repo.\n"
+            "This requires BINTRAY_USER and BINTRAY_KEY are set.",
+        )
+        parser.add_argument(
+            "--nightly_version",
+            default="",
+            required=True,
+            help="The nightly version of Halyard that we are promoting.",
+        )
+        parser.add_argument(
+            "--patch_release",
+            default=False,
+            action="store_true",
+            help="Make a patch release.",
+        )
+        parser.add_argument(
+            "--stable_version",
+            default="",
+            required=True,
+            help="The stable version we are publishing the chosen nightly Halyard version as.",
+        )
+        parser.add_argument(
+            "--docs_repo_name",
+            default="spinnaker.io",
+            required=True,
+            help="The name of the Spinnaker docs repository",
+        )
+        parser.add_argument(
+            "--docs_repo_owner",
+            default="spinnaker",
+            required=True,
+            help="The owner of the Spinnaker docs repository",
+        )
+        # Initialize parser for composed Annotator.
+        Annotator.init_argument_parser(parser)
 
-  @classmethod
-  def main(cls):
-    parser = argparse.ArgumentParser()
-    cls.init_argument_parser(parser)
-    options = parser.parse_args()
+    @classmethod
+    def main(cls):
+        parser = argparse.ArgumentParser()
+        cls.init_argument_parser(parser)
+        options = parser.parse_args()
 
-    halyard_publisher = cls(options)
-    halyard_publisher.publish_stable_halyard()
+        halyard_publisher = cls(options)
+        halyard_publisher.publish_stable_halyard()
 
-if __name__ == '__main__':
-  sys.exit(HalyardPublisher.main())
+
+if __name__ == "__main__":
+    sys.exit(HalyardPublisher.main())

--- a/dev/publish_test_results.py
+++ b/dev/publish_test_results.py
@@ -26,102 +26,119 @@ import yaml
 from spinnaker.run import check_run_quick
 
 # Path to the posts directory in the spinnaker.io site.
-POSTS_DIR = '_posts'
-
-class TestResultPublisher():
-
-  def __init__(self, options):
-    self.__nightly_version = options.nightly_version
-    self.__githubio_repo_uri = options.githubio_repo_uri
-    self.__repo_name = ''
-    self.__test_results_file = options.test_results_file
-    self.__test_results_html = ''
+POSTS_DIR = "_posts"
 
 
-  def __checkout_githubio_repo(self):
-    """Clones the spinnaker.io git repo.
-    """
-    check_run_quick('git clone {0}'.format(self.__githubio_repo_uri))
-    self.__repo_name = os.path.basename(self.__githubio_repo_uri)
-    if self.__repo_name.endswith('.git'):
-      self.__repo_name = self.__repo_name.replace('.git', '')
+class TestResultPublisher:
+    def __init__(self, options):
+        self.__nightly_version = options.nightly_version
+        self.__githubio_repo_uri = options.githubio_repo_uri
+        self.__repo_name = ""
+        self.__test_results_file = options.test_results_file
+        self.__test_results_html = ""
 
-  def __read_test_results(self):
-    """Read the test results into memory.
-    """
-    with open(self.__test_results_file, 'r') as results_file:
-      self.__test_results_html = results_file.read()
+    def __checkout_githubio_repo(self):
+        """Clones the spinnaker.io git repo."""
+        check_run_quick("git clone {0}".format(self.__githubio_repo_uri))
+        self.__repo_name = os.path.basename(self.__githubio_repo_uri)
+        if self.__repo_name.endswith(".git"):
+            self.__repo_name = self.__repo_name.replace(".git", "")
 
-  def __format_nightly_post(self):
-    # Initialized with 'front matter' necessary for the post.
-    timestamp = '{:%Y-%m-%d %H:%M:%S}'.format(datetime.datetime.now())
-    post_lines = [
-      '---',
-      'title: Spinnaker Nightly Build Version {version}'.format(version=self.__nightly_version),
-      'date: {date}'.format(date=timestamp),
-      'categories: nightly-builds',
-      '---',
-      ''
-    ]
-    post_lines.append('# Spinnaker Nightly Build Version {version}'
-                      .format(version=self.__nightly_version))
-    post_lines.append('\n# Test results\n')
-    post_lines.append(self.__test_results_html)
-    post = '\n'.join(post_lines)
-    return post
+    def __read_test_results(self):
+        """Read the test results into memory."""
+        with open(self.__test_results_file, "r") as results_file:
+            self.__test_results_html = results_file.read()
 
-  def __publish_post(self, post_content):
-    day = '{:%Y-%m-%d}'.format(datetime.datetime.now())
-    post_name = '{day}-{version}-nightly.md'.format(day=day, version=self.__nightly_version)
-    post_path = os.path.join(self.__repo_name, POSTS_DIR, post_name)
-    # Path to post file relative to the git root.
-    post_rel_path = os.path.join(POSTS_DIR, post_name)
-    with open(post_path, 'w') as post_file:
-      post_file.write(post_content)
+    def __format_nightly_post(self):
+        # Initialized with 'front matter' necessary for the post.
+        timestamp = "{:%Y-%m-%d %H:%M:%S}".format(datetime.datetime.now())
+        post_lines = [
+            "---",
+            "title: Spinnaker Nightly Build Version {version}".format(
+                version=self.__nightly_version
+            ),
+            "date: {date}".format(date=timestamp),
+            "categories: nightly-builds",
+            "---",
+            "",
+        ]
+        post_lines.append(
+            "# Spinnaker Nightly Build Version {version}".format(
+                version=self.__nightly_version
+            )
+        )
+        post_lines.append("\n# Test results\n")
+        post_lines.append(self.__test_results_html)
+        post = "\n".join(post_lines)
+        return post
 
-    check_run_quick('git -C {0} add {1}'.format(self.__repo_name, post_rel_path))
-    message = 'Nightly Build post for version {0}'.format(self.__nightly_version)
-    check_run_quick('git -C {0} commit -m "{1}"'.format(self.__repo_name, message))
-    check_run_quick('git -C {0} push origin master'.format(self.__repo_name))
+    def __publish_post(self, post_content):
+        day = "{:%Y-%m-%d}".format(datetime.datetime.now())
+        post_name = "{day}-{version}-nightly.md".format(
+            day=day, version=self.__nightly_version
+        )
+        post_path = os.path.join(self.__repo_name, POSTS_DIR, post_name)
+        # Path to post file relative to the git root.
+        post_rel_path = os.path.join(POSTS_DIR, post_name)
+        with open(post_path, "w") as post_file:
+            post_file.write(post_content)
 
-  def publish_nightly_post(self):
-    """Creates and publishes Nightly Build post for the spinnaker.io site.
+        check_run_quick("git -C {0} add {1}".format(self.__repo_name, post_rel_path))
+        message = "Nightly Build post for version {0}".format(self.__nightly_version)
+        check_run_quick('git -C {0} commit -m "{1}"'.format(self.__repo_name, message))
+        check_run_quick("git -C {0} push origin master".format(self.__repo_name))
 
-    'Publishing' in this case means creating a new file, 'git add'ing it to the
-    local git repository for spinnaker.io, and then pushing a commit
-    to origin/master.
+    def publish_nightly_post(self):
+        """Creates and publishes Nightly Build post for the spinnaker.io site.
 
-    A private key that has access to --githubio_repo needs added
-    to a running ssh-agent on the machine this script will run on:
+        'Publishing' in this case means creating a new file, 'git add'ing it to the
+        local git repository for spinnaker.io, and then pushing a commit
+        to origin/master.
 
-    > <copy or rsync the key to the vm>
-    > eval `ssh-agent`
-    > ssh-add ~/.ssh/<key with access to github repos>
-    """
-    self.__checkout_githubio_repo()
-    self.__read_test_results()
-    post = self.__format_nightly_post()
-    self.__publish_post(post)
+        A private key that has access to --githubio_repo needs added
+        to a running ssh-agent on the machine this script will run on:
 
-  @classmethod
-  def init_argument_parser(cls, parser):
-    """Initialize command-line arguments."""
-    parser.add_argument('--githubio_repo_uri', default='', required=True,
-                        help='The ssh uri of the spinnaker.io repo to'
-                        'commit the nightly build post to, e.g. git@github.com:spinnaker/spinnaker.io.')
-    parser.add_argument('--nightly_version', default='', required=True,
-                        help='The version of Spinnaker we build during our nightly build.')
-    parser.add_argument('--test_results_file', default='', required=True,
-                        help='The file containing the test results summary, e.g. index.html.')
+        > <copy or rsync the key to the vm>
+        > eval `ssh-agent`
+        > ssh-add ~/.ssh/<key with access to github repos>
+        """
+        self.__checkout_githubio_repo()
+        self.__read_test_results()
+        post = self.__format_nightly_post()
+        self.__publish_post(post)
 
-  @classmethod
-  def main(cls):
-    parser = argparse.ArgumentParser()
-    cls.init_argument_parser(parser)
-    options = parser.parse_args()
+    @classmethod
+    def init_argument_parser(cls, parser):
+        """Initialize command-line arguments."""
+        parser.add_argument(
+            "--githubio_repo_uri",
+            default="",
+            required=True,
+            help="The ssh uri of the spinnaker.io repo to"
+            "commit the nightly build post to, e.g. git@github.com:spinnaker/spinnaker.io.",
+        )
+        parser.add_argument(
+            "--nightly_version",
+            default="",
+            required=True,
+            help="The version of Spinnaker we build during our nightly build.",
+        )
+        parser.add_argument(
+            "--test_results_file",
+            default="",
+            required=True,
+            help="The file containing the test results summary, e.g. index.html.",
+        )
 
-    result_publisher = cls(options)
-    result_publisher.publish_nightly_post()
+    @classmethod
+    def main(cls):
+        parser = argparse.ArgumentParser()
+        cls.init_argument_parser(parser)
+        options = parser.parse_args()
 
-if __name__ == '__main__':
-  sys.exit(TestResultPublisher.main())
+        result_publisher = cls(options)
+        result_publisher.publish_nightly_post()
+
+
+if __name__ == "__main__":
+    sys.exit(TestResultPublisher.main())

--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -927,8 +927,8 @@ class AzureConfigurator(Configurator):
         if not options.azure_account_enabled:
             return
 
-        if (options.azure_account_packer_resource_group != None) != (
-            options.azure_account_packer_storage_account != None
+        if (options.azure_account_packer_resource_group is not None) != (
+            options.azure_account_packer_storage_account is not None
         ):
             raise ValueError(
                 "--azure_account_packer_resource_group"

--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -53,7 +53,8 @@ from buildtool import (
     check_options_set,
     check_path_exists,
     raise_and_log_error,
-    ConfigError)
+    ConfigError,
+)
 
 from validate_bom__deploy import write_data_to_secure_path
 
@@ -63,1589 +64,2200 @@ from google.oauth2 import service_account
 
 
 class Configurator(object):
-  """Interface used to control hal configuration of a particular feature set."""
+    """Interface used to control hal configuration of a particular feature set."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Adds command-line arguments to control configuration."""
-    pass
+    def init_argument_parser(self, parser, defaults):
+        """Adds command-line arguments to control configuration."""
+        pass
 
-  def validate_options(self, options):
-    """Validates command-line arguments configuring feature set."""
-    pass
+    def validate_options(self, options):
+        """Validates command-line arguments configuring feature set."""
+        pass
 
-  def add_init(self, options, script):
-    """Writes bash commands to initialize feature set before Halyard.
+    def add_init(self, options, script):
+        """Writes bash commands to initialize feature set before Halyard.
 
-    This is intended for monitoring or other things that might be
-    desired before installing halyard and performing the remaining add_config.
-    """
-    pass
+        This is intended for monitoring or other things that might be
+        desired before installing halyard and performing the remaining add_config.
+        """
+        pass
 
-  def add_config(self, options, script):
-    """Writes bash commands (e.g. hal) to configure feature set."""
-    pass
+    def add_config(self, options, script):
+        """Writes bash commands (e.g. hal) to configure feature set."""
+        pass
 
-  def setup_environment(self, options):
-    """Configures external platform infrastructure."""
-    pass
+    def setup_environment(self, options):
+        """Configures external platform infrastructure."""
+        pass
 
-  def teardown_environment(self, options):
-    """Cleans up resources created in setup_environment()."""
-    pass
+    def teardown_environment(self, options):
+        """Cleans up resources created in setup_environment()."""
+        pass
 
-  def add_files_to_upload(self, options, file_set):
-    """Adds paths to local config files that should be uploaded."""
-    pass
+    def add_files_to_upload(self, options, file_set):
+        """Adds paths to local config files that should be uploaded."""
+        pass
 
 
 class AzsStorageConfiguratorHelper(Configurator):
-  """Helper class for StorageConfigurator to handle AZS."""
+    """Helper class for StorageConfigurator to handle AZS."""
 
-  @classmethod
-  def init_argument_parser(cls, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'storage_azs_account_name', defaults, None,
-        help='The name for the Azure Storage Account to use.'
-             ' This is only used if --spinnaker_storage=azs.')
-    add_parser_argument(
-        parser, 'storage_azs_credentials', defaults, None,
-        help='Path to Azure Storage Account credentials to configure'
-             'spinnaker storage. This is only used if --spinnaker_storage=azs.')
+    @classmethod
+    def init_argument_parser(cls, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "storage_azs_account_name",
+            defaults,
+            None,
+            help="The name for the Azure Storage Account to use."
+            " This is only used if --spinnaker_storage=azs.",
+        )
+        add_parser_argument(
+            parser,
+            "storage_azs_credentials",
+            defaults,
+            None,
+            help="Path to Azure Storage Account credentials to configure"
+            "spinnaker storage. This is only used if --spinnaker_storage=azs.",
+        )
 
-  @classmethod
-  def validate_options(cls, options):
-    """Implements interface."""
-    if not options.storage_azs_credentials:
-      raise ValueError('Specified --spinnaker_storage="azs"'
-                       ' but not --storage_azs_credentials')
+    @classmethod
+    def validate_options(cls, options):
+        """Implements interface."""
+        if not options.storage_azs_credentials:
+            raise ValueError(
+                'Specified --spinnaker_storage="azs"'
+                " but not --storage_azs_credentials"
+            )
 
-  @classmethod
-  def add_files_to_upload(cls, options, file_set):
-    """Implements interface."""
-    file_set.add(options.storage_azs_credentials)
+    @classmethod
+    def add_files_to_upload(cls, options, file_set):
+        """Implements interface."""
+        file_set.add(options.storage_azs_credentials)
 
-  @classmethod
-  def add_config(cls, options, script):
-    """Implements interface."""
-    script.append(
-        'AZS_PASSWORD=$(cat {file})'
-        .format(file=os.path.basename(options.storage_azs_credentials)))
-    hal = (
-        'hal -q --log=info config storage azs edit'
-        ' --storage-account-name {name}'
-        ' --storage-account-key "$AZS_PASSWORD"'
-        .format(name=options.storage_azs_account_name))
-    script.append(hal)
+    @classmethod
+    def add_config(cls, options, script):
+        """Implements interface."""
+        script.append(
+            "AZS_PASSWORD=$(cat {file})".format(
+                file=os.path.basename(options.storage_azs_credentials)
+            )
+        )
+        hal = (
+            "hal -q --log=info config storage azs edit"
+            " --storage-account-name {name}"
+            ' --storage-account-key "$AZS_PASSWORD"'.format(
+                name=options.storage_azs_account_name
+            )
+        )
+        script.append(hal)
 
 
 class S3StorageConfiguratorHelper(Configurator):
-  """Helper class for StorageConfigurator to handle S3."""
+    """Helper class for StorageConfigurator to handle S3."""
 
-  REGIONS = ['us-east-2', 'us-east-1', 'us-west-1', 'us-west-2',
-             'ca-central-1',
-             'ap-south-1', 'ap-northeast-2', 'ap-southeast-1',
-             'ap-southeast-2', 'ap-northeast-1',
-             'eu-central-1', 'eu-west-1', 'eu-west-2', 'sa-east-1']
+    REGIONS = [
+        "us-east-2",
+        "us-east-1",
+        "us-west-1",
+        "us-west-2",
+        "ca-central-1",
+        "ap-south-1",
+        "ap-northeast-2",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-northeast-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "sa-east-1",
+    ]
 
-  @classmethod
-  def init_argument_parser(cls, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'storage_s3_bucket', defaults, None,
-        help='The name for the AWS S3 bucket to use.'
-             ' This is only used if --spinnaker_storage=s3.')
-    add_parser_argument(
-        parser, 'storage_s3_assume_role', defaults, 'role/spinnakerManaged',
-        help='Use AWS SecurityToken Service to assume this role.')
+    @classmethod
+    def init_argument_parser(cls, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "storage_s3_bucket",
+            defaults,
+            None,
+            help="The name for the AWS S3 bucket to use."
+            " This is only used if --spinnaker_storage=s3.",
+        )
+        add_parser_argument(
+            parser,
+            "storage_s3_assume_role",
+            defaults,
+            "role/spinnakerManaged",
+            help="Use AWS SecurityToken Service to assume this role.",
+        )
 
-    add_parser_argument(
-        parser, 'storage_s3_region', defaults, None, choices=cls.REGIONS,
-        help='The name for the AWS region to create the bucket in.'
-             ' This is only used if the bucket does not already exist.')
+        add_parser_argument(
+            parser,
+            "storage_s3_region",
+            defaults,
+            None,
+            choices=cls.REGIONS,
+            help="The name for the AWS region to create the bucket in."
+            " This is only used if the bucket does not already exist.",
+        )
 
-    add_parser_argument(
-        parser, 'storage_s3_endpoint', defaults, None,
-        help='The s3 endpoint.')
+        add_parser_argument(
+            parser, "storage_s3_endpoint", defaults, None, help="The s3 endpoint."
+        )
 
-    add_parser_argument(
-        parser, 'storage_s3_access_key_id', defaults, None,
-        help='AWS Access Key ID for AWS account owning s3 storage.')
-    add_parser_argument(
-        parser, 'storage_s3_credentials', defaults, None,
-        help='Path to file containing the secret access key for the S3 account')
+        add_parser_argument(
+            parser,
+            "storage_s3_access_key_id",
+            defaults,
+            None,
+            help="AWS Access Key ID for AWS account owning s3 storage.",
+        )
+        add_parser_argument(
+            parser,
+            "storage_s3_credentials",
+            defaults,
+            None,
+            help="Path to file containing the secret access key for the S3 account",
+        )
 
-  @classmethod
-  def validate_options(cls, options):
-    """Implements interface."""
-    if not options.storage_s3_credentials:
-      raise ValueError('--storage_s3_credentials is required.')
+    @classmethod
+    def validate_options(cls, options):
+        """Implements interface."""
+        if not options.storage_s3_credentials:
+            raise ValueError("--storage_s3_credentials is required.")
 
-    if not options.storage_s3_access_key_id:
-      raise ValueError('--storage_s3_access_key_id is required.')
+        if not options.storage_s3_access_key_id:
+            raise ValueError("--storage_s3_access_key_id is required.")
 
-    if not options.storage_s3_region:
-      raise ValueError('--storage_s3_region is required.')
+        if not options.storage_s3_region:
+            raise ValueError("--storage_s3_region is required.")
 
-  @classmethod
-  def add_files_to_upload(cls, options, file_set):
-    """Implements interface."""
-    if options.storage_s3_credentials:
-      file_set.add(options.storage_s3_credentials)
+    @classmethod
+    def add_files_to_upload(cls, options, file_set):
+        """Implements interface."""
+        if options.storage_s3_credentials:
+            file_set.add(options.storage_s3_credentials)
 
-  @classmethod
-  def add_config(cls, options, script):
-    """Implements interface."""
-    command = ['hal -q --log=info config storage s3 edit']
-    if options.storage_s3_access_key_id:
-      command.extend(['--access-key-id', options.storage_s3_access_key_id])
-    if options.storage_s3_bucket:
-      command.extend(['--bucket', options.storage_s3_bucket])
-    if options.storage_s3_assume_role:
-      command.extend(['--assume-role', options.storage_s3_assume_role])
-    if options.storage_s3_region:
-      command.extend(['--region', options.storage_s3_region])
-    if options.storage_s3_endpoint:
-      command.extend(['--endpoint', options.storage_s3_endpoint])
-    if options.storage_s3_credentials:
-      command.extend(['--secret-access-key < {file}'.format(
-          file=os.path.basename(options.storage_s3_credentials))])
+    @classmethod
+    def add_config(cls, options, script):
+        """Implements interface."""
+        command = ["hal -q --log=info config storage s3 edit"]
+        if options.storage_s3_access_key_id:
+            command.extend(["--access-key-id", options.storage_s3_access_key_id])
+        if options.storage_s3_bucket:
+            command.extend(["--bucket", options.storage_s3_bucket])
+        if options.storage_s3_assume_role:
+            command.extend(["--assume-role", options.storage_s3_assume_role])
+        if options.storage_s3_region:
+            command.extend(["--region", options.storage_s3_region])
+        if options.storage_s3_endpoint:
+            command.extend(["--endpoint", options.storage_s3_endpoint])
+        if options.storage_s3_credentials:
+            command.extend(
+                [
+                    "--secret-access-key < {file}".format(
+                        file=os.path.basename(options.storage_s3_credentials)
+                    )
+                ]
+            )
 
-    script.append(' '.join(command))
+        script.append(" ".join(command))
 
 
 class GcsArtifactStorageConfiguratorHelper(Configurator):
-  """Helper class for ArtifactConfigurator to handle GCS."""
+    """Helper class for ArtifactConfigurator to handle GCS."""
 
-  @classmethod
-  def init_argument_parser(cls, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'artifact_gcs_bucket', defaults, None,
-        help='The name of the bucket to create.')
-    add_parser_argument(
-        parser, 'artifact_gcs_project', defaults, None,
-        help='The name of the project the bucket to create lives in.')
-    add_parser_argument(
-        parser, 'artifact_gcs_credentials', defaults, None,
-        help='Path to google credentials file to configure spinnaker'
-             ' artifact storage.')
-    add_parser_argument(
-        parser, 'artifact_gcs_account_name', defaults, None,
-        help='Account name to use for artifact downloads.')
+    @classmethod
+    def init_argument_parser(cls, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "artifact_gcs_bucket",
+            defaults,
+            None,
+            help="The name of the bucket to create.",
+        )
+        add_parser_argument(
+            parser,
+            "artifact_gcs_project",
+            defaults,
+            None,
+            help="The name of the project the bucket to create lives in.",
+        )
+        add_parser_argument(
+            parser,
+            "artifact_gcs_credentials",
+            defaults,
+            None,
+            help="Path to google credentials file to configure spinnaker"
+            " artifact storage.",
+        )
+        add_parser_argument(
+            parser,
+            "artifact_gcs_account_name",
+            defaults,
+            None,
+            help="Account name to use for artifact downloads.",
+        )
 
-  @classmethod
-  def validate_options(cls, options):
-    """Implements interface."""
-    pass
+    @classmethod
+    def validate_options(cls, options):
+        """Implements interface."""
+        pass
 
-  @classmethod
-  def add_files_to_upload(cls, options, file_set):
-    """Implements interface."""
-    if options.artifact_gcs_credentials:
-      file_set.add(options.artifact_gcs_credentials)
+    @classmethod
+    def add_files_to_upload(cls, options, file_set):
+        """Implements interface."""
+        if options.artifact_gcs_credentials:
+            file_set.add(options.artifact_gcs_credentials)
 
-  @classmethod
-  def add_config(cls, options, script):
-    """Implements interface."""
-    if options.artifact_gcs_account_name is not None:
-      script.append('hal -q --log=info config artifact gcs enable')
-      hal = (
-          'hal -q --log=info config artifact gcs account add {name}'
-          .format(name=options.artifact_gcs_account_name))
-      if options.artifact_gcs_credentials:
-        hal += (' --json-path ' + os.path.basename(
-                    options.artifact_gcs_credentials))
-      script.append(hal)
+    @classmethod
+    def add_config(cls, options, script):
+        """Implements interface."""
+        if options.artifact_gcs_account_name is not None:
+            script.append("hal -q --log=info config artifact gcs enable")
+            hal = "hal -q --log=info config artifact gcs account add {name}".format(
+                name=options.artifact_gcs_account_name
+            )
+            if options.artifact_gcs_credentials:
+                hal += " --json-path " + os.path.basename(
+                    options.artifact_gcs_credentials
+                )
+            script.append(hal)
 
-  @staticmethod
-  def __instantiate_client(options):
-    """Instantiates and returns storage client.
-    """
-    scopes = [
-        'https://www.googleapis.com/auth/devstorage.full_control',
-        'https://www.googleapis.com/auth/cloud-platform',
-    ]
-    credentials = service_account.Credentials.from_service_account_file(
-        options.artifact_gcs_credentials,
-        scopes=scopes)
-    storage_client = storage.Client(credentials=credentials,
-                                    project=options.artifact_gcs_project)
-    return storage_client
+    @staticmethod
+    def __instantiate_client(options):
+        """Instantiates and returns storage client."""
+        scopes = [
+            "https://www.googleapis.com/auth/devstorage.full_control",
+            "https://www.googleapis.com/auth/cloud-platform",
+        ]
+        credentials = service_account.Credentials.from_service_account_file(
+            options.artifact_gcs_credentials, scopes=scopes
+        )
+        storage_client = storage.Client(
+            credentials=credentials, project=options.artifact_gcs_project
+        )
+        return storage_client
 
-  @classmethod
-  def setup_environment(cls, options):
-    """Implements interface."""
-    if options.artifact_gcs_bucket is None:
-      return
+    @classmethod
+    def setup_environment(cls, options):
+        """Implements interface."""
+        if options.artifact_gcs_bucket is None:
+            return
 
-    storage_client = GcsArtifactStorageConfiguratorHelper.__instantiate_client(options)
-    if storage_client.lookup_bucket(options.artifact_gcs_bucket) is None:
-      created_bucket = storage_client.create_bucket(options.artifact_gcs_bucket)
-      logging.debug('Created bucket for Artifact storage: %s', created_bucket)
+        storage_client = GcsArtifactStorageConfiguratorHelper.__instantiate_client(
+            options
+        )
+        if storage_client.lookup_bucket(options.artifact_gcs_bucket) is None:
+            created_bucket = storage_client.create_bucket(options.artifact_gcs_bucket)
+            logging.debug("Created bucket for Artifact storage: %s", created_bucket)
 
-  @classmethod
-  def teardown_environment(cls, options):
-    """Implements interface."""
-    if options.artifact_gcs_bucket is None:
-      return
+    @classmethod
+    def teardown_environment(cls, options):
+        """Implements interface."""
+        if options.artifact_gcs_bucket is None:
+            return
 
-    storage_client = GcsArtifactStorageConfiguratorHelper.__instantiate_client(options)
-    bucket = storage_client.lookup_bucket(options.artifact_gcs_bucket)
-    if bucket is not None:
-      bucket.delete(force=True)
-      logging.debug('Deleted bucket for Artifact storage: %s', bucket)
+        storage_client = GcsArtifactStorageConfiguratorHelper.__instantiate_client(
+            options
+        )
+        bucket = storage_client.lookup_bucket(options.artifact_gcs_bucket)
+        if bucket is not None:
+            bucket.delete(force=True)
+            logging.debug("Deleted bucket for Artifact storage: %s", bucket)
 
 
 class GcsStorageConfiguratorHelper(Configurator):
-  """Helper class for StorageConfigurator to handle GCS."""
+    """Helper class for StorageConfigurator to handle GCS."""
 
-  LOCATIONS = [
-      # multi-regional bucket
-      'us', 'eu', 'ap',
+    LOCATIONS = [
+        # multi-regional bucket
+        "us",
+        "eu",
+        "ap",
+        # regional bucket
+        "us-central1",
+        "us-east1",
+        "us-west1",
+        "us-east4",
+        "europe-west1",
+        "asia-east1",
+        "asia-northeast1",
+        "asia-southeast1",
+    ]
 
-      # regional bucket
-      'us-central1', 'us-east1', 'us-west1', 'us-east4',
-      'europe-west1',
-      'asia-east1', 'asia-northeast1', 'asia-southeast1'
-  ]
+    @classmethod
+    def init_argument_parser(cls, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "storage_gcs_bucket",
+            defaults,
+            None,
+            help=(
+                "URI for specific Google Storage bucket to use."
+                " This is suggested if using gcs storage, though can be left"
+                " empty to let Halyard create one."
+            ),
+        )
+        add_parser_argument(
+            parser,
+            "storage_gcs_location",
+            defaults,
+            "us-central1",
+            choices=cls.LOCATIONS,
+            help=("Location for the bucket if it needs to be created."),
+        )
+        add_parser_argument(
+            parser,
+            "storage_gcs_project",
+            defaults,
+            None,
+            help=(
+                "URI for specific Google Storage bucket project to use."
+                " If empty, use the --deploy_google_project."
+            ),
+        )
+        add_parser_argument(
+            parser,
+            "storage_gcs_credentials",
+            defaults,
+            None,
+            help="Path to google credentials file to configure spinnaker storage."
+            " This is only used if --spinnaker_storage=gcs."
+            " If left empty then use application default credentials.",
+        )
 
-  @classmethod
-  def init_argument_parser(cls, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'storage_gcs_bucket', defaults, None,
-        help=('URI for specific Google Storage bucket to use.'
-              ' This is suggested if using gcs storage, though can be left'
-              ' empty to let Halyard create one.'))
-    add_parser_argument(
-        parser, 'storage_gcs_location', defaults, 'us-central1',
-        choices=cls.LOCATIONS,
-        help=('Location for the bucket if it needs to be created.'))
-    add_parser_argument(
-        parser, 'storage_gcs_project', defaults, None,
-        help=('URI for specific Google Storage bucket project to use.'
-              ' If empty, use the --deploy_google_project.'))
-    add_parser_argument(
-        parser, 'storage_gcs_credentials', defaults, None,
-        help='Path to google credentials file to configure spinnaker storage.'
-             ' This is only used if --spinnaker_storage=gcs.'
-             ' If left empty then use application default credentials.')
+    @classmethod
+    def validate_options(cls, options):
+        """Implements interface."""
+        if not options.storage_gcs_bucket:
+            raise ValueError(
+                'Specified --spinnaker_storage="gcs"' " but not --storage_gcs_bucket"
+            )
 
-  @classmethod
-  def validate_options(cls, options):
-    """Implements interface."""
-    if not options.storage_gcs_bucket:
-      raise ValueError('Specified --spinnaker_storage="gcs"'
-                       ' but not --storage_gcs_bucket')
+    @classmethod
+    def add_files_to_upload(cls, options, file_set):
+        """Implements interface."""
+        if options.storage_gcs_credentials:
+            file_set.add(options.storage_gcs_credentials)
 
-  @classmethod
-  def add_files_to_upload(cls, options, file_set):
-    """Implements interface."""
-    if options.storage_gcs_credentials:
-      file_set.add(options.storage_gcs_credentials)
-
-  @classmethod
-  def add_config(cls, options, script):
-    """Implements interface."""
-    project = options.storage_gcs_project or options.deploy_google_project
-    hal = (
-        'hal -q --log=info config storage gcs edit'
-        ' --project {project}'
-        ' --bucket {bucket}'
-        ' --bucket-location {location}'
-        .format(project=project,
+    @classmethod
+    def add_config(cls, options, script):
+        """Implements interface."""
+        project = options.storage_gcs_project or options.deploy_google_project
+        hal = (
+            "hal -q --log=info config storage gcs edit"
+            " --project {project}"
+            " --bucket {bucket}"
+            " --bucket-location {location}".format(
+                project=project,
                 bucket=options.storage_gcs_bucket,
-                location=options.storage_gcs_location))
-    if options.storage_gcs_credentials:
-      hal += (' --json-path ./{filename}'
-              .format(filename=os.path.basename(
-                  options.storage_gcs_credentials)))
-    script.append(hal)
+                location=options.storage_gcs_location,
+            )
+        )
+        if options.storage_gcs_credentials:
+            hal += " --json-path ./{filename}".format(
+                filename=os.path.basename(options.storage_gcs_credentials)
+            )
+        script.append(hal)
 
 
 class ArtifactConfigurator(Configurator):
-  """Controls hal config artifact for Spinnaker artifact ."""
+    """Controls hal config artifact for Spinnaker artifact ."""
 
-  HELPERS = [
-      GcsArtifactStorageConfiguratorHelper,
-  ]
+    HELPERS = [
+        GcsArtifactStorageConfiguratorHelper,
+    ]
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    for helper in self.HELPERS:
-      helper.init_argument_parser(parser, defaults)
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        for helper in self.HELPERS:
+            helper.init_argument_parser(parser, defaults)
 
-  def validate_options(self, options):
-    """Implements interface."""
-    for helper in self.HELPERS:
-      helper.validate_options(options)
+    def validate_options(self, options):
+        """Implements interface."""
+        for helper in self.HELPERS:
+            helper.validate_options(options)
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    for helper in self.HELPERS:
-      helper.add_files_to_upload(options, file_set)
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        for helper in self.HELPERS:
+            helper.add_files_to_upload(options, file_set)
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    for helper in self.HELPERS:
-      helper.add_config(options, script)
+    def add_config(self, options, script):
+        """Implements interface."""
+        for helper in self.HELPERS:
+            helper.add_config(options, script)
 
-  def setup_environment(self, options):
-    """Implements interface."""
-    for helper in self.HELPERS:
-      helper.setup_environment(options)
+    def setup_environment(self, options):
+        """Implements interface."""
+        for helper in self.HELPERS:
+            helper.setup_environment(options)
 
-  def teardown_environment(self, options):
-    """Implements interface."""
-    for helper in self.HELPERS:
-      helper.teardown_environment(options)
+    def teardown_environment(self, options):
+        """Implements interface."""
+        for helper in self.HELPERS:
+            helper.teardown_environment(options)
 
 
 class StorageConfigurator(Configurator):
-  """Controls hal config storage for Spinnaker Storage ."""
+    """Controls hal config storage for Spinnaker Storage ."""
 
-  HELPERS = {
-      'azs': AzsStorageConfiguratorHelper,
-      'gcs': GcsStorageConfiguratorHelper,
-      's3': S3StorageConfiguratorHelper
-  }
+    HELPERS = {
+        "azs": AzsStorageConfiguratorHelper,
+        "gcs": GcsStorageConfiguratorHelper,
+        "s3": S3StorageConfiguratorHelper,
+    }
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'spinnaker_storage',
-        defaults, None,
-        choices=self.HELPERS.keys(),
-        help='The storage type to configure.')
-    for helper in self.HELPERS.values():
-      helper.init_argument_parser(parser, defaults)
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "spinnaker_storage",
+            defaults,
+            None,
+            choices=self.HELPERS.keys(),
+            help="The storage type to configure.",
+        )
+        for helper in self.HELPERS.values():
+            helper.init_argument_parser(parser, defaults)
 
-  def validate_options(self, options):
-    """Implements interface."""
-    helper = self.HELPERS.get(options.spinnaker_storage, None)
-    if helper is None:
-      raise ValueError('Unknown --spinnaker_storage="{0}"'
-                       .format(options.spinnaker_storage))
-    helper.validate_options(options)
+    def validate_options(self, options):
+        """Implements interface."""
+        helper = self.HELPERS.get(options.spinnaker_storage, None)
+        if helper is None:
+            raise ValueError(
+                'Unknown --spinnaker_storage="{0}"'.format(options.spinnaker_storage)
+            )
+        helper.validate_options(options)
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    helper = self.HELPERS.get(options.spinnaker_storage, None)
-    if helper is None:
-      raise ValueError('Unknown --spinnaker_storage="{0}"'
-                       .format(options.spinnaker_storage))
-    helper.add_files_to_upload(options, file_set)
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        helper = self.HELPERS.get(options.spinnaker_storage, None)
+        if helper is None:
+            raise ValueError(
+                'Unknown --spinnaker_storage="{0}"'.format(options.spinnaker_storage)
+            )
+        helper.add_files_to_upload(options, file_set)
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    helper = self.HELPERS.get(options.spinnaker_storage, None)
-    if helper is None:
-      raise ValueError('Unknown --spinnaker_storage="{0}"'
-                       .format(options.spinnaker_storage))
-    helper.add_config(options, script)
-    script.append('hal -q --log=info config storage edit --type {type}'
-                  .format(type=options.spinnaker_storage))
+    def add_config(self, options, script):
+        """Implements interface."""
+        helper = self.HELPERS.get(options.spinnaker_storage, None)
+        if helper is None:
+            raise ValueError(
+                'Unknown --spinnaker_storage="{0}"'.format(options.spinnaker_storage)
+            )
+        helper.add_config(options, script)
+        script.append(
+            "hal -q --log=info config storage edit --type {type}".format(
+                type=options.spinnaker_storage
+            )
+        )
 
 
 class AwsConfigurator(Configurator):
-  """Controls hal config provider aws."""
+    """Controls hal config provider aws."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    # pylint: disable=line-too-long
-    add_parser_argument(
-        parser, 'aws_access_key_id', defaults, None,
-        help='The AWS ACCESS_KEY_ID.')
-    add_parser_argument(
-        parser, 'aws_credentials', defaults, None,
-        help='A path to a file containing the AWS SECRET_ACCESS_KEY')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        # pylint: disable=line-too-long
+        add_parser_argument(
+            parser, "aws_access_key_id", defaults, None, help="The AWS ACCESS_KEY_ID."
+        )
+        add_parser_argument(
+            parser,
+            "aws_credentials",
+            defaults,
+            None,
+            help="A path to a file containing the AWS SECRET_ACCESS_KEY",
+        )
 
-    add_parser_argument(
-        parser, 'aws_account_name', defaults, 'my-aws-account',
-        help='The name of the primary AWS account to configure.')
-    add_parser_argument(
-        parser, 'aws_account_id', defaults, None,
-        help='The AWS account id for the account.'
-             ' See http://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html')
-    add_parser_argument(
-        parser, 'aws_account_role', defaults, 'role/spinnakerManaged',
-        help=' The account will assume this role.')
+        add_parser_argument(
+            parser,
+            "aws_account_name",
+            defaults,
+            "my-aws-account",
+            help="The name of the primary AWS account to configure.",
+        )
+        add_parser_argument(
+            parser,
+            "aws_account_id",
+            defaults,
+            None,
+            help="The AWS account id for the account."
+            " See http://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html",
+        )
+        add_parser_argument(
+            parser,
+            "aws_account_role",
+            defaults,
+            "role/spinnakerManaged",
+            help=" The account will assume this role.",
+        )
 
-    add_parser_argument(
-        parser, 'aws_account_regions', defaults, 'us-east-1,us-west-2',
-        help='The AWS account regions the account will manage.')
-    add_parser_argument(
-        parser, 'aws_account_pem_path', defaults, None,
-        help='The path to the PEM file for the keypair to use.'
-             'The basename minus suffix will be the name of the keypair.')
+        add_parser_argument(
+            parser,
+            "aws_account_regions",
+            defaults,
+            "us-east-1,us-west-2",
+            help="The AWS account regions the account will manage.",
+        )
+        add_parser_argument(
+            parser,
+            "aws_account_pem_path",
+            defaults,
+            None,
+            help="The path to the PEM file for the keypair to use."
+            "The basename minus suffix will be the name of the keypair.",
+        )
 
-  def validate_options(self, options):
-    """Implements interface."""
-    options.aws_account_enabled = options.aws_access_key_id is not None
+    def validate_options(self, options):
+        """Implements interface."""
+        options.aws_account_enabled = options.aws_access_key_id is not None
 
-    if options.aws_account_enabled and not options.aws_credentials:
-      raise ValueError(
-          '--aws_access_key_id given, but not --aws_credentials')
+        if options.aws_account_enabled and not options.aws_credentials:
+            raise ValueError("--aws_access_key_id given, but not --aws_credentials")
 
-    if options.aws_account_enabled and not options.aws_account_id:
-      raise ValueError(
-          '--aws_access_key_id given, but not --aws_account_id')
+        if options.aws_account_enabled and not options.aws_account_id:
+            raise ValueError("--aws_access_key_id given, but not --aws_account_id")
 
-    if options.aws_account_enabled and not options.aws_account_role:
-      raise ValueError(
-          '--aws_access_key_id given, but not --aws_account_role')
+        if options.aws_account_enabled and not options.aws_account_role:
+            raise ValueError("--aws_access_key_id given, but not --aws_account_role")
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    if not options.aws_access_key_id:
-      return
+    def add_config(self, options, script):
+        """Implements interface."""
+        if not options.aws_access_key_id:
+            return
 
-    account_params = [options.aws_account_name,
-                      '--assume-role', options.aws_account_role,
-                      '--account-id', options.aws_account_id]
+        account_params = [
+            options.aws_account_name,
+            "--assume-role",
+            options.aws_account_role,
+            "--account-id",
+            options.aws_account_id,
+        ]
 
-    if options.aws_account_pem_path:
-      basename = os.path.basename(options.aws_account_pem_path)
-      script.append('mv {file} .ssh/'.format(file=basename))
-      account_params.extend(
-          ['--default-key-pair', os.path.splitext(basename)[0]])
-    if options.aws_account_regions:
-      account_params.extend(['--regions', options.aws_account_regions])
+        if options.aws_account_pem_path:
+            basename = os.path.basename(options.aws_account_pem_path)
+            script.append("mv {file} .ssh/".format(file=basename))
+            account_params.extend(["--default-key-pair", os.path.splitext(basename)[0]])
+        if options.aws_account_regions:
+            account_params.extend(["--regions", options.aws_account_regions])
 
-    script.append('hal -q --log=info config provider aws enable')
-    script.append(
-        'hal -q --log=info config provider aws edit '
-        ' --access-key-id {id} --secret-access-key < {file}'
-        .format(id=options.aws_access_key_id,
-                file=os.path.basename(options.aws_credentials)))
-    script.append(
-        'hal -q --log=info config provider aws account add {params}'
-        .format(params=' '.join(account_params)))
+        script.append("hal -q --log=info config provider aws enable")
+        script.append(
+            "hal -q --log=info config provider aws edit "
+            " --access-key-id {id} --secret-access-key < {file}".format(
+                id=options.aws_access_key_id,
+                file=os.path.basename(options.aws_credentials),
+            )
+        )
+        script.append(
+            "hal -q --log=info config provider aws account add {params}".format(
+                params=" ".join(account_params)
+            )
+        )
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    if options.aws_credentials:
-      file_set.add(options.aws_credentials)
-    if options.aws_account_pem_path:
-      file_set.add(options.aws_account_pem_path)
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        if options.aws_credentials:
+            file_set.add(options.aws_credentials)
+        if options.aws_account_pem_path:
+            file_set.add(options.aws_account_pem_path)
 
 
 class AppengineConfigurator(Configurator):
-  """Controls hal config provider for appengine"""
+    """Controls hal config provider for appengine"""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    # pylint: disable=line-too-long
-    add_parser_argument(
-        parser, 'appengine_account_project', defaults, None,
-        help='The Google Cloud Platform project this Spinnaker account will manage.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        # pylint: disable=line-too-long
+        add_parser_argument(
+            parser,
+            "appengine_account_project",
+            defaults,
+            None,
+            help="The Google Cloud Platform project this Spinnaker account will manage.",
+        )
 
-    add_parser_argument(
-        parser, 'appengine_account_name', defaults, 'my-appengine-account',
-        help='The name of the primary Appengine account to configure.')
-    add_parser_argument(
-        parser, 'appengine_account_credentials', defaults, None,
-        help='Path to file containing the JSON Oauth credentials for the AppEngine account.')
+        add_parser_argument(
+            parser,
+            "appengine_account_name",
+            defaults,
+            "my-appengine-account",
+            help="The name of the primary Appengine account to configure.",
+        )
+        add_parser_argument(
+            parser,
+            "appengine_account_credentials",
+            defaults,
+            None,
+            help="Path to file containing the JSON Oauth credentials for the AppEngine account.",
+        )
 
-    add_parser_argument(
-        parser, 'appengine_account_git_username', defaults, None,
-        help='The name of the remote git user.')
-    add_parser_argument(
-        parser, 'appengine_account_git_https_credentials', defaults, None,
-        help='Path to file containing the password for the remote git repository.')
-    add_parser_argument(
-        parser, 'appengine_account_git_oauth_credentials', defaults, None,
-        help='Path to file containing the password for the remote git repository.')
+        add_parser_argument(
+            parser,
+            "appengine_account_git_username",
+            defaults,
+            None,
+            help="The name of the remote git user.",
+        )
+        add_parser_argument(
+            parser,
+            "appengine_account_git_https_credentials",
+            defaults,
+            None,
+            help="Path to file containing the password for the remote git repository.",
+        )
+        add_parser_argument(
+            parser,
+            "appengine_account_git_oauth_credentials",
+            defaults,
+            None,
+            help="Path to file containing the password for the remote git repository.",
+        )
 
-    add_parser_argument(
-        parser, 'appengine_account_ssh_private_key_path', defaults, None)
-    add_parser_argument(
-        parser, 'appengine_account_ssh_private_key_passphrase', defaults, None)
+        add_parser_argument(
+            parser, "appengine_account_ssh_private_key_path", defaults, None
+        )
+        add_parser_argument(
+            parser, "appengine_account_ssh_private_key_passphrase", defaults, None
+        )
 
-    add_parser_argument(
-        parser, 'appengine_account_local_repository_directory', defaults, None)
+        add_parser_argument(
+            parser, "appengine_account_local_repository_directory", defaults, None
+        )
 
-  def validate_options(self, options):
-    """Implements interface."""
+    def validate_options(self, options):
+        """Implements interface."""
 
-    options.appengine_account_enabled = (options.appengine_account_project
-                                         is not None)
-    if not options.appengine_account_enabled:
-      return
+        options.appengine_account_enabled = (
+            options.appengine_account_project is not None
+        )
+        if not options.appengine_account_enabled:
+            return
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    if not options.appengine_account_project:
-      return
+    def add_config(self, options, script):
+        """Implements interface."""
+        if not options.appengine_account_project:
+            return
 
-    script.append('hal -q --log=info config provider appengine enable')
+        script.append("hal -q --log=info config provider appengine enable")
 
-    if options.deploy_spinnaker_type == 'localdebian':
-      script.append(
-          'hal -q --log=info config provider appengine edit --gcloudPath `which gcloud`')
+        if options.deploy_spinnaker_type == "localdebian":
+            script.append(
+                "hal -q --log=info config provider appengine edit --gcloudPath `which gcloud`"
+            )
 
-    account_params = [
-        options.appengine_account_name,
-        '--project', options.appengine_account_project
-    ]
-    if options.appengine_account_credentials:
-      account_params.extend(
-          ['--json-path',
-           os.path.basename(options.appengine_account_credentials)])
-    if options.appengine_account_local_repository_directory:
-      account_params.extend(
-          ['--local-repository-directory',
-           options.appengine_account_local_repository_directory])
-    script.append(
-        'hal -q --log=info config provider appengine account add {params}'
-        .format(params=' '.join(account_params)))
+        account_params = [
+            options.appengine_account_name,
+            "--project",
+            options.appengine_account_project,
+        ]
+        if options.appengine_account_credentials:
+            account_params.extend(
+                ["--json-path", os.path.basename(options.appengine_account_credentials)]
+            )
+        if options.appengine_account_local_repository_directory:
+            account_params.extend(
+                [
+                    "--local-repository-directory",
+                    options.appengine_account_local_repository_directory,
+                ]
+            )
+        script.append(
+            "hal -q --log=info config provider appengine account add {params}".format(
+                params=" ".join(account_params)
+            )
+        )
 
-    hal_edit = ('hal -q --log=info'
-                ' config provider appengine account edit {name}'
-                .format(name=options.appengine_account_name))
+        hal_edit = (
+            "hal -q --log=info"
+            " config provider appengine account edit {name}".format(
+                name=options.appengine_account_name
+            )
+        )
 
-    # Maybe config github
-    if options.appengine_account_git_username:
-      git_params = ['--git-https-username',
-                    options.appengine_account_git_username]
-      if options.appengine_account_git_oauth_credentials:
-        git_params.append(
-            '--github-oauth-access-token < {file}'
-            .format(
-                file=os.path.basename(
-                    options.appengine_account_git_oauth_credentials)))
-      elif options.appengine_account_git_https_credentials:
-        git_params.append(
-            '--git-https-password < {path}'
-            .format(
-                path=os.path.basename(
-                    options.appengine_account_git_https_credentials)))
-      script.append(
-          '{hal} {params}'.format(hal=hal_edit, params=' '.join(git_params)))
+        # Maybe config github
+        if options.appengine_account_git_username:
+            git_params = [
+                "--git-https-username",
+                options.appengine_account_git_username,
+            ]
+            if options.appengine_account_git_oauth_credentials:
+                git_params.append(
+                    "--github-oauth-access-token < {file}".format(
+                        file=os.path.basename(
+                            options.appengine_account_git_oauth_credentials
+                        )
+                    )
+                )
+            elif options.appengine_account_git_https_credentials:
+                git_params.append(
+                    "--git-https-password < {path}".format(
+                        path=os.path.basename(
+                            options.appengine_account_git_https_credentials
+                        )
+                    )
+                )
+            script.append(
+                "{hal} {params}".format(hal=hal_edit, params=" ".join(git_params))
+            )
 
-    # Maybe config ssh
-    if options.appengine_account_ssh_private_key_path:
-      ssh_params = ['--ssh-private-key-file-path',
-                    options.appengine_account_local_repository_directory]
-      if options.appengine_account_ssh_private_key_passphrase:
-        ssh_params.append('--ssh-private-key-passphrase < {path}'.format(
-            path=os.path.basename(
-                options.appengine_account_ssh_private_key_passphrase)))
-      script.append(
-          '{hal} {params}'.format(hal=hal_edit, params=' '.join(ssh_params)))
+        # Maybe config ssh
+        if options.appengine_account_ssh_private_key_path:
+            ssh_params = [
+                "--ssh-private-key-file-path",
+                options.appengine_account_local_repository_directory,
+            ]
+            if options.appengine_account_ssh_private_key_passphrase:
+                ssh_params.append(
+                    "--ssh-private-key-passphrase < {path}".format(
+                        path=os.path.basename(
+                            options.appengine_account_ssh_private_key_passphrase
+                        )
+                    )
+                )
+            script.append(
+                "{hal} {params}".format(hal=hal_edit, params=" ".join(ssh_params))
+            )
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    if options.appengine_account_credentials:
-      file_set.add(options.appengine_account_credentials)
-    if options.appengine_account_git_https_credentials:
-      file_set.add(options.appengine_account_git_https_credentials)
-    if options.appengine_account_git_oauth_credentials:
-      file_set.add(options.appengine_account_git_oauth_credentials)
-    if options.appengine_account_ssh_private_key_passphrase:
-      file_set.add(options.appengine_account_ssh_private_key_passphrase)
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        if options.appengine_account_credentials:
+            file_set.add(options.appengine_account_credentials)
+        if options.appengine_account_git_https_credentials:
+            file_set.add(options.appengine_account_git_https_credentials)
+        if options.appengine_account_git_oauth_credentials:
+            file_set.add(options.appengine_account_git_oauth_credentials)
+        if options.appengine_account_ssh_private_key_passphrase:
+            file_set.add(options.appengine_account_ssh_private_key_passphrase)
 
 
 class AzureConfigurator(Configurator):
-  """Controls hal config provider azure."""
+    """Controls hal config provider azure."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    # pylint: disable=line-too-long
-    add_parser_argument(
-        parser, 'azure_account_credentials', defaults, None,
-        help='Path to Azure credentials file containing the appKey'
-             ' for the service principal.')
-    add_parser_argument(
-        parser, 'azure_account_name', defaults, 'my-azure-account',
-        help='The name of the primary Azure account to configure.')
-    add_parser_argument(
-        parser, 'azure_account_client_id', defaults, None,
-        help='The Azure clientId for the service principal.')
-    add_parser_argument(
-        parser, 'azure_account_subscription_id', defaults, None,
-        help='The subscriptionId for the service principal.')
-    add_parser_argument(
-        parser, 'azure_account_tenant_id', defaults, None,
-        help='The tenantId for the service principal.')
-    add_parser_argument(
-        parser, 'azure_account_object_id', defaults, None,
-        help='The objectId of the service principal.'
-             ' Needed to bake Windows images.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        # pylint: disable=line-too-long
+        add_parser_argument(
+            parser,
+            "azure_account_credentials",
+            defaults,
+            None,
+            help="Path to Azure credentials file containing the appKey"
+            " for the service principal.",
+        )
+        add_parser_argument(
+            parser,
+            "azure_account_name",
+            defaults,
+            "my-azure-account",
+            help="The name of the primary Azure account to configure.",
+        )
+        add_parser_argument(
+            parser,
+            "azure_account_client_id",
+            defaults,
+            None,
+            help="The Azure clientId for the service principal.",
+        )
+        add_parser_argument(
+            parser,
+            "azure_account_subscription_id",
+            defaults,
+            None,
+            help="The subscriptionId for the service principal.",
+        )
+        add_parser_argument(
+            parser,
+            "azure_account_tenant_id",
+            defaults,
+            None,
+            help="The tenantId for the service principal.",
+        )
+        add_parser_argument(
+            parser,
+            "azure_account_object_id",
+            defaults,
+            None,
+            help="The objectId of the service principal."
+            " Needed to bake Windows images.",
+        )
 
-    add_parser_argument(
-        parser, 'azure_account_default_key_vault', defaults, None,
-        help='The name of the KeyValue containing the default user/password'
-             ' to create VMs.')
-    add_parser_argument(
-        parser, 'azure_account_default_resource_group', defaults, None,
-        help='The default for non-application specific resources.')
-    add_parser_argument(
-        parser, 'azure_account_packer_resource_group', defaults, None,
-        help='Used by packer when baking images.')
-    add_parser_argument(
-        parser, 'azure_account_packer_storage_account', defaults, None,
-        help='The storage account ot use if baking images with packer.')
+        add_parser_argument(
+            parser,
+            "azure_account_default_key_vault",
+            defaults,
+            None,
+            help="The name of the KeyValue containing the default user/password"
+            " to create VMs.",
+        )
+        add_parser_argument(
+            parser,
+            "azure_account_default_resource_group",
+            defaults,
+            None,
+            help="The default for non-application specific resources.",
+        )
+        add_parser_argument(
+            parser,
+            "azure_account_packer_resource_group",
+            defaults,
+            None,
+            help="Used by packer when baking images.",
+        )
+        add_parser_argument(
+            parser,
+            "azure_account_packer_storage_account",
+            defaults,
+            None,
+            help="The storage account ot use if baking images with packer.",
+        )
 
+    def validate_options(self, options):
+        """Implements interface."""
+        options.azure_account_enabled = (
+            options.azure_account_subscription_id is not None
+        )
+        if not options.azure_account_enabled:
+            return
 
-  def validate_options(self, options):
-    """Implements interface."""
-    options.azure_account_enabled = (options.azure_account_subscription_id
-                                     is not None)
-    if not options.azure_account_enabled:
-      return
+        if (options.azure_account_packer_resource_group != None) != (
+            options.azure_account_packer_storage_account != None
+        ):
+            raise ValueError(
+                "--azure_account_packer_resource_group"
+                " and --azure_account_packer_storage_account"
+                " must either both be set or neither be set."
+            )
 
-    if ((options.azure_account_packer_resource_group != None)
-        != (options.azure_account_packer_storage_account != None)):
-      raise ValueError(
-          '--azure_account_packer_resource_group'
-          ' and --azure_account_packer_storage_account'
-          ' must either both be set or neither be set.')
+        for name in [
+            "client_id",
+            "credentials",
+            "subscription_id",
+            "tenant_id",
+            "default_key_vault",
+            "default_resource_group",
+        ]:
+            key = "azure_account_" + name
+            if not getattr(options, key):
+                raise ValueError(
+                    "--{0} is required with --azure_account_subscription_id.".format(
+                        key
+                    )
+                )
 
-    for name in ['client_id', 'credentials', 'subscription_id', 'tenant_id',
-                 'default_key_vault', 'default_resource_group']:
-      key = 'azure_account_' + name
-      if not getattr(options, key):
-        raise ValueError(
-            '--{0} is required with --azure_account_subscription_id.'
-            .format(key))
+    def add_config(self, options, script):
+        """Implements interface."""
+        if not options.azure_account_credentials:
+            return
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    if not options.azure_account_credentials:
-      return
+        account_params = [
+            options.azure_account_name,
+            "--client-id",
+            options.azure_account_client_id,
+            "--default-key-vault",
+            options.azure_account_default_key_vault,
+            "--default-resource-group",
+            options.azure_account_default_resource_group,
+            "--subscription-id",
+            options.azure_account_subscription_id,
+            "--tenant-id",
+            options.azure_account_tenant_id,
+        ]
+        if options.azure_account_object_id:
+            account_params.extend(["--object-id", options.azure_account_object_id])
+        if options.azure_account_packer_resource_group:
+            account_params.extend(
+                ["--packer-resource-group", options.azure_account_packer_resource_group]
+            )
+        if options.azure_account_packer_storage_account:
+            account_params.extend(
+                [
+                    "--packer-storage-account",
+                    options.azure_account_packer_storage_account,
+                ]
+            )
 
-    account_params = [
-        options.azure_account_name,
-        '--client-id', options.azure_account_client_id,
-        '--default-key-vault', options.azure_account_default_key_vault,
-        '--default-resource-group',
-        options.azure_account_default_resource_group,
-        '--subscription-id', options.azure_account_subscription_id,
-        '--tenant-id', options.azure_account_tenant_id
-    ]
-    if options.azure_account_object_id:
-      account_params.extend(['--object-id', options.azure_account_object_id])
-    if options.azure_account_packer_resource_group:
-      account_params.extend(['--packer-resource-group',
-                             options.azure_account_packer_resource_group])
-    if options.azure_account_packer_storage_account:
-      account_params.extend(['--packer-storage-account',
-                             options.azure_account_packer_storage_account])
+        script.append("hal -q --log=info config provider azure enable")
+        script.append(
+            "hal -q --log=info config provider azure account add {params}"
+            " --app-key < {creds}".format(
+                params=" ".join(account_params),
+                creds=os.path.basename(options.azure_account_credentials),
+            )
+        )
 
-    script.append('hal -q --log=info config provider azure enable')
-    script.append(
-        'hal -q --log=info config provider azure account add {params}'
-        ' --app-key < {creds}'
-        .format(params=' '.join(account_params),
-                creds=os.path.basename(options.azure_account_credentials)))
-
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    if options.azure_account_credentials:
-      file_set.add(options.azure_account_credentials)
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        if options.azure_account_credentials:
+            file_set.add(options.azure_account_credentials)
 
 
 class DcosConfigurator(Configurator):
-  """Controls hal config provider DC/OS."""
+    """Controls hal config provider DC/OS."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    # pylint: disable=line-too-long
-    add_parser_argument(
-        parser, 'dcos_cluster_name', defaults, 'my-dcos-cluster',
-        help='The name for the primary DC/OS cluster.')
-    add_parser_argument(
-        parser, 'dcos_cluster_url', defaults, None,
-        help='The URL to the primary DC/OS cluster.'
-             ' This is required to enable DC/OS')
-    add_parser_argument(
-        parser, 'dcos_account_name', defaults, 'my-dcos-account',
-        help='The name of the primary DC/OS account to configure.')
-    add_parser_argument(
-        parser, 'dcos_account_docker_account', defaults, None,
-        help='The registered docker account name to use.')
-    add_parser_argument(
-        parser, 'dcos_account_uid', defaults, None,
-        help='The DC/OS account user name the service principal.'
-             'This is required if DC/OS is enabled.')
-    add_parser_argument(
-        parser, 'dcos_account_credentials', defaults, None,
-        help='Path to DC/oS credentials file containing the password'
-             ' for the uid. This is required if DC/OS is enabled.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        # pylint: disable=line-too-long
+        add_parser_argument(
+            parser,
+            "dcos_cluster_name",
+            defaults,
+            "my-dcos-cluster",
+            help="The name for the primary DC/OS cluster.",
+        )
+        add_parser_argument(
+            parser,
+            "dcos_cluster_url",
+            defaults,
+            None,
+            help="The URL to the primary DC/OS cluster."
+            " This is required to enable DC/OS",
+        )
+        add_parser_argument(
+            parser,
+            "dcos_account_name",
+            defaults,
+            "my-dcos-account",
+            help="The name of the primary DC/OS account to configure.",
+        )
+        add_parser_argument(
+            parser,
+            "dcos_account_docker_account",
+            defaults,
+            None,
+            help="The registered docker account name to use.",
+        )
+        add_parser_argument(
+            parser,
+            "dcos_account_uid",
+            defaults,
+            None,
+            help="The DC/OS account user name the service principal."
+            "This is required if DC/OS is enabled.",
+        )
+        add_parser_argument(
+            parser,
+            "dcos_account_credentials",
+            defaults,
+            None,
+            help="Path to DC/oS credentials file containing the password"
+            " for the uid. This is required if DC/OS is enabled.",
+        )
 
-  def validate_options(self, options):
-    """Implements interface."""
-    options.dcos_account_enabled = (options.dcos_cluster_url is not None)
-    if not options.dcos_account_enabled:
-      return
+    def validate_options(self, options):
+        """Implements interface."""
+        options.dcos_account_enabled = options.dcos_cluster_url is not None
+        if not options.dcos_account_enabled:
+            return
 
-    if options.dcos_account_uid is None:
-      raise ValueError('--dcos_account_uid is not set')
-    if options.dcos_account_credentials is None:
-      raise ValueError('--dcos_account_uid provided without credentials')
-    if options.dcos_account_docker_account is None:
-      raise ValueError('--dcos_account_docker_account is not set')
+        if options.dcos_account_uid is None:
+            raise ValueError("--dcos_account_uid is not set")
+        if options.dcos_account_credentials is None:
+            raise ValueError("--dcos_account_uid provided without credentials")
+        if options.dcos_account_docker_account is None:
+            raise ValueError("--dcos_account_docker_account is not set")
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    if not options.dcos_account_enabled:
-      return
+    def add_config(self, options, script):
+        """Implements interface."""
+        if not options.dcos_account_enabled:
+            return
 
-    script.append(
-        'hal -q --log=info config provider dcos cluster add'
-        ' {name} --dcos-url {url} --skip-tls-verify'
-        .format(name=options.dcos_cluster_name,
-                url=options.dcos_cluster_url))
+        script.append(
+            "hal -q --log=info config provider dcos cluster add"
+            " {name} --dcos-url {url} --skip-tls-verify".format(
+                name=options.dcos_cluster_name, url=options.dcos_cluster_url
+            )
+        )
 
-    script.append('hal -q --log=info config provider dcos enable')
-    with open(options.dcos_account_credentials) as creds:
-      script.append(
-          'hal -q --log=info config provider dcos account add'
-          ' {name}'
-          ' --cluster {cluster}'
-          ' --docker-registries {docker}'
-          ' --uid {uid}'
-          ' --password {creds}'
-          .format(name=options.dcos_account_name,
-                  cluster=options.dcos_cluster_name,
-                  docker=options.dcos_account_docker_account,
-                  uid=options.dcos_account_uid,
-                  creds=creds.read()))
+        script.append("hal -q --log=info config provider dcos enable")
+        with open(options.dcos_account_credentials) as creds:
+            script.append(
+                "hal -q --log=info config provider dcos account add"
+                " {name}"
+                " --cluster {cluster}"
+                " --docker-registries {docker}"
+                " --uid {uid}"
+                " --password {creds}".format(
+                    name=options.dcos_account_name,
+                    cluster=options.dcos_cluster_name,
+                    docker=options.dcos_account_docker_account,
+                    uid=options.dcos_account_uid,
+                    creds=creds.read(),
+                )
+            )
 
 
 class GoogleConfigurator(Configurator):
-  """Controls hal config provider google."""
+    """Controls hal config provider google."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'google_account_project', defaults, None,
-        help='Google project to deploy to if --host_platform is gce.')
-    add_parser_argument(
-        parser, 'google_account_credentials', defaults, None,
-        help='Path to google credentials file for the google account.'
-             'Adding credentials enables the account.')
-    add_parser_argument(
-        parser, 'google_account_name', defaults, 'my-google-account',
-        help='The name of the primary google account to configure.')
-    add_parser_argument(
-        parser, 'google_account_regions', defaults, None,
-        help='The Google Cloud regions this account should manage.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "google_account_project",
+            defaults,
+            None,
+            help="Google project to deploy to if --host_platform is gce.",
+        )
+        add_parser_argument(
+            parser,
+            "google_account_credentials",
+            defaults,
+            None,
+            help="Path to google credentials file for the google account."
+            "Adding credentials enables the account.",
+        )
+        add_parser_argument(
+            parser,
+            "google_account_name",
+            defaults,
+            "my-google-account",
+            help="The name of the primary google account to configure.",
+        )
+        add_parser_argument(
+            parser,
+            "google_account_regions",
+            defaults,
+            None,
+            help="The Google Cloud regions this account should manage.",
+        )
 
-  def validate_options(self, options):
-    """Implements interface."""
-    options.google_account_enabled = (
-        options.google_account_project is not None)
+    def validate_options(self, options):
+        """Implements interface."""
+        options.google_account_enabled = options.google_account_project is not None
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    if not options.google_account_credentials:
-      return
+    def add_config(self, options, script):
+        """Implements interface."""
+        if not options.google_account_credentials:
+            return
 
-    if not options.google_account_project:
-      raise ValueError(
-          '--google_account_credentials without --google_account_project')
+        if not options.google_account_project:
+            raise ValueError(
+                "--google_account_credentials without --google_account_project"
+            )
 
-    account_params = [options.google_account_name]
-    account_params.extend([
-        '--project', options.google_account_project,
-        '--json-path', os.path.basename(options.google_account_credentials)])
+        account_params = [options.google_account_name]
+        account_params.extend(
+            [
+                "--project",
+                options.google_account_project,
+                "--json-path",
+                os.path.basename(options.google_account_credentials),
+            ]
+        )
 
-    if options.google_account_regions:
-      account_params.extend([
-        '--regions', options.google_account_regions])
+        if options.google_account_regions:
+            account_params.extend(["--regions", options.google_account_regions])
 
-    script.append('hal -q --log=info config provider google enable')
-    if options.deploy_google_zone:
-      script.append('hal -q --log=info config provider google bakery edit'
-                    ' --zone {zone}'.format(zone=options.deploy_google_zone))
-    script.append(
-        'hal -q --log=info config provider google account add {params}'
-        .format(params=' '.join(account_params)))
+        script.append("hal -q --log=info config provider google enable")
+        if options.deploy_google_zone:
+            script.append(
+                "hal -q --log=info config provider google bakery edit"
+                " --zone {zone}".format(zone=options.deploy_google_zone)
+            )
+        script.append(
+            "hal -q --log=info config provider google account add {params}".format(
+                params=" ".join(account_params)
+            )
+        )
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    if options.google_account_credentials:
-      file_set.add(options.google_account_credentials)
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        if options.google_account_credentials:
+            file_set.add(options.google_account_credentials)
+
 
 class KubernetesV2Configurator(Configurator):
-  """Controls hal config provider kubernetes (for v2 accounts)."""
+    """Controls hal config provider kubernetes (for v2 accounts)."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'k8s_v2_account_credentials', defaults, None,
-        help='Path to k8s credentials file.')
-    add_parser_argument(
-        parser, 'k8s_v2_account_name', defaults, 'my-kubernetes-v2-account',
-        help='The name of the primary Kubernetes account to configure.')
-    add_parser_argument(
-        parser, 'k8s_v2_account_context', defaults, None,
-        help='The kubernetes context for the primary Kubernetes v2 account.')
-    add_parser_argument(
-        parser, 'k8s_v2_account_namespaces', defaults, 'validate-bom',
-        help='The kubernetes namespaces for the primary Kubernetes v2 account.'
-    )
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "k8s_v2_account_credentials",
+            defaults,
+            None,
+            help="Path to k8s credentials file.",
+        )
+        add_parser_argument(
+            parser,
+            "k8s_v2_account_name",
+            defaults,
+            "my-kubernetes-v2-account",
+            help="The name of the primary Kubernetes account to configure.",
+        )
+        add_parser_argument(
+            parser,
+            "k8s_v2_account_context",
+            defaults,
+            None,
+            help="The kubernetes context for the primary Kubernetes v2 account.",
+        )
+        add_parser_argument(
+            parser,
+            "k8s_v2_account_namespaces",
+            defaults,
+            "validate-bom",
+            help="The kubernetes namespaces for the primary Kubernetes v2 account.",
+        )
 
-  def validate_options(self, options):
-    """Implements interface."""
-    pass
+    def validate_options(self, options):
+        """Implements interface."""
+        pass
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    options.k8s_v2_account_enabled = options.k8s_v2_account_credentials is not None
-    if not options.k8s_v2_account_enabled:
-      return
+    def add_config(self, options, script):
+        """Implements interface."""
+        options.k8s_v2_account_enabled = options.k8s_v2_account_credentials is not None
+        if not options.k8s_v2_account_enabled:
+            return
 
-    account_params = [options.k8s_v2_account_name]
-    account_params.extend([
-        '--kubeconfig-file',
-        os.path.basename(options.k8s_v2_account_credentials),
-        '--provider-version',
-        'v2'
-    ])
-    if options.k8s_v2_account_context:
-      account_params.extend(['--context', options.k8s_v2_account_context])
-    if options.k8s_v2_account_namespaces:
-      account_params.extend(['--namespaces', options.k8s_v2_account_namespaces])
+        account_params = [options.k8s_v2_account_name]
+        account_params.extend(
+            [
+                "--kubeconfig-file",
+                os.path.basename(options.k8s_v2_account_credentials),
+                "--provider-version",
+                "v2",
+            ]
+        )
+        if options.k8s_v2_account_context:
+            account_params.extend(["--context", options.k8s_v2_account_context])
+        if options.k8s_v2_account_namespaces:
+            account_params.extend(["--namespaces", options.k8s_v2_account_namespaces])
 
-    script.append('hal -q --log=info config provider kubernetes enable')
-    script.append('hal -q --log=info config provider kubernetes account'
-                  ' add {params}'
-                  .format(params=' '.join(account_params)))
+        script.append("hal -q --log=info config provider kubernetes enable")
+        script.append(
+            "hal -q --log=info config provider kubernetes account"
+            " add {params}".format(params=" ".join(account_params))
+        )
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    if options.k8s_v2_account_credentials:
-      file_set.add(options.k8s_v2_account_credentials)
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        if options.k8s_v2_account_credentials:
+            file_set.add(options.k8s_v2_account_credentials)
+
 
 class DockerConfigurator(Configurator):
-  """Controls hal config provider docker."""
+    """Controls hal config provider docker."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'docker_account_address', defaults, None,
-        help='Registry address to pull and deploy images from.')
-    add_parser_argument(
-        parser, 'docker_account_name', defaults, 'my-docker-account',
-        help='The name of the primary Docker account to configure.')
-    add_parser_argument(
-        parser, 'docker_account_registry_username', defaults, None,
-        help='The username for the docker registry.')
-    add_parser_argument(
-        parser, 'docker_account_credentials', defaults, None,
-        help='Path to plain-text password file.')
-    add_parser_argument(
-        parser, 'docker_account_repositories', defaults, None,
-        help='Additional list of repositories to cache images from.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "docker_account_address",
+            defaults,
+            None,
+            help="Registry address to pull and deploy images from.",
+        )
+        add_parser_argument(
+            parser,
+            "docker_account_name",
+            defaults,
+            "my-docker-account",
+            help="The name of the primary Docker account to configure.",
+        )
+        add_parser_argument(
+            parser,
+            "docker_account_registry_username",
+            defaults,
+            None,
+            help="The username for the docker registry.",
+        )
+        add_parser_argument(
+            parser,
+            "docker_account_credentials",
+            defaults,
+            None,
+            help="Path to plain-text password file.",
+        )
+        add_parser_argument(
+            parser,
+            "docker_account_repositories",
+            defaults,
+            None,
+            help="Additional list of repositories to cache images from.",
+        )
 
-  def validate_options(self, options):
-    """Implements interface."""
-    options.docker_account_enabled = options.docker_account_address is not None
+    def validate_options(self, options):
+        """Implements interface."""
+        options.docker_account_enabled = options.docker_account_address is not None
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    if not options.docker_account_address:
-      return
+    def add_config(self, options, script):
+        """Implements interface."""
+        if not options.docker_account_address:
+            return
 
-    account_params = [options.docker_account_name,
-                      '--address', options.docker_account_address]
-    if options.docker_account_credentials:
-      cred_basename = os.path.basename(options.docker_account_credentials)
-      account_params.extend(
-          ['--password-file', cred_basename])
-    if options.docker_account_registry_username:
-      account_params.extend(
-          ['--username', options.docker_account_registry_username])
-    if options.docker_account_repositories:
-      account_params.extend(
-          ['--repositories', options.docker_account_repositories])
+        account_params = [
+            options.docker_account_name,
+            "--address",
+            options.docker_account_address,
+        ]
+        if options.docker_account_credentials:
+            cred_basename = os.path.basename(options.docker_account_credentials)
+            account_params.extend(["--password-file", cred_basename])
+        if options.docker_account_registry_username:
+            account_params.extend(
+                ["--username", options.docker_account_registry_username]
+            )
+        if options.docker_account_repositories:
+            account_params.extend(
+                ["--repositories", options.docker_account_repositories]
+            )
 
-    script.append('hal -q --log=info config provider docker-registry enable')
-    script.append('hal -q --log=info config provider docker-registry account'
-                  ' add {params}'
-                  .format(params=' '.join(account_params)))
+        script.append("hal -q --log=info config provider docker-registry enable")
+        script.append(
+            "hal -q --log=info config provider docker-registry account"
+            " add {params}".format(params=" ".join(account_params))
+        )
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    if options.docker_account_credentials:
-      file_set.add(options.docker_account_credentials)
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        if options.docker_account_credentials:
+            file_set.add(options.docker_account_credentials)
 
 
 class CanaryConfigurator(Configurator):
-  """Controls hal config canary configuration."""
+    """Controls hal config canary configuration."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'canary_aws', defaults, False, type=bool,
-        help='Whether or not to canary aws account deployments.'
-             ' If so, this will use the aws account.')
-    add_parser_argument(
-        parser, 'canary_google', defaults, False, type=bool,
-        help='Whether or not to canary google account deployments.'
-             ' If so, this will use the google account, project, credentials.')
-    add_parser_argument(
-        parser, 'canary_prometheus_account', defaults, 'my-prometheus-account',
-        help='The name of the prometheus account to configure when applicable.')
-    add_parser_argument(
-        parser, 'canary_prometheus_url', defaults, None,
-        help='The prometheus server URL to use, if canarying with prometheus.')
-    add_parser_argument(
-        parser, 'canary_stackdriver', defaults, True, type=bool,
-        help='Use stackdriver where applicable.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "canary_aws",
+            defaults,
+            False,
+            type=bool,
+            help="Whether or not to canary aws account deployments."
+            " If so, this will use the aws account.",
+        )
+        add_parser_argument(
+            parser,
+            "canary_google",
+            defaults,
+            False,
+            type=bool,
+            help="Whether or not to canary google account deployments."
+            " If so, this will use the google account, project, credentials.",
+        )
+        add_parser_argument(
+            parser,
+            "canary_prometheus_account",
+            defaults,
+            "my-prometheus-account",
+            help="The name of the prometheus account to configure when applicable.",
+        )
+        add_parser_argument(
+            parser,
+            "canary_prometheus_url",
+            defaults,
+            None,
+            help="The prometheus server URL to use, if canarying with prometheus.",
+        )
+        add_parser_argument(
+            parser,
+            "canary_stackdriver",
+            defaults,
+            True,
+            type=bool,
+            help="Use stackdriver where applicable.",
+        )
 
-  def validate_options(self, options):
-    """Implements interface."""
-    options.canary_enabled = options.canary_google or options.canary_aws
+    def validate_options(self, options):
+        """Implements interface."""
+        options.canary_enabled = options.canary_google or options.canary_aws
 
-    if not options.canary_enabled:
-      return
+        if not options.canary_enabled:
+            return
 
-    if options.canary_prometheus_url:
-      check_options_set(options, ['canary_prometheus_account'])
+        if options.canary_prometheus_url:
+            check_options_set(options, ["canary_prometheus_account"])
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    if not options.canary_enabled:
-      return
+    def add_config(self, options, script):
+        """Implements interface."""
+        if not options.canary_enabled:
+            return
 
-    if options.canary_prometheus_url:
-      script.append('hal -q --log=info config canary prometheus account'
-                    ' add {account} --base-url {url}'
-                    .format(account=options.canary_prometheus_account,
-                            url=options.canary_prometheus_url))
-      script.append('hal -q --log=info config canary prometheus enable')
+        if options.canary_prometheus_url:
+            script.append(
+                "hal -q --log=info config canary prometheus account"
+                " add {account} --base-url {url}".format(
+                    account=options.canary_prometheus_account,
+                    url=options.canary_prometheus_url,
+                )
+            )
+            script.append("hal -q --log=info config canary prometheus enable")
 
-    if options.canary_aws:
-      script.append('hal -q --log=info config canary aws account add {account}'
-                    .format(account=options.aws_account_name))
-      script.append('hal -q --log=info config canary aws enable')
+        if options.canary_aws:
+            script.append(
+                "hal -q --log=info config canary aws account add {account}".format(
+                    account=options.aws_account_name
+                )
+            )
+            script.append("hal -q --log=info config canary aws enable")
 
-    if options.canary_google:
-      script.append(
-          'hal -q --log=info config canary google account add {account}'
-          ' --project {project} --json-path {json}'
-          .format(account=options.google_account_name,
-                  project=options.google_account_project,
-                  json=os.path.basename(options.google_account_credentials)))
+        if options.canary_google:
+            script.append(
+                "hal -q --log=info config canary google account add {account}"
+                " --project {project} --json-path {json}".format(
+                    account=options.google_account_name,
+                    project=options.google_account_project,
+                    json=os.path.basename(options.google_account_credentials),
+                )
+            )
 
-      if options.deploy_hal_platform == 'gce' and options.canary_stackdriver:
-        script.append('hal -q --log=info config canary google edit'
-                      ' --stackdriver-enabled true')
-      script.append('hal -q --log=info config canary google enable')
+            if options.deploy_hal_platform == "gce" and options.canary_stackdriver:
+                script.append(
+                    "hal -q --log=info config canary google edit"
+                    " --stackdriver-enabled true"
+                )
+            script.append("hal -q --log=info config canary google enable")
 
-    script.append('hal -q --log=info config canary enable')
+        script.append("hal -q --log=info config canary enable")
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    if not options.canary_enabled:
-      return
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        if not options.canary_enabled:
+            return
 
 
 class GooglePubsubConfigurator(Configurator):
-  """Controls hal config google pub/sub configuration."""
+    """Controls hal config google pub/sub configuration."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'pubsub_google_project', defaults, None,
-        help='The name of the GCE project the subscription lives in.')
-    add_parser_argument(
-        parser, 'pubsub_google_credentials_path', defaults, None,
-        help='Path to service account credentials for the subscription.')
-    add_parser_argument(
-        parser, 'pubsub_google_subscription_name', defaults, None,
-        help='The name of the pub/sub subscription to pull from.')
-    add_parser_argument(
-        parser, 'pubsub_google_name', defaults, None,
-        help='The logical name of the configured subscription in Spinnaker.')
-    add_parser_argument(
-        parser, 'pubsub_google_template_path', defaults, None,
-        help='Path to the Jinja message translation template.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "pubsub_google_project",
+            defaults,
+            None,
+            help="The name of the GCE project the subscription lives in.",
+        )
+        add_parser_argument(
+            parser,
+            "pubsub_google_credentials_path",
+            defaults,
+            None,
+            help="Path to service account credentials for the subscription.",
+        )
+        add_parser_argument(
+            parser,
+            "pubsub_google_subscription_name",
+            defaults,
+            None,
+            help="The name of the pub/sub subscription to pull from.",
+        )
+        add_parser_argument(
+            parser,
+            "pubsub_google_name",
+            defaults,
+            None,
+            help="The logical name of the configured subscription in Spinnaker.",
+        )
+        add_parser_argument(
+            parser,
+            "pubsub_google_template_path",
+            defaults,
+            None,
+            help="Path to the Jinja message translation template.",
+        )
 
-  def validate_options(self, options):
-    """Implements interface."""
-    options.pubsub_google_enabled = options.pubsub_google_project is not None
+    def validate_options(self, options):
+        """Implements interface."""
+        options.pubsub_google_enabled = options.pubsub_google_project is not None
 
-    if not options.pubsub_google_enabled:
-      return
+        if not options.pubsub_google_enabled:
+            return
 
-    check_options_set(
-        options,
-        ['pubsub_google_project', 'pubsub_google_credentials_path',
-         'pubsub_google_subscription_name', 'pubsub_google_template_path'])
-    check_path_exists(options.pubsub_google_credentials_path,
-                      "pubsub_credentials_path")
-    check_path_exists(options.pubsub_google_template_path,
-                      "pubsub_template_path")
+        check_options_set(
+            options,
+            [
+                "pubsub_google_project",
+                "pubsub_google_credentials_path",
+                "pubsub_google_subscription_name",
+                "pubsub_google_template_path",
+            ],
+        )
+        check_path_exists(
+            options.pubsub_google_credentials_path, "pubsub_credentials_path"
+        )
+        check_path_exists(options.pubsub_google_template_path, "pubsub_template_path")
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    if not options.pubsub_google_enabled:
-      return
+    def add_config(self, options, script):
+        """Implements interface."""
+        if not options.pubsub_google_enabled:
+            return
 
-    script.append('hal -q --log=info config pubsub google enable')
-    subscription_cmd = ['hal -q --log=info config pubsub google subscription']
-    if options.pubsub_google_name:
-      subscription_cmd.append('add {}'.format(options.pubsub_google_name))
-    if options.pubsub_google_project:
-      subscription_cmd.append('--project ' + options.pubsub_google_project)
-    if options.pubsub_google_credentials_path:
-      subscription_cmd.append(
-          '--json-path '
-          + os.path.basename(options.pubsub_google_credentials_path))
-    if options.pubsub_google_subscription_name:
-      subscription_cmd.append(
-          '--subscription-name ' + options.pubsub_google_subscription_name)
-    if options.pubsub_google_template_path:
-      subscription_cmd.append(
-          '--template-path '
-          + os.path.basename(options.pubsub_google_template_path))
-    script.append(' '.join(subscription_cmd))
+        script.append("hal -q --log=info config pubsub google enable")
+        subscription_cmd = ["hal -q --log=info config pubsub google subscription"]
+        if options.pubsub_google_name:
+            subscription_cmd.append("add {}".format(options.pubsub_google_name))
+        if options.pubsub_google_project:
+            subscription_cmd.append("--project " + options.pubsub_google_project)
+        if options.pubsub_google_credentials_path:
+            subscription_cmd.append(
+                "--json-path "
+                + os.path.basename(options.pubsub_google_credentials_path)
+            )
+        if options.pubsub_google_subscription_name:
+            subscription_cmd.append(
+                "--subscription-name " + options.pubsub_google_subscription_name
+            )
+        if options.pubsub_google_template_path:
+            subscription_cmd.append(
+                "--template-path "
+                + os.path.basename(options.pubsub_google_template_path)
+            )
+        script.append(" ".join(subscription_cmd))
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    if not options.pubsub_google_enabled:
-      return
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        if not options.pubsub_google_enabled:
+            return
 
-    if options.pubsub_google_credentials_path:
-      file_set.add(options.pubsub_google_credentials_path)
-    if options.pubsub_google_template_path:
-      file_set.add(options.pubsub_google_template_path)
+        if options.pubsub_google_credentials_path:
+            file_set.add(options.pubsub_google_credentials_path)
+        if options.pubsub_google_template_path:
+            file_set.add(options.pubsub_google_template_path)
 
 
 class GcsPubsubNotficationConfigurator(Configurator):
-  """Controls external (to Spinnaker) GCS -> Google Pubsub config."""
+    """Controls external (to Spinnaker) GCS -> Google Pubsub config."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'gcs_pubsub_bucket', defaults, None,
-        help='The name of the bucket to create.')
-    add_parser_argument(
-        parser, 'gcs_pubsub_credentials_path', defaults, None,
-        help='The path to the credentials used to manipulate GCS and pub/sub.')
-    add_parser_argument(
-        parser, 'gcs_pubsub_project', defaults, None,
-        help='The name of the project for bucket, topic, and subscription.')
-    add_parser_argument(
-        parser, 'gcs_pubsub_topic', defaults, None,
-        help='The name of the topic to create.')
-    add_parser_argument(
-        parser, 'gcs_pubsub_subscription', defaults, None,
-        help='The name of the subscription to create.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "gcs_pubsub_bucket",
+            defaults,
+            None,
+            help="The name of the bucket to create.",
+        )
+        add_parser_argument(
+            parser,
+            "gcs_pubsub_credentials_path",
+            defaults,
+            None,
+            help="The path to the credentials used to manipulate GCS and pub/sub.",
+        )
+        add_parser_argument(
+            parser,
+            "gcs_pubsub_project",
+            defaults,
+            None,
+            help="The name of the project for bucket, topic, and subscription.",
+        )
+        add_parser_argument(
+            parser,
+            "gcs_pubsub_topic",
+            defaults,
+            None,
+            help="The name of the topic to create.",
+        )
+        add_parser_argument(
+            parser,
+            "gcs_pubsub_subscription",
+            defaults,
+            None,
+            help="The name of the subscription to create.",
+        )
 
-  def validate_options(self, options):
-    """Implements interface."""
-    options.gcs_pubsub_enabled = options.gcs_pubsub_bucket is not None
-    if not options.gcs_pubsub_enabled:
-      return
+    def validate_options(self, options):
+        """Implements interface."""
+        options.gcs_pubsub_enabled = options.gcs_pubsub_bucket is not None
+        if not options.gcs_pubsub_enabled:
+            return
 
-    check_options_set(
-        options,
-        ['gcs_pubsub_bucket', 'gcs_pubsub_topic', 'gcs_pubsub_project',
-         'gcs_pubsub_credentials_path', 'gcs_pubsub_subscription'])
-    if (options.gcs_pubsub_subscription
-        != options.pubsub_google_subscription_name):
-      raise_and_log_error(
-          ConfigError('Inconsistent pub/sub subscription in configuration: '
-                      ' --gcs_pubsub_subscription="{}"'
-                      ' --pubsub_google_subscription_name="{}"'
-                      .format(options.gcs_pubsub_subscription,
-                              options.pubsub_google_subscription_name)))
+        check_options_set(
+            options,
+            [
+                "gcs_pubsub_bucket",
+                "gcs_pubsub_topic",
+                "gcs_pubsub_project",
+                "gcs_pubsub_credentials_path",
+                "gcs_pubsub_subscription",
+            ],
+        )
+        if options.gcs_pubsub_subscription != options.pubsub_google_subscription_name:
+            raise_and_log_error(
+                ConfigError(
+                    "Inconsistent pub/sub subscription in configuration: "
+                    ' --gcs_pubsub_subscription="{}"'
+                    ' --pubsub_google_subscription_name="{}"'.format(
+                        options.gcs_pubsub_subscription,
+                        options.pubsub_google_subscription_name,
+                    )
+                )
+            )
 
-  def __instantiate_clients(self, options):
-    """Instantiates and returns publisher, subscriber, and storage clients.
+    def __instantiate_clients(self, options):
+        """Instantiates and returns publisher, subscriber, and storage clients.
 
-    Returns:
-      Tuple of (publisher_client, subscriber_client, storage_client)
-    """
-    scopes = [
-        'https://www.googleapis.com/auth/devstorage.full_control',
-        'https://www.googleapis.com/auth/cloud-platform',
-        'https://www.googleapis.com/auth/pubsub',
-    ]
-    credentials = service_account.Credentials.from_service_account_file(
-        options.gcs_pubsub_credentials_path,
-        scopes=scopes)
-    publisher_client = pubsub.PublisherClient(credentials=credentials)
-    subscriber_client = pubsub.SubscriberClient(credentials=credentials)
-    storage_client = storage.Client(credentials=credentials,
-                                    project=options.gcs_pubsub_project)
-    return (publisher_client, subscriber_client, storage_client)
+        Returns:
+          Tuple of (publisher_client, subscriber_client, storage_client)
+        """
+        scopes = [
+            "https://www.googleapis.com/auth/devstorage.full_control",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/pubsub",
+        ]
+        credentials = service_account.Credentials.from_service_account_file(
+            options.gcs_pubsub_credentials_path, scopes=scopes
+        )
+        publisher_client = pubsub.PublisherClient(credentials=credentials)
+        subscriber_client = pubsub.SubscriberClient(credentials=credentials)
+        storage_client = storage.Client(
+            credentials=credentials, project=options.gcs_pubsub_project
+        )
+        return (publisher_client, subscriber_client, storage_client)
 
-  def setup_environment(self, options):
-    """Implements interface."""
-    if not options.gcs_pubsub_enabled:
-      return
+    def setup_environment(self, options):
+        """Implements interface."""
+        if not options.gcs_pubsub_enabled:
+            return
 
-    publisher_client, subscriber_client, storage_client = self.__instantiate_clients(options)
+        (
+            publisher_client,
+            subscriber_client,
+            storage_client,
+        ) = self.__instantiate_clients(options)
 
-    logging.info('Creating topic %s in project %s',
-                 options.gcs_pubsub_topic, options.gcs_pubsub_project)
-    topic_ref = publisher_client.topic_path(
-        options.gcs_pubsub_project, options.gcs_pubsub_topic)
-    publisher_client.create_topic(topic_ref)
+        logging.info(
+            "Creating topic %s in project %s",
+            options.gcs_pubsub_topic,
+            options.gcs_pubsub_project,
+        )
+        topic_ref = publisher_client.topic_path(
+            options.gcs_pubsub_project, options.gcs_pubsub_topic
+        )
+        publisher_client.create_topic(topic_ref)
 
-    logging.info('Creating subscription %s in project %s',
-                 options.gcs_pubsub_subscription, options.gcs_pubsub_project)
-    subscription_ref = subscriber_client.subscription_path(
-        options.gcs_pubsub_project, options.gcs_pubsub_subscription)
-    subscriber_client.create_subscription(subscription_ref, topic_ref)
-    if storage_client.lookup_bucket(options.gcs_pubsub_bucket) is None:
-      created_bucket = storage_client.create_bucket(options.gcs_pubsub_bucket)
-      logging.debug('Created bucket for Pub/Sub artifacts: %s', created_bucket)
+        logging.info(
+            "Creating subscription %s in project %s",
+            options.gcs_pubsub_subscription,
+            options.gcs_pubsub_project,
+        )
+        subscription_ref = subscriber_client.subscription_path(
+            options.gcs_pubsub_project, options.gcs_pubsub_subscription
+        )
+        subscriber_client.create_subscription(subscription_ref, topic_ref)
+        if storage_client.lookup_bucket(options.gcs_pubsub_bucket) is None:
+            created_bucket = storage_client.create_bucket(options.gcs_pubsub_bucket)
+            logging.debug("Created bucket for Pub/Sub artifacts: %s", created_bucket)
 
-    bucket = storage_client.get_bucket(options.gcs_pubsub_bucket)
-    notification = bucket.notification(
-        options.gcs_pubsub_topic, topic_project=options.gcs_pubsub_project,
-        payload_format=storage.notification.JSON_API_V1_PAYLOAD_FORMAT)
-    notification.create()
-    logging.debug('Created bucket notification %s', notification)
+        bucket = storage_client.get_bucket(options.gcs_pubsub_bucket)
+        notification = bucket.notification(
+            options.gcs_pubsub_topic,
+            topic_project=options.gcs_pubsub_project,
+            payload_format=storage.notification.JSON_API_V1_PAYLOAD_FORMAT,
+        )
+        notification.create()
+        logging.debug("Created bucket notification %s", notification)
 
-  def teardown_environment(self, options):
-    """Implements interface."""
-    if not options.gcs_pubsub_enabled:
-      return
+    def teardown_environment(self, options):
+        """Implements interface."""
+        if not options.gcs_pubsub_enabled:
+            return
 
-    publisher_client, subscriber_client, storage_client = self.__instantiate_clients(options)
+        (
+            publisher_client,
+            subscriber_client,
+            storage_client,
+        ) = self.__instantiate_clients(options)
 
-    # Pub/sub names must contain the project and collection type as specified
-    # in the spec: https://cloud.google.com//pubsub/docs/admin#resource_names.
-    subscriber_client.delete_subscription(subscriber_client.subscription_path(
-        options.gcs_pubsub_project, options.gcs_pubsub_subscription))
-    publisher_client.delete_topic(publisher_client.topic_path(
-        options.gcs_pubsub_project, options.gcs_pubsub_topic))
-    bucket = storage_client.lookup_bucket(options.gcs_pubsub_bucket)
-    if bucket is not None:
-      bucket.delete(force=True)
-      logging.debug('Deleted bucket for Pub/Sub artifacts: %s', bucket)
+        # Pub/sub names must contain the project and collection type as specified
+        # in the spec: https://cloud.google.com//pubsub/docs/admin#resource_names.
+        subscriber_client.delete_subscription(
+            subscriber_client.subscription_path(
+                options.gcs_pubsub_project, options.gcs_pubsub_subscription
+            )
+        )
+        publisher_client.delete_topic(
+            publisher_client.topic_path(
+                options.gcs_pubsub_project, options.gcs_pubsub_topic
+            )
+        )
+        bucket = storage_client.lookup_bucket(options.gcs_pubsub_bucket)
+        if bucket is not None:
+            bucket.delete(force=True)
+            logging.debug("Deleted bucket for Pub/Sub artifacts: %s", bucket)
 
 
 class JenkinsConfigurator(Configurator):
-  """Controls hal config ci."""
+    """Controls hal config ci."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'jenkins_master_name', defaults, None,
-        help='The name of the jenkins master to configure.'
-        ' If provided, this also needs --jenkins_master_address, '
-        ' --jenkins_master_user, and --jenkins_master_credentials'
-        ' or an environment variable JENKINS_MASTER_PASSWORD')
-    add_parser_argument(
-        parser, 'jenkins_master_address', defaults, None,
-        help='The network address of the jenkins master to configure.'
-        ' If provided, this also needs --jenkins_master_name, '
-        ' --jenkins_master_user, and --jenkins_master_credentials'
-        ' or an environment variable JENKINS_MASTER_PASSWORD')
-    add_parser_argument(
-        parser, 'jenkins_master_user', defaults, None,
-        help='The name of the jenkins master to configure.'
-        ' If provided, this also needs --jenkins_master_address, '
-        ' --jenkins_master_name, and --jenkins_master_credentials'
-        ' or an environment variable JENKINS_MASTER_PASSWORD')
-    add_parser_argument(
-        parser, 'jenkins_master_credentials', defaults, None,
-        help='The password for the jenkins master to configure.'
-             ' If provided, this takes precedence over'
-             ' any JENKINS_MASTER_PASSWORD environment variable value.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "jenkins_master_name",
+            defaults,
+            None,
+            help="The name of the jenkins master to configure."
+            " If provided, this also needs --jenkins_master_address, "
+            " --jenkins_master_user, and --jenkins_master_credentials"
+            " or an environment variable JENKINS_MASTER_PASSWORD",
+        )
+        add_parser_argument(
+            parser,
+            "jenkins_master_address",
+            defaults,
+            None,
+            help="The network address of the jenkins master to configure."
+            " If provided, this also needs --jenkins_master_name, "
+            " --jenkins_master_user, and --jenkins_master_credentials"
+            " or an environment variable JENKINS_MASTER_PASSWORD",
+        )
+        add_parser_argument(
+            parser,
+            "jenkins_master_user",
+            defaults,
+            None,
+            help="The name of the jenkins master to configure."
+            " If provided, this also needs --jenkins_master_address, "
+            " --jenkins_master_name, and --jenkins_master_credentials"
+            " or an environment variable JENKINS_MASTER_PASSWORD",
+        )
+        add_parser_argument(
+            parser,
+            "jenkins_master_credentials",
+            defaults,
+            None,
+            help="The password for the jenkins master to configure."
+            " If provided, this takes precedence over"
+            " any JENKINS_MASTER_PASSWORD environment variable value.",
+        )
 
-  def validate_options(self, options):
-    """Implements interface."""
-    if ((options.jenkins_master_name is None)
-        != (options.jenkins_master_address is None)
-        or ((options.jenkins_master_name is None)
-            != (options.jenkins_master_user is None))):
-      raise ValueError('Inconsistent jenkins_master specification: '
-                       ' --jenkins_master_name="{0}"'
-                       ' --jenkins_master_address="{1}"'
-                       ' --jenkins_master_user="{2}"'
-                       .format(options.jenkins_master_name,
-                               options.jenkins_master_address,
-                               options.jenkins_master_user))
-    if (options.jenkins_master_name
-        and os.environ.get('JENKINS_MASTER_PASSWORD') is None):
-      raise ValueError('--jenkins_master_name was provided,'
-                       ' but no JENKINS_MASTER_PASSWORD environment variable')
-    options.jenkins_master_enabled = options.jenkins_master_name is not None
+    def validate_options(self, options):
+        """Implements interface."""
+        if (options.jenkins_master_name is None) != (
+            options.jenkins_master_address is None
+        ) or (
+            (options.jenkins_master_name is None)
+            != (options.jenkins_master_user is None)
+        ):
+            raise ValueError(
+                "Inconsistent jenkins_master specification: "
+                ' --jenkins_master_name="{0}"'
+                ' --jenkins_master_address="{1}"'
+                ' --jenkins_master_user="{2}"'.format(
+                    options.jenkins_master_name,
+                    options.jenkins_master_address,
+                    options.jenkins_master_user,
+                )
+            )
+        if (
+            options.jenkins_master_name
+            and os.environ.get("JENKINS_MASTER_PASSWORD") is None
+        ):
+            raise ValueError(
+                "--jenkins_master_name was provided,"
+                " but no JENKINS_MASTER_PASSWORD environment variable"
+            )
+        options.jenkins_master_enabled = options.jenkins_master_name is not None
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    name = options.jenkins_master_name or None
-    address = options.jenkins_master_address or None
-    user = options.jenkins_master_user or None
-    if options.jenkins_master_credentials:
-      password_file = os.path.basename(options.jenkins_master_credentials)
-    elif os.environ.get('JENKINS_MASTER_PASSWORD', None):
-      password_file = 'jenkins_{name}_password'.format(
-          name=options.jenkins_master_name)
-    else:
-      password_file = None
+    def add_config(self, options, script):
+        """Implements interface."""
+        name = options.jenkins_master_name or None
+        address = options.jenkins_master_address or None
+        user = options.jenkins_master_user or None
+        if options.jenkins_master_credentials:
+            password_file = os.path.basename(options.jenkins_master_credentials)
+        elif os.environ.get("JENKINS_MASTER_PASSWORD", None):
+            password_file = "jenkins_{name}_password".format(
+                name=options.jenkins_master_name
+            )
+        else:
+            password_file = None
 
-    if ((name is None) != (address is None)
-        or (name is None) != (user is None)):
-      raise ValueError('Either all of --jenkins_master_name,'
-                       ' --jenkins_master_address, --jenkins_master_user'
-                       ' or none of them must be supplied.')
-    if name is None:
-      return
-    if password_file is None:
-      raise ValueError(
-          'No --jenkins_master_credentials or JENKINS_MASTER_PASSWORD'
-          ' environment variable was supplied.')
-    script.append('hal -q --log=info config ci jenkins enable')
-    script.append('hal -q --log=info config ci jenkins master'
-                  ' add {name}'
-                  ' --address {address}'
-                  ' --username {user}'
-                  ' --password < {password_file}'
-                  .format(name=options.jenkins_master_name,
-                          address=options.jenkins_master_address,
-                          user=options.jenkins_master_user,
-                          password_file=os.path.basename(password_file)))
+        if (name is None) != (address is None) or (name is None) != (user is None):
+            raise ValueError(
+                "Either all of --jenkins_master_name,"
+                " --jenkins_master_address, --jenkins_master_user"
+                " or none of them must be supplied."
+            )
+        if name is None:
+            return
+        if password_file is None:
+            raise ValueError(
+                "No --jenkins_master_credentials or JENKINS_MASTER_PASSWORD"
+                " environment variable was supplied."
+            )
+        script.append("hal -q --log=info config ci jenkins enable")
+        script.append(
+            "hal -q --log=info config ci jenkins master"
+            " add {name}"
+            " --address {address}"
+            " --username {user}"
+            " --password < {password_file}".format(
+                name=options.jenkins_master_name,
+                address=options.jenkins_master_address,
+                user=options.jenkins_master_user,
+                password_file=os.path.basename(password_file),
+            )
+        )
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    if options.jenkins_master_credentials:
-      file_set.add(options.jenkins_master_credentials)
-    elif os.environ.get('JENKINS_MASTER_PASSWORD', None):
-      path = write_data_to_secure_path(
-          os.environ.get('JENKINS_MASTER_PASSWORD'),
-          'jenkins_{0}_password'.format(options.jenkins_master_name))
-      file_set.add(path)
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        if options.jenkins_master_credentials:
+            file_set.add(options.jenkins_master_credentials)
+        elif os.environ.get("JENKINS_MASTER_PASSWORD", None):
+            path = write_data_to_secure_path(
+                os.environ.get("JENKINS_MASTER_PASSWORD"),
+                "jenkins_{0}_password".format(options.jenkins_master_name),
+            )
+            file_set.add(path)
 
 
 class LoggingConfigurator(Configurator):
-  """Controls hal config logging."""
+    """Controls hal config logging."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'google_cloud_logging', defaults, False, type=bool,
-        help='Install Google Cloud Logging agent.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "google_cloud_logging",
+            defaults,
+            False,
+            type=bool,
+            help="Install Google Cloud Logging agent.",
+        )
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
 
-    if not options.google_cloud_logging:
-      return
+        if not options.google_cloud_logging:
+            return
 
-    # Upload install script from this repo
-    basedir = os.path.join(os.path.dirname(__file__),
-                           '..', 'google', 'google_cloud_logging')
-    file_set.add(os.path.join(basedir, 'add_google_cloud_logging.sh'))
-    file_set.add(os.path.join(basedir, 'spinnaker.conf'))
+        # Upload install script from this repo
+        basedir = os.path.join(
+            os.path.dirname(__file__), "..", "google", "google_cloud_logging"
+        )
+        file_set.add(os.path.join(basedir, "add_google_cloud_logging.sh"))
+        file_set.add(os.path.join(basedir, "spinnaker.conf"))
 
-  def add_init(self, options, script):
-    """Implements interface."""
+    def add_init(self, options, script):
+        """Implements interface."""
 
-    script.append('ntpq -p || true')
+        script.append("ntpq -p || true")
 
-    if not options.google_cloud_logging:
-      return
+        if not options.google_cloud_logging:
+            return
 
-    script.append('chmod +x ./add_google_cloud_logging.sh')
-    script.append('sudo ./add_google_cloud_logging.sh')
+        script.append("chmod +x ./add_google_cloud_logging.sh")
+        script.append("sudo ./add_google_cloud_logging.sh")
 
 
 class MonitoringConfigurator(Configurator):
-  """Controls hal config monitoring."""
+    """Controls hal config monitoring."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'monitoring_prometheus_gateway', defaults, None,
-        help='If provided, and which is "prometheus",'
-             ' configure to use the gateway server at thsi URL.')
-    add_parser_argument(
-        parser, 'monitoring_install_which', defaults, None,
-        help='If provided, install monitoring with these params.'
-             'This can be a comma-delimited list of services to use.')
-    add_parser_argument(
-        parser, 'monitoring_filter_dir', defaults, None,
-        help='If provided, use the metric fitlers in filter_dir.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "monitoring_prometheus_gateway",
+            defaults,
+            None,
+            help='If provided, and which is "prometheus",'
+            " configure to use the gateway server at thsi URL.",
+        )
+        add_parser_argument(
+            parser,
+            "monitoring_install_which",
+            defaults,
+            None,
+            help="If provided, install monitoring with these params."
+            "This can be a comma-delimited list of services to use.",
+        )
+        add_parser_argument(
+            parser,
+            "monitoring_filter_dir",
+            defaults,
+            None,
+            help="If provided, use the metric fitlers in filter_dir.",
+        )
 
-  def validate_options(self, options):
-    """Implements interface."""
-    options.monitoring_which_list = options.monitoring_install_which.split(',')
-    if (options.monitoring_prometheus_gateway
-        and 'prometheus' not in options.monitoring_which_list):
-      raise ValueError('gateway is only applicable to '
-                       ' --monitoring_install_which="prometheus"')
+    def validate_options(self, options):
+        """Implements interface."""
+        options.monitoring_which_list = options.monitoring_install_which.split(",")
+        if (
+            options.monitoring_prometheus_gateway
+            and "prometheus" not in options.monitoring_which_list
+        ):
+            raise ValueError(
+                "gateway is only applicable to "
+                ' --monitoring_install_which="prometheus"'
+            )
 
-  def __inject_prometheus_node_exporter(self, options, script):
-    """Add installation instructions for node_exporter
+    def __inject_prometheus_node_exporter(self, options, script):
+        """Add installation instructions for node_exporter
 
-    Add these to the start of the script so we can monitor installation.
-    """
-    version = '0.17.0'
-    node_version = 'node_exporter-{0}.linux-amd64'.format(version)
-    install_node_exporter = [
-        'curl -s -S -L -o /tmp/node_exporter.gz'
-        ' https://github.com/prometheus/node_exporter/releases/download'
-        '/v{version}/{node_version}.tar.gz'
-        .format(version=version, node_version=node_version),
+        Add these to the start of the script so we can monitor installation.
+        """
+        version = "0.17.0"
+        node_version = "node_exporter-{0}.linux-amd64".format(version)
+        install_node_exporter = [
+            "curl -s -S -L -o /tmp/node_exporter.gz"
+            " https://github.com/prometheus/node_exporter/releases/download"
+            "/v{version}/{node_version}.tar.gz".format(
+                version=version, node_version=node_version
+            ),
+            "sudo tar xzf /tmp/node_exporter.gz -C /opt",
+            "sudo ln -fs /opt/{node_version}/node_exporter"
+            " /usr/bin/node_exporter".format(node_version=node_version),
+            "rm /tmp/node_exporter.gz",
+            "(sudo /usr/bin/node_exporter < /dev/null > /dev/null 2>&1 &)",
+        ]
 
-        'sudo tar xzf /tmp/node_exporter.gz -C /opt',
+        # Prepend install_node_exporter to the beginning of the list.
+        # This is so we can monitor installation process itself,
+        # at least from this point in the script execution (before halyard install).
+        #
+        # There is no prepend, only individual element insert.
+        # But there is a reverse, so we'll do a bit of manipulation here
+        script.reverse()
+        install_node_exporter.reverse()
+        script.extend(install_node_exporter)
+        script.reverse()
 
-        'sudo ln -fs /opt/{node_version}/node_exporter'
-        ' /usr/bin/node_exporter'
-        .format(node_version=node_version),
+    def add_init(self, options, script):
+        """Implements interface."""
+        if not options.monitoring_install_which:
+            return
 
-        'rm /tmp/node_exporter.gz',
+        # Start up monitoring now so we can monitor these VMs
+        if (
+            "prometheus" in options.monitoring_which_list
+            and options.deploy_spinnaker_type == "localdebian"
+        ):
+            self.__inject_prometheus_node_exporter(options, script)
 
-        '(sudo /usr/bin/node_exporter < /dev/null > /dev/null 2>&1 &)',
-    ]
+    def add_files_to_upload(self, options, file_set):
+        if options.monitoring_filter_dir:
+            logging.info("Taring %s", options.monitoring_filter_dir)
+            os.system(
+                "tar cf monitoring_filters.tar -C %s ." % options.monitoring_filter_dir
+            )
+            file_set.add("monitoring_filters.tar")
 
-    # Prepend install_node_exporter to the beginning of the list.
-    # This is so we can monitor installation process itself,
-    # at least from this point in the script execution (before halyard install).
-    #
-    # There is no prepend, only individual element insert.
-    # But there is a reverse, so we'll do a bit of manipulation here
-    script.reverse()
-    install_node_exporter.reverse()
-    script.extend(install_node_exporter)
-    script.reverse()
+    def add_config(self, options, script):
+        """Implements interface."""
+        if not options.monitoring_install_which:
+            return
 
-  def add_init(self, options, script):
-    """Implements interface."""
-    if not options.monitoring_install_which:
-      return
+        script.append("mkdir -p  ~/.hal/default/service-settings")
+        script.append(
+            'echo "host: 0.0.0.0"'
+            " > ~/.hal/default/service-settings/monitoring-daemon.yml"
+        )
 
-    # Start up monitoring now so we can monitor these VMs
-    if ('prometheus' in options.monitoring_which_list
-        and options.deploy_spinnaker_type == 'localdebian'):
-      self.__inject_prometheus_node_exporter(options, script)
-
-  def add_files_to_upload(self, options, file_set):
-    if options.monitoring_filter_dir:
-      logging.info('Taring %s', options.monitoring_filter_dir)
-      os.system('tar cf monitoring_filters.tar -C %s .'
-                % options.monitoring_filter_dir)
-      file_set.add('monitoring_filters.tar')
-
-  def add_config(self, options, script):
-    """Implements interface."""
-    if not options.monitoring_install_which:
-      return
-
-    script.append('mkdir -p  ~/.hal/default/service-settings')
-    script.append('echo "host: 0.0.0.0"'
-                  ' > ~/.hal/default/service-settings/monitoring-daemon.yml')
-
-    for which in options.monitoring_which_list:
-      script.append('hal -q --log=info config metric-stores {which} enable'
-                    .format(which=which))
-    if options.monitoring_prometheus_gateway:
-      script.append('hal -q --log=info config metric-stores prometheus edit'
-                    ' --push-gateway {gateway}'
-                    .format(gateway=options.monitoring_prometheus_gateway))
-    if options.monitoring_filter_dir:
-      # Unpack the tar file into halyard's config directory.
-      script.extend([
-          'mkdir -p ~/.hal/default/profiles/monitoring-daemon/filters',
-          'tar xf monitoring_filters.tar'
-             ' --directory ~/.hal/default/profiles/monitoring-daemon/filters'
-      ])
+        for which in options.monitoring_which_list:
+            script.append(
+                "hal -q --log=info config metric-stores {which} enable".format(
+                    which=which
+                )
+            )
+        if options.monitoring_prometheus_gateway:
+            script.append(
+                "hal -q --log=info config metric-stores prometheus edit"
+                " --push-gateway {gateway}".format(
+                    gateway=options.monitoring_prometheus_gateway
+                )
+            )
+        if options.monitoring_filter_dir:
+            # Unpack the tar file into halyard's config directory.
+            script.extend(
+                [
+                    "mkdir -p ~/.hal/default/profiles/monitoring-daemon/filters",
+                    "tar xf monitoring_filters.tar"
+                    " --directory ~/.hal/default/profiles/monitoring-daemon/filters",
+                ]
+            )
 
 
 class NotificationConfigurator(Configurator):
-  """Controls hal config notification."""
-  pass
+    """Controls hal config notification."""
+
+    pass
 
 
 class SecurityConfigurator(Configurator):
-  """Controls hal config security."""
-  pass
+    """Controls hal config security."""
+
+    pass
 
 
 class SpinnakerConfigurator(Configurator):
-  """Controls spinnaker-local overrides."""
+    """Controls spinnaker-local overrides."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'halyard_profile_dir', defaults, None,
-        help='Directory for custom service setting files'
-             ' to install as the default halyard profile.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "halyard_profile_dir",
+            defaults,
+            None,
+            help="Directory for custom service setting files"
+            " to install as the default halyard profile.",
+        )
 
+    def validate_options(self, options):
+        """Implements interface."""
+        if options.halyard_profile_dir and not os.path.exists(
+            options.halyard_profile_dir
+        ):
+            raise ValueError(
+                "--halyard_profile_dir %r does not exist" % options.halyard_profile_dir
+            )
 
-  def validate_options(self, options):
-    """Implements interface."""
-    if (options.halyard_profile_dir
-        and not os.path.exists(options.halyard_profile_dir)):
-        raise ValueError('--halyard_profile_dir %r does not exist' %
-                         options.halyard_profile_dir)
-
-  def add_config(self, options, script):
-    """Implements interface."""
-    script.append('mkdir -p  ~/.hal/default/profiles')
-    script.append('echo "management.security.enabled: false"'
-                  ' > ~/.hal/default/profiles/spinnaker-local.yml')
-    hystrix_config = '''\
+    def add_config(self, options, script):
+        """Implements interface."""
+        script.append("mkdir -p  ~/.hal/default/profiles")
+        script.append(
+            'echo "management.security.enabled: false"'
+            " > ~/.hal/default/profiles/spinnaker-local.yml"
+        )
+        hystrix_config = """\
 hystrix:
   threadpool:
     default:
       maxQueueSize: 100
       queueSizeRejectionThreshold: 100
-'''
-    script.append('echo "{}" > ~/.hal/default/profiles/gate-local.yml'.format(hystrix_config))
-    script.append('echo "{}" > ~/.hal/default/profiles/front50-local.yml'.format(hystrix_config))
+"""
+        script.append(
+            'echo "{}" > ~/.hal/default/profiles/gate-local.yml'.format(hystrix_config)
+        )
+        script.append(
+            'echo "{}" > ~/.hal/default/profiles/front50-local.yml'.format(
+                hystrix_config
+            )
+        )
 
-    # Good enough ULID impl for our purposes.
-    fake_ulid = ''.join(random.choice(string.ascii_uppercase + string.digits)
-                        for _ in range(26))
-    telemetry_config = '''\
+        # Good enough ULID impl for our purposes.
+        fake_ulid = "".join(
+            random.choice(string.ascii_uppercase + string.digits) for _ in range(26)
+        )
+        telemetry_config = """\
 stats:
   enabled: true
   endpoint: https://stats-staging.spinnaker.io
   instanceId: {}
   spinnakerVersion: {}
-'''.format(fake_ulid, options.deploy_version)
+""".format(
+            fake_ulid, options.deploy_version
+        )
 
-    script.append('echo "{}" > ~/.hal/default/profiles/echo-local.yml'.format(telemetry_config))
+        script.append(
+            'echo "{}" > ~/.hal/default/profiles/echo-local.yml'.format(
+                telemetry_config
+            )
+        )
 
-    if options.halyard_profile_dir:
-      # Unpack the tar file into halyard's defualt profile directory.
-      script.extend([
-          'mkdir -p ~/.hal/default/profiles',
-          'tar xf halyard_profiles.tar'
-             ' --directory ~/.hal/default/profiles'
-      ])
+        if options.halyard_profile_dir:
+            # Unpack the tar file into halyard's defualt profile directory.
+            script.extend(
+                [
+                    "mkdir -p ~/.hal/default/profiles",
+                    "tar xf halyard_profiles.tar"
+                    " --directory ~/.hal/default/profiles",
+                ]
+            )
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    if options.halyard_profile_dir:
-      logging.info('Taring %s', options.halyard_profile_dir)
-      os.system('tar cf halyard_profiles.tar -C %s .'
-                % options.halyard_profile_dir)
-      file_set.add('halyard_profiles.tar')
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        if options.halyard_profile_dir:
+            logging.info("Taring %s", options.halyard_profile_dir)
+            os.system(
+                "tar cf halyard_profiles.tar -C %s ." % options.halyard_profile_dir
+            )
+            file_set.add("halyard_profiles.tar")
 
 
 class HaConfigurator(Configurator):
-  """Controls hal config deploy ha (only supported by distributed deployments with a Kubernetes v2 account)."""
+    """Controls hal config deploy ha (only supported by distributed deployments with a Kubernetes v2 account)."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'ha_clouddriver_enabled', defaults, False, type=bool,
-        help='Whether or not to deploy clouddriver in HA mode.')
-    add_parser_argument(
-        parser, 'ha_clouddriver_redis_master_endpoint', defaults, None,
-        help='The endpoint of the clouddriver Redis master service')
-    add_parser_argument(
-        parser, 'ha_clouddriver_redis_slave_endpoint', defaults, None,
-        help='The endpoint of the clouddriver Redis slave service')
-    add_parser_argument(
-        parser, 'ha_clouddriver_redis_slave_deck_endpoint', defaults, None,
-        help='The endpoint of the clouddriver-ro-deck Redis slave service')
-    add_parser_argument(
-        parser, 'ha_echo_enabled', defaults, False, type=bool,
-        help='Whether or not to deploy echo in HA mode.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "ha_clouddriver_enabled",
+            defaults,
+            False,
+            type=bool,
+            help="Whether or not to deploy clouddriver in HA mode.",
+        )
+        add_parser_argument(
+            parser,
+            "ha_clouddriver_redis_master_endpoint",
+            defaults,
+            None,
+            help="The endpoint of the clouddriver Redis master service",
+        )
+        add_parser_argument(
+            parser,
+            "ha_clouddriver_redis_slave_endpoint",
+            defaults,
+            None,
+            help="The endpoint of the clouddriver Redis slave service",
+        )
+        add_parser_argument(
+            parser,
+            "ha_clouddriver_redis_slave_deck_endpoint",
+            defaults,
+            None,
+            help="The endpoint of the clouddriver-ro-deck Redis slave service",
+        )
+        add_parser_argument(
+            parser,
+            "ha_echo_enabled",
+            defaults,
+            False,
+            type=bool,
+            help="Whether or not to deploy echo in HA mode.",
+        )
 
-  def validate_options(self, options):
-    """Implements interface."""
-    options.ha_enabled = (
-        options.ha_clouddriver_enabled
-        or options.ha_echo_enabled)
-    if options.ha_clouddriver_enabled:
-      if (options.ha_clouddriver_redis_master_endpoint is None) != (options.ha_clouddriver_redis_slave_endpoint is None):
-        raise ValueError('Either both --ha_clouddriver_redis_master_endpoint'
-                         ' and --ha_clouddriver_redis_slave_endpoint or neither'
-                         ' of them must be supplied.')
+    def validate_options(self, options):
+        """Implements interface."""
+        options.ha_enabled = options.ha_clouddriver_enabled or options.ha_echo_enabled
+        if options.ha_clouddriver_enabled:
+            if (options.ha_clouddriver_redis_master_endpoint is None) != (
+                options.ha_clouddriver_redis_slave_endpoint is None
+            ):
+                raise ValueError(
+                    "Either both --ha_clouddriver_redis_master_endpoint"
+                    " and --ha_clouddriver_redis_slave_endpoint or neither"
+                    " of them must be supplied."
+                )
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    if options.ha_clouddriver_enabled:
-      script.append('hal -q --log=info config deploy ha clouddriver enable')
+    def add_config(self, options, script):
+        """Implements interface."""
+        if options.ha_clouddriver_enabled:
+            script.append("hal -q --log=info config deploy ha clouddriver enable")
 
-      ha_clouddriver_params = []
-      if options.ha_clouddriver_redis_master_endpoint is not None:
-        ha_clouddriver_params.extend(['--redis-master-endpoint',
-                                      options.ha_clouddriver_redis_master_endpoint])
-      if options.ha_clouddriver_redis_slave_deck_endpoint is not None:
-        ha_clouddriver_params.extend(['--redis-slave-deck-endpoint',
-                                      options.ha_clouddriver_redis_slave_deck_endpoint])
-      if options.ha_clouddriver_redis_slave_endpoint is not None:
-        ha_clouddriver_params.extend(['--redis-slave-endpoint',
-                                      options.ha_clouddriver_redis_slave_endpoint])
-      if ha_clouddriver_params:
-        script.append('hal -q --log=info config deploy ha clouddriver edit {params}'
-                      .format(params=' '.join(ha_clouddriver_params)))
+            ha_clouddriver_params = []
+            if options.ha_clouddriver_redis_master_endpoint is not None:
+                ha_clouddriver_params.extend(
+                    [
+                        "--redis-master-endpoint",
+                        options.ha_clouddriver_redis_master_endpoint,
+                    ]
+                )
+            if options.ha_clouddriver_redis_slave_deck_endpoint is not None:
+                ha_clouddriver_params.extend(
+                    [
+                        "--redis-slave-deck-endpoint",
+                        options.ha_clouddriver_redis_slave_deck_endpoint,
+                    ]
+                )
+            if options.ha_clouddriver_redis_slave_endpoint is not None:
+                ha_clouddriver_params.extend(
+                    [
+                        "--redis-slave-endpoint",
+                        options.ha_clouddriver_redis_slave_endpoint,
+                    ]
+                )
+            if ha_clouddriver_params:
+                script.append(
+                    "hal -q --log=info config deploy ha clouddriver edit {params}".format(
+                        params=" ".join(ha_clouddriver_params)
+                    )
+                )
 
-    if options.ha_echo_enabled:
-      script.append('hal -q --log=info config deploy ha echo enable')
+        if options.ha_echo_enabled:
+            script.append("hal -q --log=info config deploy ha echo enable")
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    pass
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        pass
+
 
 class PluginStageConfigurator(Configurator):
-  """Controls hal plugins."""
+    """Controls hal plugins."""
 
-  def init_argument_parser(self, parser, defaults):
-    """Implements interface."""
-    add_parser_argument(
-        parser, 'plugin_repo', defaults, None,
-        help='The address of the plugin repository to pull metadata from.')
+    def init_argument_parser(self, parser, defaults):
+        """Implements interface."""
+        add_parser_argument(
+            parser,
+            "plugin_repo",
+            defaults,
+            None,
+            help="The address of the plugin repository to pull metadata from.",
+        )
 
-    add_parser_argument(
-        parser, 'plugin_name', defaults, None,
-        help='The name of the plugin to deploy.')
+        add_parser_argument(
+            parser,
+            "plugin_name",
+            defaults,
+            None,
+            help="The name of the plugin to deploy.",
+        )
 
-    add_parser_argument(
-        parser, 'plugin_extension', defaults, None,
-        help='The name of the plugin extension to deploy.')
+        add_parser_argument(
+            parser,
+            "plugin_extension",
+            defaults,
+            None,
+            help="The name of the plugin extension to deploy.",
+        )
 
-    add_parser_argument(
-        parser, 'plugin_version', defaults, None,
-        help='The plugin version to deploy.')
+        add_parser_argument(
+            parser,
+            "plugin_version",
+            defaults,
+            None,
+            help="The plugin version to deploy.",
+        )
 
-  def add_config(self, options, script):
-    """Implements interface."""
-    if options.plugin_repo is None:
-      return
+    def add_config(self, options, script):
+        """Implements interface."""
+        if options.plugin_repo is None:
+            return
 
-    script.append(
-        'hal -q --log=info plugins repository add spin-test-repo'
-        ' --url={repo}'.format(repo=options.plugin_repo))
+        script.append(
+            "hal -q --log=info plugins repository add spin-test-repo"
+            " --url={repo}".format(repo=options.plugin_repo)
+        )
 
-    script.append(
-        'hal -q --log=info plugins add {name}'
-        ' --enabled=true'
-        ' --extensions={extension}'
-        ' --version={version}'.format(
+        script.append(
+            "hal -q --log=info plugins add {name}"
+            " --enabled=true"
+            " --extensions={extension}"
+            " --version={version}".format(
                 name=options.plugin_name,
                 extension=options.plugin_extension,
                 version=options.plugin_version,
-            ))
+            )
+        )
 
-  def validate_options(self, options):
-    """Implements interface."""
-    if options.plugin_repo is None:
-      return
+    def validate_options(self, options):
+        """Implements interface."""
+        if options.plugin_repo is None:
+            return
 
-    if options.plugin_name is None:
-      raise ValueError('--plugin_name is required if --plugin_repo is'
-              ' supplied.')
+        if options.plugin_name is None:
+            raise ValueError(
+                "--plugin_name is required if --plugin_repo is" " supplied."
+            )
 
-    if options.plugin_extension is None:
-      raise ValueError('--plugin_extension is required if --plugin_repo is'
-              ' supplied.')
+        if options.plugin_extension is None:
+            raise ValueError(
+                "--plugin_extension is required if --plugin_repo is" " supplied."
+            )
 
-    if options.plugin_version is None:
-      raise ValueError('--plugin_version is required if --plugin_repo is'
-              ' supplied.')
+        if options.plugin_version is None:
+            raise ValueError(
+                "--plugin_version is required if --plugin_repo is" " supplied."
+            )
 
-  def add_files_to_upload(self, options, file_set):
-    """Implements interface."""
-    pass
+    def add_files_to_upload(self, options, file_set):
+        """Implements interface."""
+        pass
 
 
 CONFIGURATOR_LIST = [
@@ -1673,62 +2285,60 @@ CONFIGURATOR_LIST = [
 
 
 def init_argument_parser(parser, defaults):
-  """Initialize the argument parser with configuration options.
+    """Initialize the argument parser with configuration options.
 
-  Args:
-    parser: [ArgumentParser] The argument parser to add the options to.
-  """
-  for configurator in CONFIGURATOR_LIST:
-    configurator.init_argument_parser(parser, defaults)
+    Args:
+      parser: [ArgumentParser] The argument parser to add the options to.
+    """
+    for configurator in CONFIGURATOR_LIST:
+        configurator.init_argument_parser(parser, defaults)
 
 
 def validate_options(options):
-  """Validate supplied options to ensure basic idea is ok.
+    """Validate supplied options to ensure basic idea is ok.
 
-  This doesnt perform a fine-grained check, just whether or not
-  the arguments seem consistent or complete so we can fail fast.
-  """
-  for configurator in CONFIGURATOR_LIST:
-    configurator.validate_options(options)
+    This doesnt perform a fine-grained check, just whether or not
+    the arguments seem consistent or complete so we can fail fast.
+    """
+    for configurator in CONFIGURATOR_LIST:
+        configurator.validate_options(options)
 
 
 def make_scripts(options):
-  """Creates the bash script for configuring Spinnaker.
+    """Creates the bash script for configuring Spinnaker.
 
-  Returns a pair of lists of bash statement strings.
-  The first is to be run before halyard is install to initialize the host,
-  the second after halyard is installed in order to configure spinnaker.
-  """
-  init_script = []
-  config_script = []
-  for configurator in CONFIGURATOR_LIST:
-    configurator.add_init(options, init_script)
-    configurator.add_config(options, config_script)
+    Returns a pair of lists of bash statement strings.
+    The first is to be run before halyard is install to initialize the host,
+    the second after halyard is installed in order to configure spinnaker.
+    """
+    init_script = []
+    config_script = []
+    for configurator in CONFIGURATOR_LIST:
+        configurator.add_init(options, init_script)
+        configurator.add_config(options, config_script)
 
-  return init_script, config_script
+    return init_script, config_script
 
 
 def setup_environment(options):
-  """Performs any external infrastructure or cloud provider config.
-  """
-  for configurator in CONFIGURATOR_LIST:
-    configurator.setup_environment(options)
+    """Performs any external infrastructure or cloud provider config."""
+    for configurator in CONFIGURATOR_LIST:
+        configurator.setup_environment(options)
 
 
 def teardown_environment(options):
-  """Tears down any external infrastructure or cloud provider config.
-  """
-  for configurator in CONFIGURATOR_LIST:
-    configurator.teardown_environment(options)
+    """Tears down any external infrastructure or cloud provider config."""
+    for configurator in CONFIGURATOR_LIST:
+        configurator.teardown_environment(options)
 
 
 def get_files_to_upload(options):
-  """Collects the paths to files that the configuration script will reference.
+    """Collects the paths to files that the configuration script will reference.
 
-  Returns:
-     A set of path strings.
-  """
-  file_set = set([])
-  for configurator in CONFIGURATOR_LIST:
-    configurator.add_files_to_upload(options, file_set)
-  return file_set
+    Returns:
+       A set of path strings.
+    """
+    file_set = set([])
+    for configurator in CONFIGURATOR_LIST:
+        configurator.add_files_to_upload(options, file_set)
+    return file_set

--- a/dev/validate_bom__deploy.py
+++ b/dev/validate_bom__deploy.py
@@ -43,1450 +43,1766 @@ from buildtool import (
     ExecutionError,
     ResponseError,
     TimeoutError,
-    UnexpectedError)
+    UnexpectedError,
+)
 
 
-SUPPORTED_DEPLOYMENT_TYPES = ['localdebian', 'distributed']
-SUPPORTED_DISTRIBUTED_PLATFORMS = ['kubernetes_v2']
-HALYARD_SERVICES = ['halyard']
+SUPPORTED_DEPLOYMENT_TYPES = ["localdebian", "distributed"]
+SUPPORTED_DISTRIBUTED_PLATFORMS = ["kubernetes_v2"]
+HALYARD_SERVICES = ["halyard"]
 SPINNAKER_SERVICES = [
-    'clouddriver', 'echo', 'fiat', 'front50', 'gate', 'igor', 'orca',
-    'rosco', 'kayenta', 'monitoring'
+    "clouddriver",
+    "echo",
+    "fiat",
+    "front50",
+    "gate",
+    "igor",
+    "orca",
+    "rosco",
+    "kayenta",
+    "monitoring",
 ]
 
 
 def decode_json(data):
-  try:
-    return json.JSONDecoder().decode(data)
-  except (ValueError, TypeError) as err:
-    logging.error('Error decoding JSON: %s\n%s\n',
-                  err.message, data)
-    raise
+    try:
+        return json.JSONDecoder().decode(data)
+    except (ValueError, TypeError) as err:
+        logging.error("Error decoding JSON: %s\n%s\n", err.message, data)
+        raise
 
 
 def replace_ha_services(services, options):
-  """Replace services with their HA services.
+    """Replace services with their HA services.
 
-  Given a list of services and options, return a new list of services where
-  services that are enabled for HA are replaced with their HA counterparts.
-  """
+    Given a list of services and options, return a new list of services where
+    services that are enabled for HA are replaced with their HA counterparts.
+    """
 
-  transform_map = {}
-  if options.ha_clouddriver_enabled:
-    transform_map['clouddriver'] = \
-        ['clouddriver-caching', 'clouddriver-rw', 'clouddriver-ro', 'clouddriver-ro-deck']
-  if options.ha_echo_enabled:
-    transform_map['echo'] = \
-        ['echo-scheduler', 'echo-worker']
+    transform_map = {}
+    if options.ha_clouddriver_enabled:
+        transform_map["clouddriver"] = [
+            "clouddriver-caching",
+            "clouddriver-rw",
+            "clouddriver-ro",
+            "clouddriver-ro-deck",
+        ]
+    if options.ha_echo_enabled:
+        transform_map["echo"] = ["echo-scheduler", "echo-worker"]
 
-  transformed_services = []
-  for service in services:
-    transformed_services.extend(transform_map.get(service, [service]))
-  return transformed_services
+    transformed_services = []
+    for service in services:
+        transformed_services.extend(transform_map.get(service, [service]))
+    return transformed_services
 
 
 def ensure_empty_ssh_key(path, user):
-  """Ensure there is an ssh key at the given path.
+    """Ensure there is an ssh key at the given path.
 
-  It is assumed that this key has no password associated with it so we
-  can use it for ssh/scp.
-  """
+    It is assumed that this key has no password associated with it so we
+    can use it for ssh/scp.
+    """
 
-  if os.path.exists(path):
-    return
+    if os.path.exists(path):
+        return
 
-  logging.debug('Creating %s SSH key for user "%s"', path, user)
-  check_subprocess_sequence([
-      'ssh-keygen -N "" -t rsa -f {path} -C {user}'.format(
-          path=path, user=user),
-      'sed "s/^ssh-rsa/{user}:ssh-rsa/" -i {path}'.format(
-          user=user, path=path)
-  ])
+    logging.debug('Creating %s SSH key for user "%s"', path, user)
+    check_subprocess_sequence(
+        [
+            'ssh-keygen -N "" -t rsa -f {path} -C {user}'.format(path=path, user=user),
+            'sed "s/^ssh-rsa/{user}:ssh-rsa/" -i {path}'.format(user=user, path=path),
+        ]
+    )
 
 
 def write_data_to_secure_path(data, path=None, is_script=False):
-  """Write data to a path with user-only access.
+    """Write data to a path with user-only access.
 
-  Args:
-    path: [string] Path to file or None to create a temporary file.
-    is_script: [bool] True if data is a script (and should be executable).
+    Args:
+      path: [string] Path to file or None to create a temporary file.
+      is_script: [bool] True if data is a script (and should be executable).
 
-  Returns:
-    path to file written.
-  """
-  # pylint: disable=invalid-name
-  if path is None:
-    fd, path = tempfile.mkstemp()
-  else:
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT)
+    Returns:
+      path to file written.
+    """
+    # pylint: disable=invalid-name
+    if path is None:
+        fd, path = tempfile.mkstemp()
+    else:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT)
 
-  maybe_executable = stat.S_IXUSR if is_script else 0
-  flags = stat.S_IRUSR | stat.S_IWUSR | maybe_executable
-  os.fchmod(fd, flags)
-  os.write(fd, data.encode('utf-8'))
-  os.close(fd)
-  return path
+    maybe_executable = stat.S_IXUSR if is_script else 0
+    flags = stat.S_IRUSR | stat.S_IWUSR | maybe_executable
+    os.fchmod(fd, flags)
+    os.write(fd, data.encode("utf-8"))
+    os.close(fd)
+    return path
 
 
 def write_script_to_path(script, path=None):
-  """Write the script to a path as a secure, user-only executable file.
+    """Write the script to a path as a secure, user-only executable file.
 
-  Args:
-    script: [list] Sequence of bash statements to script.
-    path: [string] Path to file to write, or None to create a temp file.
+    Args:
+      script: [list] Sequence of bash statements to script.
+      path: [string] Path to file to write, or None to create a temp file.
 
-  Returns:
-    path written
-  """
-  data = ['#!/bin/bash',
-          'set -e',
-          'set -x']
-  data.extend(script)
-  return write_data_to_secure_path(
-      '\n'.join(data), path=path, is_script=True)
+    Returns:
+      path written
+    """
+    data = ["#!/bin/bash", "set -e", "set -x"]
+    data.extend(script)
+    return write_data_to_secure_path("\n".join(data), path=path, is_script=True)
 
 
 class BaseValidateBomDeployer(object):
-  """Base class/interface for Deployer that uses Halyard to deploy Spinnaker.
+    """Base class/interface for Deployer that uses Halyard to deploy Spinnaker.
 
-  This class is not intended to be constructed directly. Instead see the
-  free function make_deployer() in this module.
-  """
-
-  @property
-  def options(self):
-    """The options bound at construction."""
-    return self.__options
-
-  @property
-  def metrics(self):
-    """The metrics regisry bound at construction."""
-    return self.__metrics
-
-  @property
-  def hal_user(self):
-    """Returns the Halyard User within the deployment VM."""
-    return self.__hal_user
-
-  def __init__(self, options, metrics, runtime_class=None):
-    if runtime_class:
-      self.__spinnaker_deployer = runtime_class(options, metrics)
-    else:
-      self.__spinnaker_deployer = self
-    self.__options = options
-    self.__metrics = metrics
-    self.__hal_user = options.deploy_hal_user
-    logging.info('hal_user="%s"', self.__hal_user)
-
-  def make_port_forward_command(self, service, local_port, remote_port):
-    """Return the command used to forward ports to the given service.
-
-    Returns:
-      array of commandline arguments to create a subprocess with.
+    This class is not intended to be constructed directly. Instead see the
+    free function make_deployer() in this module.
     """
-    return self.__spinnaker_deployer.do_make_port_forward_command(
-        service, local_port, remote_port)
 
-  def deploy(self, init_script, config_script, files_to_upload):
-    """Deploy and configure spinnaker.
+    @property
+    def options(self):
+        """The options bound at construction."""
+        return self.__options
 
-    The deployment configuration is specified via the bound options.
-    The runtime configuration is passed to the call.
+    @property
+    def metrics(self):
+        """The metrics regisry bound at construction."""
+        return self.__metrics
 
-    Args:
-      init_script: [list] The sequence of bash commands to run in order
-         to prepare the host before installing halyard and configuring.
-      config_script: [list] The sequence of bash commands to run in order
-         to configure spinnaker.
-      file_to_upload: [set] A set of file paths to upload to the deployed
-         instance before running the init_script. Presumably these will
-         be referenced by the init_script or config_script.
-    """
-    deploy_labels = {}
-    self.__metrics.track_and_time_call(
-        'DeploySpinnaker',
-        deploy_labels, self.__metrics.default_determine_outcome_labels,
-        self.__wrapped_deploy, init_script, config_script, files_to_upload)
+    @property
+    def hal_user(self):
+        """Returns the Halyard User within the deployment VM."""
+        return self.__hal_user
 
-  def __wrapped_deploy(self, init_script, config_script, files_to_upload):
-    platform = self.options.deploy_hal_platform
-    logging.info('Deploying with hal on %s...', platform)
-    script = list(init_script)
-    self.add_install_hal_script_statements(script)
-    if self.options.halyard_config_bucket_credentials:
-      files_to_upload.add(self.options.halyard_config_bucket_credentials)
-      self.add_inject_halyard_application_default_credentials(
-          self.options.halyard_config_bucket_credentials, script)
-
-    self.add_platform_deploy_script_statements(script)
-    # Add the version first to avoid warnings or facilitate checks
-    # with the configuration commands
-    script.append('hal -q --log=info config version edit'
-                  ' --version {version}'
-                  .format(version=self.options.deploy_version))
-
-    script.extend(config_script)
-    self.add_hal_deploy_script_statements(script)
-
-    # Dump the hal config so we log it for posterity
-    script.append('hal -q --log=info config')
-
-    script.append('sudo hal -q --log=info deploy apply')
-    self.add_post_deploy_statements(script)
-
-    if not self.options.deploy_deploy:
-      logging.warning('Skipping deployment because --deploy_deploy=false\n')
-      return
-    self.do_deploy(script, files_to_upload)
-    logging.info('Finished deploying to %s', platform)
-
-  def undeploy(self):
-    undeploy_labels = {}
-    self.__metrics.track_and_time_call(
-        'UndeploySpinnaker',
-        undeploy_labels, self.__metrics.default_determine_outcome_labels,
-        self.__wrapped_undeploy)
-
-  def __wrapped_undeploy(self):
-    """Remove the spinnaker deployment and reclaim resources."""
-    # Consider also undeploying from options.deploy_spinnaker_platform
-    # with self.__runtime_deployer
-    platform = self.options.deploy_hal_platform
-    logging.info('Undeploying hal on %s...', platform)
-    if not self.options.deploy_undeploy:
-      logging.warning(
-          'Skipping undeploy because --deploy_undeploy=false\n')
-      return
-
-    self.do_undeploy()
-    logging.info('Finished undeploying from %s', platform)
-
-  def collect_logs(self):
-    """Collect all the microservice log files."""
-    log_dir = os.path.join(self.options.log_dir, 'service_logs')
-    if not os.path.exists(log_dir):
-      os.makedirs(log_dir)
-
-    def fetch_service_log(service):
-      try:
-        deployer = (self if service in HALYARD_SERVICES
-                    else self.__spinnaker_deployer)
-        deployer.do_fetch_service_log_file(service, log_dir)
-      except Exception as ex:
-        message = 'Error fetching log for service "{service}": {ex}'.format(
-            service=service, ex=ex)
-        if ex.message.find('No such file') >= 0:
-          message += '\n    Perhaps the service never started.'
-          # dont log since the error was already captured.
+    def __init__(self, options, metrics, runtime_class=None):
+        if runtime_class:
+            self.__spinnaker_deployer = runtime_class(options, metrics)
         else:
-          logging.error(message)
-          message += '\n{trace}'.format(
-              trace=traceback.format_exc())
+            self.__spinnaker_deployer = self
+        self.__options = options
+        self.__metrics = metrics
+        self.__hal_user = options.deploy_hal_user
+        logging.info('hal_user="%s"', self.__hal_user)
 
-        write_data_to_secure_path(
-            message, os.path.join(log_dir, service + '.log'))
+    def make_port_forward_command(self, service, local_port, remote_port):
+        """Return the command used to forward ports to the given service.
 
-    logging.info('Collecting server log files into "%s"', log_dir)
-    all_services = replace_ha_services(SPINNAKER_SERVICES, self.options)
-    all_services.extend(HALYARD_SERVICES)
-    thread_pool = ThreadPool(len(all_services))
-    thread_pool.map(fetch_service_log, all_services)
-    thread_pool.terminate()
+        Returns:
+          array of commandline arguments to create a subprocess with.
+        """
+        return self.__spinnaker_deployer.do_make_port_forward_command(
+            service, local_port, remote_port
+        )
 
-  def do_make_port_forward_command(self, service, local_port, remote_port):
-    """Hook for concrete platforms to return the port forwarding command.
+    def deploy(self, init_script, config_script, files_to_upload):
+        """Deploy and configure spinnaker.
 
-    Returns:
-      array of commandline arguments to create a subprocess with.
-    """
-    raise NotImplementedError(self.__class__.__name__)
+        The deployment configuration is specified via the bound options.
+        The runtime configuration is passed to the call.
 
-  def do_deploy(self, script, files_to_upload):
-    """Hook for specialized platforms to implement the concrete deploy()."""
-    # pylint: disable=unused-argument
-    raise NotImplementedError(self.__class__.__name__)
+        Args:
+          init_script: [list] The sequence of bash commands to run in order
+             to prepare the host before installing halyard and configuring.
+          config_script: [list] The sequence of bash commands to run in order
+             to configure spinnaker.
+          file_to_upload: [set] A set of file paths to upload to the deployed
+             instance before running the init_script. Presumably these will
+             be referenced by the init_script or config_script.
+        """
+        deploy_labels = {}
+        self.__metrics.track_and_time_call(
+            "DeploySpinnaker",
+            deploy_labels,
+            self.__metrics.default_determine_outcome_labels,
+            self.__wrapped_deploy,
+            init_script,
+            config_script,
+            files_to_upload,
+        )
 
-  def do_undeploy(self):
-    """Hook for specialized platforms to implement the concrete undeploy()."""
-    raise NotImplementedError(self.__class__.__name__)
+    def __wrapped_deploy(self, init_script, config_script, files_to_upload):
+        platform = self.options.deploy_hal_platform
+        logging.info("Deploying with hal on %s...", platform)
+        script = list(init_script)
+        self.add_install_hal_script_statements(script)
+        if self.options.halyard_config_bucket_credentials:
+            files_to_upload.add(self.options.halyard_config_bucket_credentials)
+            self.add_inject_halyard_application_default_credentials(
+                self.options.halyard_config_bucket_credentials, script
+            )
 
-  def add_inject_halyard_application_default_credentials(
-      self, local_path, script):
-    """Inject google application credentials into halyards startup script.
-    This is only so we can install halyard against a halyard test repo.
-    We're doing this injection because halyard does not explicitly support this
-    use case from installation, though does support the use of application
-    default credentials.
-    """
-    script.append('first=$(head -1 /opt/halyard/bin/halyard)')
-    script.append(
-        'inject="export GOOGLE_APPLICATION_CREDENTIALS={path}"'
-        .format(path='$(pwd)/' + os.path.basename(local_path)))
-    script.append('remaining=$(tail -n +2 /opt/halyard/bin/halyard)')
-    script.append('cat <<EOF | sudo tee /opt/halyard/bin/halyard\n'
-                  '$first\n$inject\n$remaining\n'
-                  'EOF')
-    script.append('sudo chmod 755 /opt/halyard/bin/halyard')
+        self.add_platform_deploy_script_statements(script)
+        # Add the version first to avoid warnings or facilitate checks
+        # with the configuration commands
+        script.append(
+            "hal -q --log=info config version edit"
+            " --version {version}".format(version=self.options.deploy_version)
+        )
 
-    # Kill running halyard so it restarts with credentials.
-    # This method awaiting support in halyard to terminate the job.
-    # In the meantime, we'll kill all the java processes. Since this
-    # is run on a newly provisioned VM, it should only be halyard.
-    script.append('echo "Using nuclear option to stop existing halyard"')
-    script.append('killall java || true') # hack
-    script.append('echo "Restarting halyard..."')
-    script.append('sudo su -c "hal -v" -s /bin/bash {user}'
-                  .format(user=self.options.deploy_hal_user))
-    script.append('for i in `seq 1 30`; do'
-                  ' if hal --ready &> /dev/null; then break; fi;'
-                  ' sleep 1; done')
+        script.extend(config_script)
+        self.add_hal_deploy_script_statements(script)
 
-  def add_install_hal_script_statements(self, script):
-    """Adds the sequence of Bash statements to fetch and install halyard."""
-    options = self.options
-    script.append('sudo apt-get update && sudo apt-get install -y openjdk-11-jre-headless')
-    script.append('curl -s -O {url}'.format(url=options.halyard_install_script))
-    install_params = ['-y']
-    if options.halyard_config_bucket:
-      install_params.extend(['--config-bucket', options.halyard_config_bucket])
-    if options.halyard_bucket_base_url:
-      install_params.extend(['--halyard-bucket-base-url',
-                             options.halyard_bucket_base_url])
-    if options.halyard_version:
-      install_params.extend(['--version', options.halyard_version])
-    if self.hal_user:
-      install_params.extend(['--user', self.hal_user])
-    if options.spinnaker_repository:
-      install_params.extend(
-          ['--spinnaker-repository', options.spinnaker_repository])
-    if options.spinnaker_registry:
-      install_params.extend(
-          ['--spinnaker-registry', options.spinnaker_registry])
+        # Dump the hal config so we log it for posterity
+        script.append("hal -q --log=info config")
 
-    script.append('sudo bash ./InstallHalyard.sh {install_params}'
-                  .format(install_params=' '.join(install_params)))
-    return script
+        script.append("sudo hal -q --log=info deploy apply")
+        self.add_post_deploy_statements(script)
 
-  def add_platform_deploy_script_statements(self, script):
-    """Hook for deployment platform to add specific hal statements."""
-    pass
+        if not self.options.deploy_deploy:
+            logging.warning("Skipping deployment because --deploy_deploy=false\n")
+            return
+        self.do_deploy(script, files_to_upload)
+        logging.info("Finished deploying to %s", platform)
 
-  def add_hal_deploy_script_statements(self, script):
-    """Adds the hal deploy statements prior to "apply"."""
-    options = self.options
+    def undeploy(self):
+        undeploy_labels = {}
+        self.__metrics.track_and_time_call(
+            "UndeploySpinnaker",
+            undeploy_labels,
+            self.__metrics.default_determine_outcome_labels,
+            self.__wrapped_undeploy,
+        )
 
-    type_args = ['--type', options.deploy_spinnaker_type]
+    def __wrapped_undeploy(self):
+        """Remove the spinnaker deployment and reclaim resources."""
+        # Consider also undeploying from options.deploy_spinnaker_platform
+        # with self.__runtime_deployer
+        platform = self.options.deploy_hal_platform
+        logging.info("Undeploying hal on %s...", platform)
+        if not self.options.deploy_undeploy:
+            logging.warning("Skipping undeploy because --deploy_undeploy=false\n")
+            return
 
-    if options.deploy_spinnaker_type == 'distributed':
-      # Kubectl required for the next hal command, so install it if needed.
-      script.append(
-          'if ! `which kubectl >& /dev/null`; then'
-          ' curl -LO https://storage.googleapis.com/kubernetes-release/release'
-          '/$(curl -s https://storage.googleapis.com/kubernetes-release/release'
-          '/stable.txt)/bin/linux/amd64/kubectl'
-          '; chmod +x ./kubectl'
-          '; sudo mv ./kubectl /usr/local/bin/kubectl'
-          '; fi')
-      if options.injected_deploy_spinnaker_account:
-        type_args.extend(['--account-name',
-                          options.injected_deploy_spinnaker_account])
-      if options.deploy_distributed_platform == 'kubernetes_v2':
-        script.append('hal -q --log=info config deploy edit --location {namespace}'
-            .format(namespace=self.options.deploy_k8s_v2_namespace))
+        self.do_undeploy()
+        logging.info("Finished undeploying from %s", platform)
 
-    script.append('hal -q --log=info config deploy edit {args}'
-                  .format(args=' '.join(type_args)))
+    def collect_logs(self):
+        """Collect all the microservice log files."""
+        log_dir = os.path.join(self.options.log_dir, "service_logs")
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
 
-  def add_post_deploy_statements(self, script):
-    """Add any statements following "hal deploy apply"."""
-    pass
+        def fetch_service_log(service):
+            try:
+                deployer = (
+                    self if service in HALYARD_SERVICES else self.__spinnaker_deployer
+                )
+                deployer.do_fetch_service_log_file(service, log_dir)
+            except Exception as ex:
+                message = 'Error fetching log for service "{service}": {ex}'.format(
+                    service=service, ex=ex
+                )
+                if ex.message.find("No such file") >= 0:
+                    message += "\n    Perhaps the service never started."
+                    # dont log since the error was already captured.
+                else:
+                    logging.error(message)
+                    message += "\n{trace}".format(trace=traceback.format_exc())
+
+                write_data_to_secure_path(
+                    message, os.path.join(log_dir, service + ".log")
+                )
+
+        logging.info('Collecting server log files into "%s"', log_dir)
+        all_services = replace_ha_services(SPINNAKER_SERVICES, self.options)
+        all_services.extend(HALYARD_SERVICES)
+        thread_pool = ThreadPool(len(all_services))
+        thread_pool.map(fetch_service_log, all_services)
+        thread_pool.terminate()
+
+    def do_make_port_forward_command(self, service, local_port, remote_port):
+        """Hook for concrete platforms to return the port forwarding command.
+
+        Returns:
+          array of commandline arguments to create a subprocess with.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def do_deploy(self, script, files_to_upload):
+        """Hook for specialized platforms to implement the concrete deploy()."""
+        # pylint: disable=unused-argument
+        raise NotImplementedError(self.__class__.__name__)
+
+    def do_undeploy(self):
+        """Hook for specialized platforms to implement the concrete undeploy()."""
+        raise NotImplementedError(self.__class__.__name__)
+
+    def add_inject_halyard_application_default_credentials(self, local_path, script):
+        """Inject google application credentials into halyards startup script.
+        This is only so we can install halyard against a halyard test repo.
+        We're doing this injection because halyard does not explicitly support this
+        use case from installation, though does support the use of application
+        default credentials.
+        """
+        script.append("first=$(head -1 /opt/halyard/bin/halyard)")
+        script.append(
+            'inject="export GOOGLE_APPLICATION_CREDENTIALS={path}"'.format(
+                path="$(pwd)/" + os.path.basename(local_path)
+            )
+        )
+        script.append("remaining=$(tail -n +2 /opt/halyard/bin/halyard)")
+        script.append(
+            "cat <<EOF | sudo tee /opt/halyard/bin/halyard\n"
+            "$first\n$inject\n$remaining\n"
+            "EOF"
+        )
+        script.append("sudo chmod 755 /opt/halyard/bin/halyard")
+
+        # Kill running halyard so it restarts with credentials.
+        # This method awaiting support in halyard to terminate the job.
+        # In the meantime, we'll kill all the java processes. Since this
+        # is run on a newly provisioned VM, it should only be halyard.
+        script.append('echo "Using nuclear option to stop existing halyard"')
+        script.append("killall java || true")  # hack
+        script.append('echo "Restarting halyard..."')
+        script.append(
+            'sudo su -c "hal -v" -s /bin/bash {user}'.format(
+                user=self.options.deploy_hal_user
+            )
+        )
+        script.append(
+            "for i in `seq 1 30`; do"
+            " if hal --ready &> /dev/null; then break; fi;"
+            " sleep 1; done"
+        )
+
+    def add_install_hal_script_statements(self, script):
+        """Adds the sequence of Bash statements to fetch and install halyard."""
+        options = self.options
+        script.append(
+            "sudo apt-get update && sudo apt-get install -y openjdk-11-jre-headless"
+        )
+        script.append("curl -s -O {url}".format(url=options.halyard_install_script))
+        install_params = ["-y"]
+        if options.halyard_config_bucket:
+            install_params.extend(["--config-bucket", options.halyard_config_bucket])
+        if options.halyard_bucket_base_url:
+            install_params.extend(
+                ["--halyard-bucket-base-url", options.halyard_bucket_base_url]
+            )
+        if options.halyard_version:
+            install_params.extend(["--version", options.halyard_version])
+        if self.hal_user:
+            install_params.extend(["--user", self.hal_user])
+        if options.spinnaker_repository:
+            install_params.extend(
+                ["--spinnaker-repository", options.spinnaker_repository]
+            )
+        if options.spinnaker_registry:
+            install_params.extend(["--spinnaker-registry", options.spinnaker_registry])
+
+        script.append(
+            "sudo bash ./InstallHalyard.sh {install_params}".format(
+                install_params=" ".join(install_params)
+            )
+        )
+        return script
+
+    def add_platform_deploy_script_statements(self, script):
+        """Hook for deployment platform to add specific hal statements."""
+        pass
+
+    def add_hal_deploy_script_statements(self, script):
+        """Adds the hal deploy statements prior to "apply"."""
+        options = self.options
+
+        type_args = ["--type", options.deploy_spinnaker_type]
+
+        if options.deploy_spinnaker_type == "distributed":
+            # Kubectl required for the next hal command, so install it if needed.
+            script.append(
+                "if ! `which kubectl >& /dev/null`; then"
+                " curl -LO https://storage.googleapis.com/kubernetes-release/release"
+                "/$(curl -s https://storage.googleapis.com/kubernetes-release/release"
+                "/stable.txt)/bin/linux/amd64/kubectl"
+                "; chmod +x ./kubectl"
+                "; sudo mv ./kubectl /usr/local/bin/kubectl"
+                "; fi"
+            )
+            if options.injected_deploy_spinnaker_account:
+                type_args.extend(
+                    ["--account-name", options.injected_deploy_spinnaker_account]
+                )
+            if options.deploy_distributed_platform == "kubernetes_v2":
+                script.append(
+                    "hal -q --log=info config deploy edit --location {namespace}".format(
+                        namespace=self.options.deploy_k8s_v2_namespace
+                    )
+                )
+
+        script.append(
+            "hal -q --log=info config deploy edit {args}".format(
+                args=" ".join(type_args)
+            )
+        )
+
+    def add_post_deploy_statements(self, script):
+        """Add any statements following "hal deploy apply"."""
+        pass
+
 
 class KubernetesV2ValidateBomDeployer(BaseValidateBomDeployer):
-  """Concrete deployer used to deploy Hal onto Google Cloud Platform.
+    """Concrete deployer used to deploy Hal onto Google Cloud Platform.
 
-  This class is not intended to be constructed directly. Instead see the
-  free function make_deployer() in this module.
-  """
-  def __init__(self, options, metrics, **kwargs):
-    super(KubernetesV2ValidateBomDeployer, self).__init__(
-        options, metrics, **kwargs)
-
-  @classmethod
-  def init_platform_argument_parser(cls, parser, defaults):
-    """Adds custom configuration parameters to argument parser.
-
-    This is a helper function for the free function init_argument_parser().
+    This class is not intended to be constructed directly. Instead see the
+    free function make_deployer() in this module.
     """
-    add_parser_argument(
-        parser, 'deploy_k8s_v2_namespace', defaults, 'spinnaker',
-        help='Namespace for the account Spinnaker is deployed into.')
 
-  @classmethod
-  def validate_options_helper(cls, options):
-    """Adds custom configuration parameters to argument parser.
+    def __init__(self, options, metrics, **kwargs):
+        super(KubernetesV2ValidateBomDeployer, self).__init__(
+            options, metrics, **kwargs
+        )
 
-    This is a helper function for make_deployer().
-    """
-    if options.deploy_distributed_platform != 'kubernetes_v2':
-      return
+    @classmethod
+    def init_platform_argument_parser(cls, parser, defaults):
+        """Adds custom configuration parameters to argument parser.
 
-    if not options.k8s_v2_account_name:
-      raise_and_log_error(
-          ConfigError('--deploy_distributed_platform="kubernetes_v2" requires'
-                      ' a --k8s_v2_account_name be configured.'))
+        This is a helper function for the free function init_argument_parser().
+        """
+        add_parser_argument(
+            parser,
+            "deploy_k8s_v2_namespace",
+            defaults,
+            "spinnaker",
+            help="Namespace for the account Spinnaker is deployed into.",
+        )
 
-    if hasattr(options, "injected_deploy_spinnaker_account"):
-      raise_and_log_error(
-          UnexpectedError('deploy_spinnaker_account was already set to "{0}"'
-                          .format(options.injected_deploy_spinnaker_account)))
-    options.injected_deploy_spinnaker_account = options.k8s_v2_account_name
+    @classmethod
+    def validate_options_helper(cls, options):
+        """Adds custom configuration parameters to argument parser.
 
-  def __wait_for_deployment(self, k8s_namespace, service, context):
-    options = self.options
-    kubectl_command = 'kubectl --context {context} wait deployment/spin-{service} --timeout=300s --for=condition=available  --namespace {namespace}'.format(
-        context=context,
-        service=service,
-        namespace=k8s_namespace)
-    logging.info('Waiting for service %s to be up', service)
-    retcode, stdout = run_subprocess(kubectl_command)
-    if retcode != 0:
-      message = 'Timed out waiting for deployment to be available for service "{service}".: {error}'.format(
-          service=service,
-          error=stdout.strip())
-      raise_and_log_error(ExecutionError(message, program='kubectl'))
-    logging.info('Service %s is up', service)
+        This is a helper function for make_deployer().
+        """
+        if options.deploy_distributed_platform != "kubernetes_v2":
+            return
 
-  def __get_pod_name(self, k8s_v2_namespace, service):
-    """Determine the pod name for the deployed service."""
-    options = self.options
-    self.__wait_for_deployment(k8s_v2_namespace, service, options.k8s_v2_account_context)
-    flags = ' --namespace {namespace} --logtostderr=false'.format(
-        namespace=k8s_v2_namespace)
-    kubectl_command = 'kubectl {context} get pods {flags}'.format(
-        context=('--context {0}'.format(options.k8s_v2_account_context)
-                 if options.k8s_v2_account_context
-                 else ''),
-        flags=flags)
+        if not options.k8s_v2_account_name:
+            raise_and_log_error(
+                ConfigError(
+                    '--deploy_distributed_platform="kubernetes_v2" requires'
+                    " a --k8s_v2_account_name be configured."
+                )
+            )
 
-    retcode, stdout = run_subprocess(
-        '{command}'
-        ' | gawk -F "[[:space:]]+" "/{service}/ {{print \\$1}}"'
-        ' | tail -1'.format(
-            command=kubectl_command, service=service),
-        shell=True)
-    pod = stdout.strip()
-    if not pod:
-      message = 'There is no pod for "{service}" in {namespace}'.format(
-          service=service, namespace=k8s_v2_namespace)
-      raise_and_log_error(ConfigError(message, cause='NoPod'))
+        if hasattr(options, "injected_deploy_spinnaker_account"):
+            raise_and_log_error(
+                UnexpectedError(
+                    'deploy_spinnaker_account was already set to "{0}"'.format(
+                        options.injected_deploy_spinnaker_account
+                    )
+                )
+            )
+        options.injected_deploy_spinnaker_account = options.k8s_v2_account_name
 
-    if retcode != 0:
-      message = 'Could not find pod for "{service}".: {error}'.format(
-          service=service,
-          error=stdout.strip())
-      raise_and_log_error(ExecutionError(message, program='kubectl'))
-    else:
-      logging.debug('pod "%s" -> %s', service, stdout)
+    def __wait_for_deployment(self, k8s_namespace, service, context):
+        options = self.options
+        kubectl_command = "kubectl --context {context} wait deployment/spin-{service} --timeout=300s --for=condition=available  --namespace {namespace}".format(
+            context=context, service=service, namespace=k8s_namespace
+        )
+        logging.info("Waiting for service %s to be up", service)
+        retcode, stdout = run_subprocess(kubectl_command)
+        if retcode != 0:
+            message = 'Timed out waiting for deployment to be available for service "{service}".: {error}'.format(
+                service=service, error=stdout.strip()
+            )
+            raise_and_log_error(ExecutionError(message, program="kubectl"))
+        logging.info("Service %s is up", service)
 
-    return stdout.strip()
+    def __get_pod_name(self, k8s_v2_namespace, service):
+        """Determine the pod name for the deployed service."""
+        options = self.options
+        self.__wait_for_deployment(
+            k8s_v2_namespace, service, options.k8s_v2_account_context
+        )
+        flags = " --namespace {namespace} --logtostderr=false".format(
+            namespace=k8s_v2_namespace
+        )
+        kubectl_command = "kubectl {context} get pods {flags}".format(
+            context=(
+                "--context {0}".format(options.k8s_v2_account_context)
+                if options.k8s_v2_account_context
+                else ""
+            ),
+            flags=flags,
+        )
 
-  def do_make_port_forward_command(self, service, local_port, remote_port):
-    """Implements interface."""
-    options = self.options
-    k8s_v2_namespace = options.deploy_k8s_v2_namespace
-    service_pod = self.__get_pod_name(k8s_v2_namespace, service)
+        retcode, stdout = run_subprocess(
+            "{command}"
+            ' | gawk -F "[[:space:]]+" "/{service}/ {{print \\$1}}"'
+            " | tail -1".format(command=kubectl_command, service=service),
+            shell=True,
+        )
+        pod = stdout.strip()
+        if not pod:
+            message = 'There is no pod for "{service}" in {namespace}'.format(
+                service=service, namespace=k8s_v2_namespace
+            )
+            raise_and_log_error(ConfigError(message, cause="NoPod"))
 
-    return [
-        'kubectl', '--namespace', k8s_v2_namespace,
-        'port-forward', service_pod,
-        '{local}:{remote}'.format(local=local_port, remote=remote_port)
-    ]
+        if retcode != 0:
+            message = 'Could not find pod for "{service}".: {error}'.format(
+                service=service, error=stdout.strip()
+            )
+            raise_and_log_error(ExecutionError(message, program="kubectl"))
+        else:
+            logging.debug('pod "%s" -> %s', service, stdout)
 
-  def do_deploy(self, script, files_to_upload):
-    """Implements the BaseBomValidateDeployer interface."""
-    # This is not yet supported in this script.
-    # To deploy spinnaker to kubernetes, you need to go through
-    # a halyard VM deployment. Halyard itself can be deployed to K8s.
-    # This script doesnt.
-    super(KubernetesV2ValidateBomDeployer, self).do_deploy(
-        script, files_to_upload)
+        return stdout.strip()
 
-  def do_undeploy(self):
-    """Implements the BaseBomValidateDeployer interface."""
-    super(KubernetesV2ValidateBomDeployer, self).do_undeploy()
-    # kubectl delete namespace spinnaker
+    def do_make_port_forward_command(self, service, local_port, remote_port):
+        """Implements interface."""
+        options = self.options
+        k8s_v2_namespace = options.deploy_k8s_v2_namespace
+        service_pod = self.__get_pod_name(k8s_v2_namespace, service)
 
-  def do_fetch_service_log_file(self, service, log_dir):
-    """Retrieve log file for the given service's pod.
+        return [
+            "kubectl",
+            "--namespace",
+            k8s_v2_namespace,
+            "port-forward",
+            service_pod,
+            "{local}:{remote}".format(local=local_port, remote=remote_port),
+        ]
 
-    Args:
-      service: [string] The service's log to get
-      log_dir: [string] The directory name to write the logs into.
-    """
-    if service == 'monitoring':
-      # monitoring is in a sidecar of each service
-      return
+    def do_deploy(self, script, files_to_upload):
+        """Implements the BaseBomValidateDeployer interface."""
+        # This is not yet supported in this script.
+        # To deploy spinnaker to kubernetes, you need to go through
+        # a halyard VM deployment. Halyard itself can be deployed to K8s.
+        # This script doesnt.
+        super(KubernetesV2ValidateBomDeployer, self).do_deploy(script, files_to_upload)
 
-    options = self.options
-    k8s_v2_namespace = options.deploy_k8s_v2_namespace
-    service_pod = self.__get_pod_name(k8s_v2_namespace, service)
+    def do_undeploy(self):
+        """Implements the BaseBomValidateDeployer interface."""
+        super(KubernetesV2ValidateBomDeployer, self).do_undeploy()
+        # kubectl delete namespace spinnaker
 
-    containers = [service]
-    if options.monitoring_install_which:
-      containers.append('monitoring-daemon')
+    def do_fetch_service_log_file(self, service, log_dir):
+        """Retrieve log file for the given service's pod.
 
-    for container in containers:
-      if container == 'monitoring-daemon':
-        path = os.path.join(log_dir, service + '_monitoring.log')
-      else:
-        path = os.path.join(log_dir, service + '.log')
-      retcode, stdout = run_subprocess(
-          'kubectl -n {namespace} -c {container} {context} logs {pod}'
-          .format(namespace=k8s_v2_namespace,
-                  container=container,
-                  context=('--context {0}'.format(options.k8s_v2_account_context)
-                           if options.k8s_v2_account_context
-                           else ''),
-                  pod=service_pod),
-          shell=True)
-      write_data_to_secure_path(stdout, path)
+        Args:
+          service: [string] The service's log to get
+          log_dir: [string] The directory name to write the logs into.
+        """
+        if service == "monitoring":
+            # monitoring is in a sidecar of each service
+            return
+
+        options = self.options
+        k8s_v2_namespace = options.deploy_k8s_v2_namespace
+        service_pod = self.__get_pod_name(k8s_v2_namespace, service)
+
+        containers = [service]
+        if options.monitoring_install_which:
+            containers.append("monitoring-daemon")
+
+        for container in containers:
+            if container == "monitoring-daemon":
+                path = os.path.join(log_dir, service + "_monitoring.log")
+            else:
+                path = os.path.join(log_dir, service + ".log")
+            retcode, stdout = run_subprocess(
+                "kubectl -n {namespace} -c {container} {context} logs {pod}".format(
+                    namespace=k8s_v2_namespace,
+                    container=container,
+                    context=(
+                        "--context {0}".format(options.k8s_v2_account_context)
+                        if options.k8s_v2_account_context
+                        else ""
+                    ),
+                    pod=service_pod,
+                ),
+                shell=True,
+            )
+            write_data_to_secure_path(stdout, path)
 
 
 class GenericVmValidateBomDeployer(BaseValidateBomDeployer):
-  """Concrete deployer used to deploy Hal onto Generic VM
+    """Concrete deployer used to deploy Hal onto Generic VM
 
-  This class is not intended to be constructed directly. Instead see the
-  free function make_deployer() in this module.
-  """
-
-  @property
-  def instance_ip(self):
-    """The underlying IP address for the deployed instance."""
-    if not self.__instance_ip:
-      self.__instance_ip = self.do_determine_instance_ip()
-    return self.__instance_ip
-
-  def set_instance_ip(self, value):
-    """Sets the underlying IP address for the deployed instance."""
-    self.__instance_ip = value
-
-  @property
-  def ssh_key_path(self):
-    """Returns the path to the ssh key for the deployment VM."""
-    return self.__ssh_key_path
-
-  @ssh_key_path.setter
-  def ssh_key_path(self, path):
-    """Sets the path to the ssh key to use."""
-    self.__ssh_key_path = path
-
-  def __init__(self, options, metrics, **kwargs):
-    super(GenericVmValidateBomDeployer, self).__init__(
-        options, metrics, **kwargs)
-    self.__instance_ip = None
-    self.__ssh_key_path = os.path.join(os.environ['HOME'], '.ssh',
-                                       '{0}_empty_key'.format(self.hal_user))
-
-  def do_make_port_forward_command(self, service, local_port, remote_port):
-    """Implements interface."""
-    return [
-        'ssh', '-i', self.__ssh_key_path,
-        '-o', 'StrictHostKeyChecking=no',
-        '-o', 'UserKnownHostsFile=/dev/null',
-        '{user}@{ip}'.format(user=self.hal_user, ip=self.instance_ip),
-        '-L', '{local_port}:localhost:{remote_port}'.format(
-            local_port=local_port, remote_port=remote_port),
-        '-N']
-
-  def do_determine_instance_ip(self):
-    """Hook for determining the ip address of the hal instance."""
-    raise NotImplementedError(self.__class__.__name__)
-
-  def do_create_vm(self, options):
-    """Hook for concrete deployer to craete the VM."""
-    raise NotImplementedError(self.__class__.__name__)
-
-  def __upload_files_helper(self, files_to_upload):
-    copy_files = (
-        'scp'
-        ' -i {ssh_key_path}'
-        ' -o StrictHostKeyChecking=no'
-        ' -o UserKnownHostsFile=/dev/null'
-        ' {files}'
-        ' {user}@{ip}:~'
-        .format(ssh_key_path=self.__ssh_key_path,
-                files=' '.join(files_to_upload),
-                user=self.hal_user,
-                ip=self.instance_ip))
-    logging.info('Copying deployment and configuration files')
-
-    # pylint: disable=unused-variable
-    for retry in range(0, 10):
-      returncode, _ = run_subprocess(copy_files)
-      if returncode == 0:
-        break
-      time.sleep(2)
-
-    if returncode != 0:
-      check_subprocess(copy_files)
-
-  def __wait_for_ssh_helper(self):
-    logging.info('Waiting for ssh %s@%s...', self.hal_user, self.instance_ip)
-    end_time = time.time() + 30
-    while time.time() < end_time:
-      retcode, _ = run_subprocess(
-          'ssh'
-          ' -i {ssh_key}'
-          ' -o StrictHostKeyChecking=no'
-          ' -o UserKnownHostsFile=/dev/null'
-          ' {user}@{ip}'
-          ' "exit 0"'
-          .format(user=self.hal_user,
-                  ip=self.instance_ip,
-                  ssh_key=self.__ssh_key_path))
-      if retcode == 0:
-        logging.info('%s is ready', self.instance_ip)
-        break
-      time.sleep(1)
-
-  def attempt_install(self, script_path, retry):
-    """Attempt to the install script on the remote instance.
-
-    Bintray is flaky making this not uncommon to fail intermittently.
-    Therefore, it is intended that this function may be called multiple
-    times on the same instance.
+    This class is not intended to be constructed directly. Instead see the
+    free function make_deployer() in this module.
     """
-    attempt_decorator = '+%d' % retry if retry > 0 else ''
-    logging.info('Configuring deployment%s',
-                 ' retry=%d' % retry if retry else '')
-    logfile = os.path.join(
-        self.options.output_dir,
-        'install_spinnaker-%d%s.log' % (os.getpid(), attempt_decorator))
-    try:
-      command = (
-          'ssh'
-          ' -i {ssh_key}'
-          ' -o StrictHostKeyChecking=no'
-          ' -o UserKnownHostsFile=/dev/null'
-          ' {user}@{ip}'
-          ' bash -l -c ./{script_name}'
-          .format(user=self.hal_user,
-                  ip=self.instance_ip,
-                  ssh_key=self.__ssh_key_path,
-                  script_name=os.path.basename(script_path)))
-      check_subprocesses_to_logfile('install spinnaker', logfile, [command])
-    except ExecutionError as error:
-      scan_logs_for_install_errors(logfile)
-      return ExecutionError('Halyard deployment failed: %s' % error.message,
-                            program='install')
-    except Exception as ex:
-      return UnexpectedError(ex.message)
 
-    return None
+    @property
+    def instance_ip(self):
+        """The underlying IP address for the deployed instance."""
+        if not self.__instance_ip:
+            self.__instance_ip = self.do_determine_instance_ip()
+        return self.__instance_ip
 
-  def do_deploy(self, script, files_to_upload):
-    """Implements the BaseBomValidateDeployer interface."""
-    options = self.options
-    ensure_empty_ssh_key(self.__ssh_key_path, self.hal_user)
+    def set_instance_ip(self, value):
+        """Sets the underlying IP address for the deployed instance."""
+        self.__instance_ip = value
 
-    script_parts = []
-    for path in files_to_upload:
-      filename = os.path.basename(path)
-      script_parts.append('sudo chmod 600 {file}'.format(file=filename))
-      script_parts.append('sudo chown {user}:{user} {file}'
-                          .format(user=self.hal_user, file=filename))
+    @property
+    def ssh_key_path(self):
+        """Returns the path to the ssh key for the deployment VM."""
+        return self.__ssh_key_path
 
-    script_parts.extend(script)
-    script_path = write_script_to_path(script_parts, path=None)
-    files_to_upload.add(script_path)
+    @ssh_key_path.setter
+    def ssh_key_path(self, path):
+        """Sets the path to the ssh key to use."""
+        self.__ssh_key_path = path
 
-    try:
-      self.do_create_vm(options)
-      self.__upload_files_helper(files_to_upload)
-      self.__wait_for_ssh_helper()
-    except Exception as ex:
-      raise_and_log_error(
-          ExecutionError('Caught "%s" provisioning vm' % ex.message,
-                         program='provisionVm'))
-    finally:
-      shutil.copyfile(script_path,
-                      os.path.join(options.output_dir, 'install-script.sh'))
-      os.remove(script_path)
-      files_to_upload.remove(script_path)  # in case we need to retry
+    def __init__(self, options, metrics, **kwargs):
+        super(GenericVmValidateBomDeployer, self).__init__(options, metrics, **kwargs)
+        self.__instance_ip = None
+        self.__ssh_key_path = os.path.join(
+            os.environ["HOME"], ".ssh", "{0}_empty_key".format(self.hal_user)
+        )
 
-    error = None
-    max_retries = 10
-    install_labels = {}
-    for retry in range(0, max_retries):
-      error = self.metrics.track_and_time_call(
-          'InstallSpinnaker',
-          install_labels,
-          self.metrics.determine_outcome_labels_from_error_result,
-          self.attempt_install, script_path, retry)
-      if not error:
-        break
+    def do_make_port_forward_command(self, service, local_port, remote_port):
+        """Implements interface."""
+        return [
+            "ssh",
+            "-i",
+            self.__ssh_key_path,
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "{user}@{ip}".format(user=self.hal_user, ip=self.instance_ip),
+            "-L",
+            "{local_port}:localhost:{remote_port}".format(
+                local_port=local_port, remote_port=remote_port
+            ),
+            "-N",
+        ]
 
-      logging.warning('Encountered an error during install: %s', error.message)
-      if retry < (max_retries - 1):
-        # Re-upload the files because script may have moved them around
-        # so re-running the script wont find them anymore.
-        self.__upload_files_helper(files_to_upload)
-        logging.debug('Re-uploading install files...')
+    def do_determine_instance_ip(self):
+        """Hook for determining the ip address of the hal instance."""
+        raise NotImplementedError(self.__class__.__name__)
 
-        # Clear halyard history
-        clear_halyard_command = (
-          'ssh'
-          ' -i {ssh_key}'
-          ' -o StrictHostKeyChecking=no'
-          ' -o UserKnownHostsFile=/dev/null'
-          ' {user}@{ip}'
-          ' "hal deploy clean || true; echo "Y" | sudo ~/.hal/uninstall.sh || true;"'
-          .format(user=self.hal_user,
-                  ip=self.instance_ip,
-                  ssh_key=self.__ssh_key_path))
-        run_subprocess(clear_halyard_command)
+    def do_create_vm(self, options):
+        """Hook for concrete deployer to craete the VM."""
+        raise NotImplementedError(self.__class__.__name__)
 
-        logging.debug('Waiting a minute before retrying...')
-        time.sleep(60)
+    def __upload_files_helper(self, files_to_upload):
+        copy_files = (
+            "scp"
+            " -i {ssh_key_path}"
+            " -o StrictHostKeyChecking=no"
+            " -o UserKnownHostsFile=/dev/null"
+            " {files}"
+            " {user}@{ip}:~".format(
+                ssh_key_path=self.__ssh_key_path,
+                files=" ".join(files_to_upload),
+                user=self.hal_user,
+                ip=self.instance_ip,
+            )
+        )
+        logging.info("Copying deployment and configuration files")
 
-    if error:
-      raise_and_log_error(error)
+        # pylint: disable=unused-variable
+        for retry in range(0, 10):
+            returncode, _ = run_subprocess(copy_files)
+            if returncode == 0:
+                break
+            time.sleep(2)
 
-  def do_fetch_service_log_file(self, service, log_dir):
-    """Implements the BaseBomValidateDeployer interface."""
-    write_data_to_secure_path('', os.path.join(log_dir, service + '.log'))
-    retcode, stdout = run_subprocess(
-        'ssh'
-        ' -i {ssh_key}'
-        ' -o StrictHostKeyChecking=no'
-        ' -o UserKnownHostsFile=/dev/null'
-        ' {user}@{ip}'
-        ' "if [[ -f /var/log/spinnaker/{service_dir}/{service_name}.log ]];'
-        '  then cat /var/log/spinnaker/{service_dir}/{service_name}.log;'
-        '  else command -v journalctl >/dev/null && journalctl -u {service_name}; fi"'
-        .format(user=self.hal_user,
+        if returncode != 0:
+            check_subprocess(copy_files)
+
+    def __wait_for_ssh_helper(self):
+        logging.info("Waiting for ssh %s@%s...", self.hal_user, self.instance_ip)
+        end_time = time.time() + 30
+        while time.time() < end_time:
+            retcode, _ = run_subprocess(
+                "ssh"
+                " -i {ssh_key}"
+                " -o StrictHostKeyChecking=no"
+                " -o UserKnownHostsFile=/dev/null"
+                " {user}@{ip}"
+                ' "exit 0"'.format(
+                    user=self.hal_user, ip=self.instance_ip, ssh_key=self.__ssh_key_path
+                )
+            )
+            if retcode == 0:
+                logging.info("%s is ready", self.instance_ip)
+                break
+            time.sleep(1)
+
+    def attempt_install(self, script_path, retry):
+        """Attempt to the install script on the remote instance.
+
+        Bintray is flaky making this not uncommon to fail intermittently.
+        Therefore, it is intended that this function may be called multiple
+        times on the same instance.
+        """
+        attempt_decorator = "+%d" % retry if retry > 0 else ""
+        logging.info("Configuring deployment%s", " retry=%d" % retry if retry else "")
+        logfile = os.path.join(
+            self.options.output_dir,
+            "install_spinnaker-%d%s.log" % (os.getpid(), attempt_decorator),
+        )
+        try:
+            command = (
+                "ssh"
+                " -i {ssh_key}"
+                " -o StrictHostKeyChecking=no"
+                " -o UserKnownHostsFile=/dev/null"
+                " {user}@{ip}"
+                " bash -l -c ./{script_name}".format(
+                    user=self.hal_user,
+                    ip=self.instance_ip,
+                    ssh_key=self.__ssh_key_path,
+                    script_name=os.path.basename(script_path),
+                )
+            )
+            check_subprocesses_to_logfile("install spinnaker", logfile, [command])
+        except ExecutionError as error:
+            scan_logs_for_install_errors(logfile)
+            return ExecutionError(
+                "Halyard deployment failed: %s" % error.message, program="install"
+            )
+        except Exception as ex:
+            return UnexpectedError(ex.message)
+
+        return None
+
+    def do_deploy(self, script, files_to_upload):
+        """Implements the BaseBomValidateDeployer interface."""
+        options = self.options
+        ensure_empty_ssh_key(self.__ssh_key_path, self.hal_user)
+
+        script_parts = []
+        for path in files_to_upload:
+            filename = os.path.basename(path)
+            script_parts.append("sudo chmod 600 {file}".format(file=filename))
+            script_parts.append(
+                "sudo chown {user}:{user} {file}".format(
+                    user=self.hal_user, file=filename
+                )
+            )
+
+        script_parts.extend(script)
+        script_path = write_script_to_path(script_parts, path=None)
+        files_to_upload.add(script_path)
+
+        try:
+            self.do_create_vm(options)
+            self.__upload_files_helper(files_to_upload)
+            self.__wait_for_ssh_helper()
+        except Exception as ex:
+            raise_and_log_error(
+                ExecutionError(
+                    'Caught "%s" provisioning vm' % ex.message, program="provisionVm"
+                )
+            )
+        finally:
+            shutil.copyfile(
+                script_path, os.path.join(options.output_dir, "install-script.sh")
+            )
+            os.remove(script_path)
+            files_to_upload.remove(script_path)  # in case we need to retry
+
+        error = None
+        max_retries = 10
+        install_labels = {}
+        for retry in range(0, max_retries):
+            error = self.metrics.track_and_time_call(
+                "InstallSpinnaker",
+                install_labels,
+                self.metrics.determine_outcome_labels_from_error_result,
+                self.attempt_install,
+                script_path,
+                retry,
+            )
+            if not error:
+                break
+
+            logging.warning("Encountered an error during install: %s", error.message)
+            if retry < (max_retries - 1):
+                # Re-upload the files because script may have moved them around
+                # so re-running the script wont find them anymore.
+                self.__upload_files_helper(files_to_upload)
+                logging.debug("Re-uploading install files...")
+
+                # Clear halyard history
+                clear_halyard_command = (
+                    "ssh"
+                    " -i {ssh_key}"
+                    " -o StrictHostKeyChecking=no"
+                    " -o UserKnownHostsFile=/dev/null"
+                    " {user}@{ip}"
+                    ' "hal deploy clean || true; echo "Y" | sudo ~/.hal/uninstall.sh || true;"'.format(
+                        user=self.hal_user,
+                        ip=self.instance_ip,
+                        ssh_key=self.__ssh_key_path,
+                    )
+                )
+                run_subprocess(clear_halyard_command)
+
+                logging.debug("Waiting a minute before retrying...")
+                time.sleep(60)
+
+        if error:
+            raise_and_log_error(error)
+
+    def do_fetch_service_log_file(self, service, log_dir):
+        """Implements the BaseBomValidateDeployer interface."""
+        write_data_to_secure_path("", os.path.join(log_dir, service + ".log"))
+        retcode, stdout = run_subprocess(
+            "ssh"
+            " -i {ssh_key}"
+            " -o StrictHostKeyChecking=no"
+            " -o UserKnownHostsFile=/dev/null"
+            " {user}@{ip}"
+            ' "if [[ -f /var/log/spinnaker/{service_dir}/{service_name}.log ]];'
+            "  then cat /var/log/spinnaker/{service_dir}/{service_name}.log;"
+            '  else command -v journalctl >/dev/null && journalctl -u {service_name}; fi"'.format(
+                user=self.hal_user,
                 ip=self.instance_ip,
                 ssh_key=self.ssh_key_path,
                 service_dir=service,
-                service_name=service))
-    if retcode != 0:
-      logging.warning('Failed obtaining %s.log: %s', service, stdout)
-    write_to_path(stdout, os.path.join(log_dir, service + '.log'))
+                service_name=service,
+            )
+        )
+        if retcode != 0:
+            logging.warning("Failed obtaining %s.log: %s", service, stdout)
+        write_to_path(stdout, os.path.join(log_dir, service + ".log"))
 
 
 class AwsValidateBomDeployer(GenericVmValidateBomDeployer):
-  """Concrete deployer used to deploy Hal onto Amazon EC2
+    """Concrete deployer used to deploy Hal onto Amazon EC2
 
-  This class is not intended to be constructed directly. Instead see the
-  free function make_deployer() in this module.
-  """
-
-  @classmethod
-  def init_platform_argument_parser(cls, parser, defaults):
-    """Adds custom configuration parameters to argument parser.
-
-    This is a helper function for the free function init_argument_parser().
+    This class is not intended to be constructed directly. Instead see the
+    free function make_deployer() in this module.
     """
-    add_parser_argument(
-        parser, 'deploy_aws_name', defaults, None,
-        help='Value for name to tag instance with.')
-    add_parser_argument(
-        parser, 'deploy_aws_pem_path', defaults, None,
-        help='Path to the EC2 PEM file.')
-    add_parser_argument(
-        parser, 'deploy_aws_security_group', defaults, None,
-        help='Name of EC2 security group.')
 
-    # Make this instead default to a search for the current image.
-    # https://cloud-images.ubuntu.com/locator/ec2/
-    add_parser_argument(
-        # 14.04 east-1 hvm:ebs
-        parser, 'deploy_aws_ami', defaults, 'ami-0b542c1d',
-        help='Image ID to run.')
-    add_parser_argument(
-        parser, 'deploy_aws_region', defaults, 'us-east-1',
-        help='Region to deploy aws instance into.'
-             ' Need an aws profile with this name')
+    @classmethod
+    def init_platform_argument_parser(cls, parser, defaults):
+        """Adds custom configuration parameters to argument parser.
 
-  @classmethod
-  def validate_options_helper(cls, options):
-    """Adds custom configuration parameters to argument parser.
+        This is a helper function for the free function init_argument_parser().
+        """
+        add_parser_argument(
+            parser,
+            "deploy_aws_name",
+            defaults,
+            None,
+            help="Value for name to tag instance with.",
+        )
+        add_parser_argument(
+            parser,
+            "deploy_aws_pem_path",
+            defaults,
+            None,
+            help="Path to the EC2 PEM file.",
+        )
+        add_parser_argument(
+            parser,
+            "deploy_aws_security_group",
+            defaults,
+            None,
+            help="Name of EC2 security group.",
+        )
 
-    This is a helper function for make_deployer().
-    """
-    if not options.deploy_aws_name:
-      return
-    if not options.deploy_aws_pem_path:
-      raise_and_log_error(ConfigError('--deploy_aws_pem_path not specified.'))
-    if not os.path.exists(options.deploy_aws_pem_path):
-      raise_and_log_error(
-          ConfigError('File "{path}" does not exist.'
-                      .format(path=options.deploy_aws_pem_path)))
-    if not options.deploy_aws_security_group:
-      raise_and_log_error(
-          ConfigError('--deploy_aws_security_group not specified.'))
+        # Make this instead default to a search for the current image.
+        # https://cloud-images.ubuntu.com/locator/ec2/
+        add_parser_argument(
+            # 14.04 east-1 hvm:ebs
+            parser,
+            "deploy_aws_ami",
+            defaults,
+            "ami-0b542c1d",
+            help="Image ID to run.",
+        )
+        add_parser_argument(
+            parser,
+            "deploy_aws_region",
+            defaults,
+            "us-east-1",
+            help="Region to deploy aws instance into."
+            " Need an aws profile with this name",
+        )
 
-    if options.deploy_deploy:
-      logging.debug('Looking for existing EC2 instance.')
-      retcode, stdout = run_subprocess(
-          'aws ec2 describe-instances'
-          ' --profile {region}'
-          ' --filters "Name=tag:Name,Values={name}"'
-          ' "Name=instance-state-name,Values=running"'
-          .format(region=options.deploy_aws_region,
-                  name=options.deploy_aws_name))
-      if retcode != 0:
-        raise_and_log_error(
-            ExecutionError('Could not probe AWS: {0}'.format(stdout),
-                           program='aws'))
-      reservations = decode_json(stdout).get('Reservations')
-      # For some reason aws is ignoring our filter, so check again just to be
-      # sure the reservations returned are the ones we asked for.
-      for reservation in reservations or []:
-        for tags in reservation.get('Tags', []):
-          if (tags.get('Key') == 'Name'
-              and tags.get('Value') == options.deploy_aws_name):
+    @classmethod
+    def validate_options_helper(cls, options):
+        """Adds custom configuration parameters to argument parser.
+
+        This is a helper function for make_deployer().
+        """
+        if not options.deploy_aws_name:
+            return
+        if not options.deploy_aws_pem_path:
+            raise_and_log_error(ConfigError("--deploy_aws_pem_path not specified."))
+        if not os.path.exists(options.deploy_aws_pem_path):
             raise_and_log_error(
                 ConfigError(
-                    'Running "{name}" already exists: {info}'
-                    .format(name=options.deploy_aws_name, info=reservation),
-                    cause='VmExists'))
-        logging.warning('aws returned another instance - ignore: %s',
-                        reservation)
+                    'File "{path}" does not exist.'.format(
+                        path=options.deploy_aws_pem_path
+                    )
+                )
+            )
+        if not options.deploy_aws_security_group:
+            raise_and_log_error(
+                ConfigError("--deploy_aws_security_group not specified.")
+            )
 
-  def __init__(self, options, metrics, **kwargs):
-    super(AwsValidateBomDeployer, self).__init__(options, metrics, **kwargs)
-    self.__instance_id = None
-    self.ssh_key_path = options.deploy_aws_pem_path
+        if options.deploy_deploy:
+            logging.debug("Looking for existing EC2 instance.")
+            retcode, stdout = run_subprocess(
+                "aws ec2 describe-instances"
+                " --profile {region}"
+                ' --filters "Name=tag:Name,Values={name}"'
+                ' "Name=instance-state-name,Values=running"'.format(
+                    region=options.deploy_aws_region, name=options.deploy_aws_name
+                )
+            )
+            if retcode != 0:
+                raise_and_log_error(
+                    ExecutionError(
+                        "Could not probe AWS: {0}".format(stdout), program="aws"
+                    )
+                )
+            reservations = decode_json(stdout).get("Reservations")
+            # For some reason aws is ignoring our filter, so check again just to be
+            # sure the reservations returned are the ones we asked for.
+            for reservation in reservations or []:
+                for tags in reservation.get("Tags", []):
+                    if (
+                        tags.get("Key") == "Name"
+                        and tags.get("Value") == options.deploy_aws_name
+                    ):
+                        raise_and_log_error(
+                            ConfigError(
+                                'Running "{name}" already exists: {info}'.format(
+                                    name=options.deploy_aws_name, info=reservation
+                                ),
+                                cause="VmExists",
+                            )
+                        )
+                logging.warning(
+                    "aws returned another instance - ignore: %s", reservation
+                )
 
-  def __find_instance_with_name(self, response, name):
-    """Locate the desired instance in the response."""
-    if not response:
-      logging.error('Unexpected empty response.')
-      return {}
+    def __init__(self, options, metrics, **kwargs):
+        super(AwsValidateBomDeployer, self).__init__(options, metrics, **kwargs)
+        self.__instance_id = None
+        self.ssh_key_path = options.deploy_aws_pem_path
 
-    for elem in response:
-      for instance in elem['Instances']:
-        for tag in instance.get('Tags', []):
-          if tag['Key'] == 'Name' and tag['Value'] == name:
-            return instance
+    def __find_instance_with_name(self, response, name):
+        """Locate the desired instance in the response."""
+        if not response:
+            logging.error("Unexpected empty response.")
+            return {}
 
-    logging.error('No instance tagged %r found in response.', name)
-    return {}
+        for elem in response:
+            for instance in elem["Instances"]:
+                for tag in instance.get("Tags", []):
+                    if tag["Key"] == "Name" and tag["Value"] == name:
+                        return instance
 
-  def do_determine_instance_ip(self):
-    """Implements GenericVmValidateBomDeployer interface."""
-    options = self.options
-    logging.debug('Looking up EC2 instance IP.')
-    retcode, stdout = run_subprocess(
-        'aws ec2 describe-instances'
-        ' --profile {region}'
-        ' --output json'
-        ' --filters "Name=tag:Name,Values={name}"'
-        ' "Name=instance-state-name,Values=running"'
-        .format(region=options.deploy_aws_region,
-                name=options.deploy_aws_name))
-    if retcode != 0:
-      raise_and_log_error(
-          ExecutionError('Could not determine public IP: {0}'.format(stdout),
-                         program='aws'))
-    found = decode_json(stdout).get('Reservations')
-    if not found:
-      raise_and_log_error(
-          ResponseError(
-              '"{0}" is not running'.format(options.deploy_aws_name),
-              server='ec2'))
+        logging.error("No instance tagged %r found in response.", name)
+        return {}
 
-    try:
-      # Although we filtered, sometimes aws CLI returns others.
-      instance = self.__find_instance_with_name(
-          found, options.deploy_aws_name)
-      public_ip = instance['PublicIpAddress']
-    except KeyError:
-      logging.error('**** aws ec2 describe instances returned %r\n'
-                    'expected "PublicIpAddress" for instance named %s',
-                    found, options.deploy_aws_name)
-      raise
-    logging.debug('Using public IP=%s', public_ip)
-    return public_ip
+    def do_determine_instance_ip(self):
+        """Implements GenericVmValidateBomDeployer interface."""
+        options = self.options
+        logging.debug("Looking up EC2 instance IP.")
+        retcode, stdout = run_subprocess(
+            "aws ec2 describe-instances"
+            " --profile {region}"
+            " --output json"
+            ' --filters "Name=tag:Name,Values={name}"'
+            ' "Name=instance-state-name,Values=running"'.format(
+                region=options.deploy_aws_region, name=options.deploy_aws_name
+            )
+        )
+        if retcode != 0:
+            raise_and_log_error(
+                ExecutionError(
+                    "Could not determine public IP: {0}".format(stdout), program="aws"
+                )
+            )
+        found = decode_json(stdout).get("Reservations")
+        if not found:
+            raise_and_log_error(
+                ResponseError(
+                    '"{0}" is not running'.format(options.deploy_aws_name), server="ec2"
+                )
+            )
 
-  def do_create_vm(self, options):
-    """Implements GenericVmValidateBomDeployer interface."""
-    pem_basename = os.path.basename(options.deploy_aws_pem_path)
-    key_pair_name = os.path.splitext(pem_basename)[0]
-    logging.info('Creating "%s" with key-pair "%s"',
-                 options.deploy_aws_name, key_pair_name)
+        try:
+            # Although we filtered, sometimes aws CLI returns others.
+            instance = self.__find_instance_with_name(found, options.deploy_aws_name)
+            public_ip = instance["PublicIpAddress"]
+        except KeyError:
+            logging.error(
+                "**** aws ec2 describe instances returned %r\n"
+                'expected "PublicIpAddress" for instance named %s',
+                found,
+                options.deploy_aws_name,
+            )
+            raise
+        logging.debug("Using public IP=%s", public_ip)
+        return public_ip
 
-    logging.debug('Creating new EC2 VM.')
-    response = check_subprocess(
-        'aws ec2 run-instances'
-        ' --profile {region}'
-        ' --output json'
-        ' --count 1'
-        ' --image-id {ami}'
-        ' --instance-type {type}'
-        ' --key-name {key_pair_name}'
-        ' --security-group-ids {sg}'
-        .format(region=options.deploy_aws_region,
+    def do_create_vm(self, options):
+        """Implements GenericVmValidateBomDeployer interface."""
+        pem_basename = os.path.basename(options.deploy_aws_pem_path)
+        key_pair_name = os.path.splitext(pem_basename)[0]
+        logging.info(
+            'Creating "%s" with key-pair "%s"', options.deploy_aws_name, key_pair_name
+        )
+
+        logging.debug("Creating new EC2 VM.")
+        response = check_subprocess(
+            "aws ec2 run-instances"
+            " --profile {region}"
+            " --output json"
+            " --count 1"
+            " --image-id {ami}"
+            " --instance-type {type}"
+            " --key-name {key_pair_name}"
+            " --security-group-ids {sg}".format(
+                region=options.deploy_aws_region,
                 ami=options.deploy_aws_ami,
-                type='t2.xlarge',  # 4 core x 16G
+                type="t2.xlarge",  # 4 core x 16G
                 key_pair_name=key_pair_name,
-                sg=options.deploy_aws_security_group))
-    doc = decode_json(response)
-    self.__instance_id = doc["Instances"][0]["InstanceId"]
-    logging.info('Created instance id=%s to tag as "%s"',
-                 self.__instance_id, options.deploy_aws_name)
+                sg=options.deploy_aws_security_group,
+            )
+        )
+        doc = decode_json(response)
+        self.__instance_id = doc["Instances"][0]["InstanceId"]
+        logging.info(
+            'Created instance id=%s to tag as "%s"',
+            self.__instance_id,
+            options.deploy_aws_name,
+        )
 
-    # It's slow to start up and sometimes there is a race condition
-    # in which describe-instances doesnt know about our id even though
-    # create-tags did, or create-tags doesnt know abut the new id.
-    time.sleep(5)
-    end_time = time.time() + 10*60
-    did_tag = False
-    while time.time() < end_time:
-      if not did_tag:
-        tag_retcode, _ = run_subprocess(
-            'aws ec2 create-tags'
-            ' --region {region}'
-            ' --resources {instance_id}'
-            ' --tags "Key=Name,Value={name}"'
-            .format(region=options.deploy_aws_region,
-                    instance_id=self.__instance_id,
-                    name=options.deploy_aws_name))
-        did_tag = tag_retcode == 0
-      if self.__is_ready():
-        return
-      time.sleep(5)
-    raise_and_log_error(
-        TimeoutError('Giving up waiting for deployment.', cause='ec2'))
+        # It's slow to start up and sometimes there is a race condition
+        # in which describe-instances doesnt know about our id even though
+        # create-tags did, or create-tags doesnt know abut the new id.
+        time.sleep(5)
+        end_time = time.time() + 10 * 60
+        did_tag = False
+        while time.time() < end_time:
+            if not did_tag:
+                tag_retcode, _ = run_subprocess(
+                    "aws ec2 create-tags"
+                    " --region {region}"
+                    " --resources {instance_id}"
+                    ' --tags "Key=Name,Value={name}"'.format(
+                        region=options.deploy_aws_region,
+                        instance_id=self.__instance_id,
+                        name=options.deploy_aws_name,
+                    )
+                )
+                did_tag = tag_retcode == 0
+            if self.__is_ready():
+                return
+            time.sleep(5)
+        raise_and_log_error(
+            TimeoutError("Giving up waiting for deployment.", cause="ec2")
+        )
 
-  def __is_ready(self):
-    retcode, stdout = run_subprocess(
-        'aws ec2 describe-instances'
-        ' --profile {region}'
-        ' --output json'
-        ' --instance-ids {id}'
-        ' --query "Reservations[*].Instances[*]"'
-        .format(region=self.options.deploy_aws_region,
-                id=self.__instance_id))
-    if retcode != 0:
-      logging.warning('Could not determine public IP: %s', stdout)
-      return False
+    def __is_ready(self):
+        retcode, stdout = run_subprocess(
+            "aws ec2 describe-instances"
+            " --profile {region}"
+            " --output json"
+            " --instance-ids {id}"
+            ' --query "Reservations[*].Instances[*]"'.format(
+                region=self.options.deploy_aws_region, id=self.__instance_id
+            )
+        )
+        if retcode != 0:
+            logging.warning("Could not determine public IP: %s", stdout)
+            return False
 
-    # result is an array of reservations of ararys of instances.
-    # but we only expect one, so fish out the first instance info
-    info = decode_json(stdout)[0][0]
-    state = info.get('State', {}).get('Name')
-    if state in ['pending', 'initializing']:
-      logging.info('Waiting for %s to finish initializing (state=%s)',
-                   self.__instance_id, state)
-      return False
+        # result is an array of reservations of ararys of instances.
+        # but we only expect one, so fish out the first instance info
+        info = decode_json(stdout)[0][0]
+        state = info.get("State", {}).get("Name")
+        if state in ["pending", "initializing"]:
+            logging.info(
+                "Waiting for %s to finish initializing (state=%s)",
+                self.__instance_id,
+                state,
+            )
+            return False
 
-    if state in ['shutting-down', 'terminated']:
-      raise_and_log_error(ResponseError('VM failed: {0}'.format(info),
-                                        server='ec2'))
+        if state in ["shutting-down", "terminated"]:
+            raise_and_log_error(
+                ResponseError("VM failed: {0}".format(info), server="ec2")
+            )
 
-    logging.info('%s is in state %s', self.__instance_id, state)
-    self.set_instance_ip(info.get('PublicIpAddress'))
-    # attempt to ssh into it so we know we're accepting connections when
-    # we return. It takes time to start
-    logging.info('Checking if it is ready for ssh...')
-    retcode, stdout = run_subprocess(
-        'ssh'
-        ' -i {ssh_key}'
-        ' -o StrictHostKeyChecking=no'
-        ' -o UserKnownHostsFile=/dev/null'
-        ' {user}@{ip}'
-        ' "exit 0"'
-        .format(user=self.hal_user,
-                ip=self.instance_ip,
-                ssh_key=self.ssh_key_path))
-    if retcode == 0:
-      logging.info('%s is ready', self.instance_ip)
-      return True
+        logging.info("%s is in state %s", self.__instance_id, state)
+        self.set_instance_ip(info.get("PublicIpAddress"))
+        # attempt to ssh into it so we know we're accepting connections when
+        # we return. It takes time to start
+        logging.info("Checking if it is ready for ssh...")
+        retcode, stdout = run_subprocess(
+            "ssh"
+            " -i {ssh_key}"
+            " -o StrictHostKeyChecking=no"
+            " -o UserKnownHostsFile=/dev/null"
+            " {user}@{ip}"
+            ' "exit 0"'.format(
+                user=self.hal_user, ip=self.instance_ip, ssh_key=self.ssh_key_path
+            )
+        )
+        if retcode == 0:
+            logging.info("%s is ready", self.instance_ip)
+            return True
 
-    # Sometimes ssh accepts but authentication still fails
-    # for a while. If this is the case, then try again
-    # though the whole loop to distinguish VM going away.
-    logging.info('%s\nNot yet ready...', stdout.strip())
-    return False
+        # Sometimes ssh accepts but authentication still fails
+        # for a while. If this is the case, then try again
+        # though the whole loop to distinguish VM going away.
+        logging.info("%s\nNot yet ready...", stdout.strip())
+        return False
 
-  def do_undeploy(self):
-    """Implements the BaseBomValidateDeployer interface."""
-    options = self.options
-    logging.info('Terminating "%s"', options.deploy_aws_name)
+    def do_undeploy(self):
+        """Implements the BaseBomValidateDeployer interface."""
+        options = self.options
+        logging.info('Terminating "%s"', options.deploy_aws_name)
 
-    if self.__instance_id:
-      all_ids = [self.__instance_id]
-    else:
-      lookup_response = check_subprocess(
-          'aws ec2 describe-instances'
-          ' --profile {region}'
-          ' --filters "Name=tag:Name,Values={name}"'
-          ' "Name=instance-state-name,Values=running"'
-          .format(region=options.deploy_aws_region,
-                  name=options.deploy_aws_name))
-      exists = decode_json(lookup_response).get('Reservations')
-      if not exists:
-        logging.warning('"%s" is not running', options.deploy_aws_name)
-        return
-      all_ids = []
-      for reservation in exists:
-        all_ids.extend([instance['InstanceId']
-                        for instance in reservation['Instances']])
+        if self.__instance_id:
+            all_ids = [self.__instance_id]
+        else:
+            lookup_response = check_subprocess(
+                "aws ec2 describe-instances"
+                " --profile {region}"
+                ' --filters "Name=tag:Name,Values={name}"'
+                ' "Name=instance-state-name,Values=running"'.format(
+                    region=options.deploy_aws_region, name=options.deploy_aws_name
+                )
+            )
+            exists = decode_json(lookup_response).get("Reservations")
+            if not exists:
+                logging.warning('"%s" is not running', options.deploy_aws_name)
+                return
+            all_ids = []
+            for reservation in exists:
+                all_ids.extend(
+                    [instance["InstanceId"] for instance in reservation["Instances"]]
+                )
 
-    for instance_id in all_ids:
-      logging.info('Terminating "%s" instanceId=%s',
-                   options.deploy_aws_name, instance_id)
-      retcode, _ = run_subprocess(
-          'aws ec2 terminate-instances'
-          '  --profile {region}'
-          '  --instance-ids {id}'
-          .format(region=options.deploy_aws_region, id=instance_id))
-      if retcode != 0:
-        logging.warning('Failed to delete "%s" instanceId=%s',
-                        options.deploy_aws_name, instance_id)
+        for instance_id in all_ids:
+            logging.info(
+                'Terminating "%s" instanceId=%s', options.deploy_aws_name, instance_id
+            )
+            retcode, _ = run_subprocess(
+                "aws ec2 terminate-instances"
+                "  --profile {region}"
+                "  --instance-ids {id}".format(
+                    region=options.deploy_aws_region, id=instance_id
+                )
+            )
+            if retcode != 0:
+                logging.warning(
+                    'Failed to delete "%s" instanceId=%s',
+                    options.deploy_aws_name,
+                    instance_id,
+                )
 
 
 class AzureValidateBomDeployer(GenericVmValidateBomDeployer):
-  """Concrete deployer used to deploy Hal onto Microsoft Azure
+    """Concrete deployer used to deploy Hal onto Microsoft Azure
 
-  This class is not intended to be constructed directly. Instead see the
-  free function make_deployer() in this module.
-  """
-
-  @classmethod
-  def init_platform_argument_parser(cls, parser, defaults):
-    """Adds custom configuration parameters to argument parser.
-
-    This is a helper function for the free function init_argument_parser().
+    This class is not intended to be constructed directly. Instead see the
+    free function make_deployer() in this module.
     """
-    add_parser_argument(
-        parser, 'deploy_azure_location', defaults, 'eastus',
-        help='Azure region to deploy to if --deploy_hal_platform is "azure".')
-    add_parser_argument(
-        parser, 'deploy_azure_resource_group', defaults, None,
-        help='Azure resource group to deploy to'
-             ' if --deploy_hal_platform is "azure".')
-    add_parser_argument(
-        parser, 'deploy_azure_name', defaults, None,
-        help='Azure VM name to deploy to if --deploy_hal_platform is "azure".')
-    add_parser_argument(
-        parser, 'deploy_azure_image',
-        defaults, 'Canonical:UbuntuServer:14.04.5-LTS:latest',
-        help='Azure image to deploy.')
 
-  @classmethod
-  def validate_options_helper(cls, options):
-    """Adds custom configuration parameters to argument parser.
+    @classmethod
+    def init_platform_argument_parser(cls, parser, defaults):
+        """Adds custom configuration parameters to argument parser.
 
-    This is a helper function for make_deployer().
-    """
-    if not options.deploy_azure_resource_group:
-      raise_and_log_error(
-          ConfigError('--deploy_azure_resource_group not specified.'))
-    if not options.deploy_azure_name:
-      raise_and_log_error(
-          ConfigError('--deploy_azure_name not specified.'))
+        This is a helper function for the free function init_argument_parser().
+        """
+        add_parser_argument(
+            parser,
+            "deploy_azure_location",
+            defaults,
+            "eastus",
+            help='Azure region to deploy to if --deploy_hal_platform is "azure".',
+        )
+        add_parser_argument(
+            parser,
+            "deploy_azure_resource_group",
+            defaults,
+            None,
+            help="Azure resource group to deploy to"
+            ' if --deploy_hal_platform is "azure".',
+        )
+        add_parser_argument(
+            parser,
+            "deploy_azure_name",
+            defaults,
+            None,
+            help='Azure VM name to deploy to if --deploy_hal_platform is "azure".',
+        )
+        add_parser_argument(
+            parser,
+            "deploy_azure_image",
+            defaults,
+            "Canonical:UbuntuServer:14.04.5-LTS:latest",
+            help="Azure image to deploy.",
+        )
 
-    if options.deploy_deploy:
-      retcode, _ = run_subprocess(
-          'az vm show --resource-group {rg} --vm-name {name}'
-          .format(rg=options.deploy_azure_resource_group,
-                  name=options.deploy_azure_name))
+    @classmethod
+    def validate_options_helper(cls, options):
+        """Adds custom configuration parameters to argument parser.
 
-      if retcode == 0:
-        raise_and_log_error(UnexpectedError(
-            '"{name}" already exists in resource-group={rg}'
-            .format(name=options.deploy_azure_name,
-                    rg=options.deploy_azure_resource_group)))
+        This is a helper function for make_deployer().
+        """
+        if not options.deploy_azure_resource_group:
+            raise_and_log_error(
+                ConfigError("--deploy_azure_resource_group not specified.")
+            )
+        if not options.deploy_azure_name:
+            raise_and_log_error(ConfigError("--deploy_azure_name not specified."))
 
-  def do_create_vm(self, options):
-    """Implements GenericVmValidateBomDeployer interface."""
-    logging.info('Creating "%s" in resource-group "%s"',
-                 options.deploy_azure_name,
-                 options.deploy_azure_resource_group)
+        if options.deploy_deploy:
+            retcode, _ = run_subprocess(
+                "az vm show --resource-group {rg} --vm-name {name}".format(
+                    rg=options.deploy_azure_resource_group,
+                    name=options.deploy_azure_name,
+                )
+            )
 
-    response = check_subprocess(
-        'az vm create'
-        ' --name {name}'
-        ' --resource-group {rg}'
-        ' --location {location}'
-        ' --image {image}'
-        ' --use-unmanaged-disk'
-        ' --storage-sku Standard_LRS'
-        ' --size Standard_D12_v2_Promo'
-        ' --ssh-key-value {ssh_key_path}.pub'
-        .format(name=options.deploy_azure_name,
+            if retcode == 0:
+                raise_and_log_error(
+                    UnexpectedError(
+                        '"{name}" already exists in resource-group={rg}'.format(
+                            name=options.deploy_azure_name,
+                            rg=options.deploy_azure_resource_group,
+                        )
+                    )
+                )
+
+    def do_create_vm(self, options):
+        """Implements GenericVmValidateBomDeployer interface."""
+        logging.info(
+            'Creating "%s" in resource-group "%s"',
+            options.deploy_azure_name,
+            options.deploy_azure_resource_group,
+        )
+
+        response = check_subprocess(
+            "az vm create"
+            " --name {name}"
+            " --resource-group {rg}"
+            " --location {location}"
+            " --image {image}"
+            " --use-unmanaged-disk"
+            " --storage-sku Standard_LRS"
+            " --size Standard_D12_v2_Promo"
+            " --ssh-key-value {ssh_key_path}.pub".format(
+                name=options.deploy_azure_name,
                 rg=options.deploy_azure_resource_group,
                 location=options.deploy_azure_location,
                 image=options.deploy_azure_image,
-                ssh_key_path=self.ssh_key_path))
-    self.set_instance_ip(decode_json(response)['publicIpAddress'])
+                ssh_key_path=self.ssh_key_path,
+            )
+        )
+        self.set_instance_ip(decode_json(response)["publicIpAddress"])
 
-  def do_undeploy(self):
-    """Implements the BaseBomValidateDeployer interface."""
-    options = self.options
-    if options.deploy_spinnaker_type == 'distributed':
-      run_subprocess(
-          'ssh'
-          ' -i {ssh_key}'
-          ' -o StrictHostKeyChecking=no'
-          ' -o UserKnownHostsFile=/dev/null'
-          ' {user}@{ip} sudo hal -q --log=info deploy clean'
-          .format(user=self.hal_user,
-                  ip=self.instance_ip,
-                  ssh_key=self.ssh_key_path))
-    check_subprocess(
-        'az vm delete -y'
-        ' --name {name}'
-        ' --resource-group {rg}'
-        .format(name=options.deploy_azure_name,
-                rg=options.deploy_azure_resource_group))
+    def do_undeploy(self):
+        """Implements the BaseBomValidateDeployer interface."""
+        options = self.options
+        if options.deploy_spinnaker_type == "distributed":
+            run_subprocess(
+                "ssh"
+                " -i {ssh_key}"
+                " -o StrictHostKeyChecking=no"
+                " -o UserKnownHostsFile=/dev/null"
+                " {user}@{ip} sudo hal -q --log=info deploy clean".format(
+                    user=self.hal_user, ip=self.instance_ip, ssh_key=self.ssh_key_path
+                )
+            )
+        check_subprocess(
+            "az vm delete -y"
+            " --name {name}"
+            " --resource-group {rg}".format(
+                name=options.deploy_azure_name, rg=options.deploy_azure_resource_group
+            )
+        )
 
-  def do_determine_instance_ip(self):
-    """Implements GenericVmValidateBomDeployer interface."""
-    options = self.options
-    retcode, stdout = run_subprocess(
-        'az vm list-ip-addresses --name {name} --resource-group {group}'.format(
-            name=options.deploy_azure_name,
-            group=options.deploy_azure_resource_group))
-    if retcode != 0:
-      raise_and_log_error(
-          ExecutionError('Could not determine public IP: {0}'.format(stdout),
-                         program='az'))
-    found = decode_json(stdout)[0].get('virtualMachine')
-    if not found:
-      raise_and_log_error(
-          ResponseError(
-              '"{0}" is not running'.format(options.deploy_azure_name),
-              server='az'))
-    return found['network']['publicIpAddresses'][0]['ipAddress']
+    def do_determine_instance_ip(self):
+        """Implements GenericVmValidateBomDeployer interface."""
+        options = self.options
+        retcode, stdout = run_subprocess(
+            "az vm list-ip-addresses --name {name} --resource-group {group}".format(
+                name=options.deploy_azure_name,
+                group=options.deploy_azure_resource_group,
+            )
+        )
+        if retcode != 0:
+            raise_and_log_error(
+                ExecutionError(
+                    "Could not determine public IP: {0}".format(stdout), program="az"
+                )
+            )
+        found = decode_json(stdout)[0].get("virtualMachine")
+        if not found:
+            raise_and_log_error(
+                ResponseError(
+                    '"{0}" is not running'.format(options.deploy_azure_name),
+                    server="az",
+                )
+            )
+        return found["network"]["publicIpAddresses"][0]["ipAddress"]
 
 
 class GoogleValidateBomDeployer(GenericVmValidateBomDeployer):
-  """Concrete deployer used to deploy Hal onto Google Cloud Platform.
+    """Concrete deployer used to deploy Hal onto Google Cloud Platform.
 
-  This class is not intended to be constructed directly. Instead see the
-  free function make_deployer() in this module.
-  """
+    This class is not intended to be constructed directly. Instead see the
+    free function make_deployer() in this module.
+    """
 
-  def do_determine_instance_ip(self):
-    """Implements GenericVmValidateBomDeployer interface."""
-    options = self.options
+    def do_determine_instance_ip(self):
+        """Implements GenericVmValidateBomDeployer interface."""
+        options = self.options
 
-    # Note: this used to dup_stderr_to_stdout=False with an older API
-    # presumably this wont return stderr anymore or it will corrupt the json.
-    logging.debug('Looking up IP address for "%s"...',
-                  options.deploy_google_instance)
-    response = check_subprocess(
-        'gcloud compute instances describe'
-        ' --format json'
-        ' --account {gcloud_account}'
-        ' --project {project} --zone {zone} {instance}'
-        .format(gcloud_account=options.deploy_hal_google_service_account,
+        # Note: this used to dup_stderr_to_stdout=False with an older API
+        # presumably this wont return stderr anymore or it will corrupt the json.
+        logging.debug(
+            'Looking up IP address for "%s"...', options.deploy_google_instance
+        )
+        response = check_subprocess(
+            "gcloud compute instances describe"
+            " --format json"
+            " --account {gcloud_account}"
+            " --project {project} --zone {zone} {instance}".format(
+                gcloud_account=options.deploy_hal_google_service_account,
                 project=options.deploy_google_project,
                 zone=options.deploy_google_zone,
-                instance=options.deploy_google_instance),
-        # Setting this to PIPE means it will get logged instead of getting
-        # commingled with stdout into the response
-        stderr=subprocess.PIPE)
-    nic = decode_json(response)['networkInterfaces'][0]
+                instance=options.deploy_google_instance,
+            ),
+            # Setting this to PIPE means it will get logged instead of getting
+            # commingled with stdout into the response
+            stderr=subprocess.PIPE,
+        )
+        nic = decode_json(response)["networkInterfaces"][0]
 
-    use_internal_ip = options.deploy_google_use_internal_ip
-    if use_internal_ip:
-      logging.debug('Using internal IP=%s', nic['networkIP'])
-      return nic['networkIP']
+        use_internal_ip = options.deploy_google_use_internal_ip
+        if use_internal_ip:
+            logging.debug("Using internal IP=%s", nic["networkIP"])
+            return nic["networkIP"]
 
-    ip = nic['accessConfigs'][0]['natIP']
-    logging.debug('Using natIP=%s', ip)
-    return ip
+        ip = nic["accessConfigs"][0]["natIP"]
+        logging.debug("Using natIP=%s", ip)
+        return ip
 
-  def __init__(self, options, metrics, **kwargs):
-    super(GoogleValidateBomDeployer, self).__init__(options, metrics, **kwargs)
+    def __init__(self, options, metrics, **kwargs):
+        super(GoogleValidateBomDeployer, self).__init__(options, metrics, **kwargs)
 
-  @classmethod
-  def init_platform_argument_parser(cls, parser, defaults):
-    """Adds custom configuration parameters to argument parser.
+    @classmethod
+    def init_platform_argument_parser(cls, parser, defaults):
+        """Adds custom configuration parameters to argument parser.
 
-    This is a helper function for the free function init_argument_parser().
-    """
-    add_parser_argument(
-        parser, 'deploy_google_project', defaults, None,
-        help='Google project to deploy to if --deploy_hal_platform is "gce".')
-    add_parser_argument(
-        parser, 'deploy_google_zone', defaults, 'us-central1-f',
-        help='Google zone to deploy to if --deploy_hal_platform is "gce".')
-    add_parser_argument(
-        parser, 'deploy_google_instance', defaults, None,
-        help='Google instance to deploy to if --deploy_hal_platform is "gce".')
-    add_parser_argument(
-        parser, 'deploy_google_machine_type', defaults, 'n1-standard-4',
-        help='Google machine type if --deploy_hal_platform is "gce".')
-    add_parser_argument(
-        parser, 'deploy_google_image_family', defaults, 'ubuntu-1604-lts',
-        help='Google image family to deploy if --deploy_hal_platform is "gce".')
-    add_parser_argument(
-        parser, 'deploy_google_image_project', defaults, 'ubuntu-os-cloud',
-        help='Project containing image from --deploy_google_image_family.')
-    add_parser_argument(
-        parser, 'deploy_google_network', defaults, 'default',
-        help='The GCP Network to deploy spinnaker into.')
+        This is a helper function for the free function init_argument_parser().
+        """
+        add_parser_argument(
+            parser,
+            "deploy_google_project",
+            defaults,
+            None,
+            help='Google project to deploy to if --deploy_hal_platform is "gce".',
+        )
+        add_parser_argument(
+            parser,
+            "deploy_google_zone",
+            defaults,
+            "us-central1-f",
+            help='Google zone to deploy to if --deploy_hal_platform is "gce".',
+        )
+        add_parser_argument(
+            parser,
+            "deploy_google_instance",
+            defaults,
+            None,
+            help='Google instance to deploy to if --deploy_hal_platform is "gce".',
+        )
+        add_parser_argument(
+            parser,
+            "deploy_google_machine_type",
+            defaults,
+            "n1-standard-4",
+            help='Google machine type if --deploy_hal_platform is "gce".',
+        )
+        add_parser_argument(
+            parser,
+            "deploy_google_image_family",
+            defaults,
+            "ubuntu-1604-lts",
+            help='Google image family to deploy if --deploy_hal_platform is "gce".',
+        )
+        add_parser_argument(
+            parser,
+            "deploy_google_image_project",
+            defaults,
+            "ubuntu-os-cloud",
+            help="Project containing image from --deploy_google_image_family.",
+        )
+        add_parser_argument(
+            parser,
+            "deploy_google_network",
+            defaults,
+            "default",
+            help="The GCP Network to deploy spinnaker into.",
+        )
 
-    add_parser_argument(
-        parser, 'deploy_google_use_internal_ip', defaults, True, type=bool,
-        help='Force the internal IP to connect to the deployed instance.'
-        ' This is only valid when talking within the same project.')
-    parser.add_argument(
-        '--deploy_google_use_external_ip',
-        dest='deploy_google_use_internal_ip', action='store_false',
-        help='DEPRECATED: Use --deploy_google_use_internal_ip=false')
+        add_parser_argument(
+            parser,
+            "deploy_google_use_internal_ip",
+            defaults,
+            True,
+            type=bool,
+            help="Force the internal IP to connect to the deployed instance."
+            " This is only valid when talking within the same project.",
+        )
+        parser.add_argument(
+            "--deploy_google_use_external_ip",
+            dest="deploy_google_use_internal_ip",
+            action="store_false",
+            help="DEPRECATED: Use --deploy_google_use_internal_ip=false",
+        )
 
-    add_parser_argument(
-        parser, 'deploy_google_tags',
-        defaults, 'spinnaker-validation-instance',
-        help='A comma-delimited list of GCP network tags to tag'
-             ' the deployed instances with.')
+        add_parser_argument(
+            parser,
+            "deploy_google_tags",
+            defaults,
+            "spinnaker-validation-instance",
+            help="A comma-delimited list of GCP network tags to tag"
+            " the deployed instances with.",
+        )
 
-    add_parser_argument(
-        parser, 'deploy_hal_google_service_account', defaults, None,
-        help='When deploying to gce, this is the service account to use'
-             ' for configuring halyard.')
+        add_parser_argument(
+            parser,
+            "deploy_hal_google_service_account",
+            defaults,
+            None,
+            help="When deploying to gce, this is the service account to use"
+            " for configuring halyard.",
+        )
 
-  @classmethod
-  def validate_options_helper(cls, options):
-    """Adds custom configuration parameters to argument parser.
+    @classmethod
+    def validate_options_helper(cls, options):
+        """Adds custom configuration parameters to argument parser.
 
-    This is a helper function for make_deployer().
-    """
-    if not options.deploy_google_project:
-      raise_and_log_error(
-          ConfigError('--deploy_google_project not specified.'))
-    if not options.deploy_google_instance:
-      raise_and_log_error(
-          ConfigError('--deploy_google_instance not specified.'))
-    if not options.deploy_hal_google_service_account:
-      raise_and_log_error(
-          ConfigError('--deploy_hal_google_service_account not specified.'))
+        This is a helper function for make_deployer().
+        """
+        if not options.deploy_google_project:
+            raise_and_log_error(ConfigError("--deploy_google_project not specified."))
+        if not options.deploy_google_instance:
+            raise_and_log_error(ConfigError("--deploy_google_instance not specified."))
+        if not options.deploy_hal_google_service_account:
+            raise_and_log_error(
+                ConfigError("--deploy_hal_google_service_account not specified.")
+            )
 
-    if options.deploy_deploy:
-      logging.debug('Checking if "%s" already exists...',
-                    options.deploy_google_instance)
-      retcode, _ = run_subprocess(
-          'gcloud compute instances describe'
-          ' --account {gcloud_account}'
-          ' --project {project} --zone {zone} {instance}'
-          .format(gcloud_account=options.deploy_hal_google_service_account,
-                  project=options.deploy_google_project,
-                  zone=options.deploy_google_zone,
-                  instance=options.deploy_google_instance))
-
-      if retcode == 0:
-        raise_and_log_error(ConfigError(
-            '"{instance}" already exists in project={project} zone={zone}'
-            .format(instance=options.deploy_google_instance,
+        if options.deploy_deploy:
+            logging.debug(
+                'Checking if "%s" already exists...', options.deploy_google_instance
+            )
+            retcode, _ = run_subprocess(
+                "gcloud compute instances describe"
+                " --account {gcloud_account}"
+                " --project {project} --zone {zone} {instance}".format(
+                    gcloud_account=options.deploy_hal_google_service_account,
                     project=options.deploy_google_project,
-                    zone=options.deploy_google_zone),
-            cause='VmExists'))
+                    zone=options.deploy_google_zone,
+                    instance=options.deploy_google_instance,
+                )
+            )
 
-  def do_create_vm(self, options):
-    """Implements the BaseBomValidateDeployer interface."""
-    logging.info('Creating "%s" in project "%s"',
-                 options.deploy_google_instance,
-                 options.deploy_google_project)
-    with open(self.ssh_key_path + '.pub', 'r') as f:
-      ssh_key = f.read().strip()
-    if ssh_key.startswith('ssh-rsa'):
-      ssh_key = self.hal_user + ':' + ssh_key
+            if retcode == 0:
+                raise_and_log_error(
+                    ConfigError(
+                        '"{instance}" already exists in project={project} zone={zone}'.format(
+                            instance=options.deploy_google_instance,
+                            project=options.deploy_google_project,
+                            zone=options.deploy_google_zone,
+                        ),
+                        cause="VmExists",
+                    )
+                )
 
-    check_subprocess(
-        'gcloud compute instances create'
-        ' --account {gcloud_account}'
-        ' --machine-type {machine_type}'
-        ' --image-family {image_family}'
-        ' --image-project {image_project}'
-        ' --metadata block-project-ssh-keys=TRUE,ssh-keys="{ssh_key}"'
-        ' --project {project} --zone {zone}'
-        ' --network {network}'
-        ' --tags {network_tags}'
-        ' --scopes {scopes}'
-        ' {instance}'
-        .format(gcloud_account=options.deploy_hal_google_service_account,
+    def do_create_vm(self, options):
+        """Implements the BaseBomValidateDeployer interface."""
+        logging.info(
+            'Creating "%s" in project "%s"',
+            options.deploy_google_instance,
+            options.deploy_google_project,
+        )
+        with open(self.ssh_key_path + ".pub", "r") as f:
+            ssh_key = f.read().strip()
+        if ssh_key.startswith("ssh-rsa"):
+            ssh_key = self.hal_user + ":" + ssh_key
+
+        check_subprocess(
+            "gcloud compute instances create"
+            " --account {gcloud_account}"
+            " --machine-type {machine_type}"
+            " --image-family {image_family}"
+            " --image-project {image_project}"
+            ' --metadata block-project-ssh-keys=TRUE,ssh-keys="{ssh_key}"'
+            " --project {project} --zone {zone}"
+            " --network {network}"
+            " --tags {network_tags}"
+            " --scopes {scopes}"
+            " {instance}".format(
+                gcloud_account=options.deploy_hal_google_service_account,
                 machine_type=options.deploy_google_machine_type,
                 image_family=options.deploy_google_image_family,
                 image_project=options.deploy_google_image_project,
                 project=options.deploy_google_project,
                 zone=options.deploy_google_zone,
-                scopes='compute-rw,storage-full,logging-write,monitoring',
+                scopes="compute-rw,storage-full,logging-write,monitoring",
                 network=options.deploy_google_network,
                 network_tags=options.deploy_google_tags,
                 ssh_key=ssh_key,
-                instance=options.deploy_google_instance),
-      stream=sys.stdout)
+                instance=options.deploy_google_instance,
+            ),
+            stream=sys.stdout,
+        )
 
-  def do_undeploy(self):
-    """Implements the BaseBomValidateDeployer interface."""
-    options = self.options
-    if options.deploy_spinnaker_type == 'distributed':
-      run_subprocess(
-          'ssh'
-          ' -i {ssh_key}'
-          ' -o StrictHostKeyChecking=no'
-          ' -o UserKnownHostsFile=/dev/null'
-          ' {user}@{ip} sudo hal -q --log=info deploy clean'
-          .format(user=self.hal_user,
-                  ip=self.instance_ip,
-                  ssh_key=self.ssh_key_path))
+    def do_undeploy(self):
+        """Implements the BaseBomValidateDeployer interface."""
+        options = self.options
+        if options.deploy_spinnaker_type == "distributed":
+            run_subprocess(
+                "ssh"
+                " -i {ssh_key}"
+                " -o StrictHostKeyChecking=no"
+                " -o UserKnownHostsFile=/dev/null"
+                " {user}@{ip} sudo hal -q --log=info deploy clean".format(
+                    user=self.hal_user, ip=self.instance_ip, ssh_key=self.ssh_key_path
+                )
+            )
 
-    check_subprocess(
-        'gcloud -q compute instances delete'
-        ' --account {gcloud_account}'
-        ' --project {project} --zone {zone} {instance}'
-        .format(gcloud_account=options.deploy_hal_google_service_account,
+        check_subprocess(
+            "gcloud -q compute instances delete"
+            " --account {gcloud_account}"
+            " --project {project} --zone {zone} {instance}".format(
+                gcloud_account=options.deploy_hal_google_service_account,
                 project=options.deploy_google_project,
                 zone=options.deploy_google_zone,
-                instance=options.deploy_google_instance))
+                instance=options.deploy_google_instance,
+            )
+        )
 
 
 def make_deployer(options, metrics):
-  """Public interface to instantiate the desired Deployer.
+    """Public interface to instantiate the desired Deployer.
 
-  Args:
-    options: [Namespace] from an argument parser given to init_argument_parser
-  """
-  if options.deploy_hal_platform == 'gce':
-    hal_klass = GoogleValidateBomDeployer
-  elif options.deploy_hal_platform == 'ec2':
-    hal_klass = AwsValidateBomDeployer
-  elif options.deploy_hal_platform == 'azure':
-    hal_klass = AzureValidateBomDeployer
-  else:
-    raise_and_log_error(ConfigError(
-        'Invalid --deploy_hal_platform=%s' % options.deploy_hal_platform))
-
-  if options.deploy_spinnaker_type not in SUPPORTED_DEPLOYMENT_TYPES:
-    raise_and_log_error(ConfigError(
-        'Invalid --deploy_spinnaker_type "{0}". Must be one of {1}'
-        .format(options.deploy_spinnaker_type, SUPPORTED_DEPLOYMENT_TYPES)))
-
-  # This is the class for accessing the Spinnaker deployment if other than Hal.
-  spin_klass = None
-
-  if options.deploy_spinnaker_type == 'distributed':
-    if (options.deploy_distributed_platform
-        not in SUPPORTED_DISTRIBUTED_PLATFORMS):
-      raise_and_log_error(ConfigError(
-          'A "distributed" deployment requires --deploy_distributed_platform'))
-    if options.deploy_distributed_platform == 'kubernetes_v2':
-      spin_klass = KubernetesV2ValidateBomDeployer
+    Args:
+      options: [Namespace] from an argument parser given to init_argument_parser
+    """
+    if options.deploy_hal_platform == "gce":
+        hal_klass = GoogleValidateBomDeployer
+    elif options.deploy_hal_platform == "ec2":
+        hal_klass = AwsValidateBomDeployer
+    elif options.deploy_hal_platform == "azure":
+        hal_klass = AzureValidateBomDeployer
     else:
-      raise_and_log_error(ConfigError(
-          'Unknown --deploy_distributed_platform.'
-          ' This must be the value of one of the following parameters: {0}'
-          .format(SUPPORTED_DISTRIBUTED_PLATFORMS)))
+        raise_and_log_error(
+            ConfigError(
+                "Invalid --deploy_hal_platform=%s" % options.deploy_hal_platform
+            )
+        )
 
-  hal_klass.validate_options_helper(options)
-  if spin_klass:
-    spin_klass.validate_options_helper(options)
+    if options.deploy_spinnaker_type not in SUPPORTED_DEPLOYMENT_TYPES:
+        raise_and_log_error(
+            ConfigError(
+                'Invalid --deploy_spinnaker_type "{0}". Must be one of {1}'.format(
+                    options.deploy_spinnaker_type, SUPPORTED_DEPLOYMENT_TYPES
+                )
+            )
+        )
 
-  return hal_klass(options, metrics, runtime_class=spin_klass)
+    # This is the class for accessing the Spinnaker deployment if other than Hal.
+    spin_klass = None
+
+    if options.deploy_spinnaker_type == "distributed":
+        if options.deploy_distributed_platform not in SUPPORTED_DISTRIBUTED_PLATFORMS:
+            raise_and_log_error(
+                ConfigError(
+                    'A "distributed" deployment requires --deploy_distributed_platform'
+                )
+            )
+        if options.deploy_distributed_platform == "kubernetes_v2":
+            spin_klass = KubernetesV2ValidateBomDeployer
+        else:
+            raise_and_log_error(
+                ConfigError(
+                    "Unknown --deploy_distributed_platform."
+                    " This must be the value of one of the following parameters: {0}".format(
+                        SUPPORTED_DISTRIBUTED_PLATFORMS
+                    )
+                )
+            )
+
+    hal_klass.validate_options_helper(options)
+    if spin_klass:
+        spin_klass.validate_options_helper(options)
+
+    return hal_klass(options, metrics, runtime_class=spin_klass)
 
 
 def determine_deployment_platform(options):
-  """Helper function to determine the deployment platform being tested.
+    """Helper function to determine the deployment platform being tested.
 
-  This is used for instrumentation purposes.
-  """
-  platform = options.deploy_hal_platform
-  if options.deploy_spinnaker_type == 'distributed':
-    if platform == 'gce':
-      platform = 'gke'
-    else:
-      platform += '+k8s'
-  return platform
+    This is used for instrumentation purposes.
+    """
+    platform = options.deploy_hal_platform
+    if options.deploy_spinnaker_type == "distributed":
+        if platform == "gce":
+            platform = "gke"
+        else:
+            platform += "+k8s"
+    return platform
 
 
 def init_argument_parser(parser, defaults):
-  """Initialize the argument parser with deployment and configuration params.
+    """Initialize the argument parser with deployment and configuration params.
 
-  Args:
-    parser: [ArgumentParser] The argument parser to add the parameters to.
-  """
-  # pylint: disable=line-too-long
-  add_parser_argument(
-      parser, 'halyard_install_script', defaults,
-      'https://raw.githubusercontent.com/spinnaker/halyard/master/install/debian/InstallHalyard.sh',
-      help='The URL to the InstallHalyard.sh script.')
+    Args:
+      parser: [ArgumentParser] The argument parser to add the parameters to.
+    """
+    # pylint: disable=line-too-long
+    add_parser_argument(
+        parser,
+        "halyard_install_script",
+        defaults,
+        "https://raw.githubusercontent.com/spinnaker/halyard/master/install/debian/InstallHalyard.sh",
+        help="The URL to the InstallHalyard.sh script.",
+    )
 
-  add_parser_argument(
-      parser, 'halyard_version', defaults, None,
-      help='If provided, the specific version of halyard to use.')
+    add_parser_argument(
+        parser,
+        "halyard_version",
+        defaults,
+        None,
+        help="If provided, the specific version of halyard to use.",
+    )
 
-  add_parser_argument(
-      parser, 'halyard_bucket_base_url', defaults, None,
-      help='The base URL for the bucket containing the halyard jar files'
-           ' to override, if any.')
+    add_parser_argument(
+        parser,
+        "halyard_bucket_base_url",
+        defaults,
+        None,
+        help="The base URL for the bucket containing the halyard jar files"
+        " to override, if any.",
+    )
 
-  add_parser_argument(
-      parser, 'halyard_config_bucket', defaults, None,
-      help='The global halyard configuration bucket to override, if any.')
+    add_parser_argument(
+        parser,
+        "halyard_config_bucket",
+        defaults,
+        None,
+        help="The global halyard configuration bucket to override, if any.",
+    )
 
-  add_parser_argument(
-      parser, 'halyard_config_bucket_credentials', defaults, None,
-      help='If specified, give these credentials to halyard'
-           ' in order to access the global halyard GCS bucket.')
+    add_parser_argument(
+        parser,
+        "halyard_config_bucket_credentials",
+        defaults,
+        None,
+        help="If specified, give these credentials to halyard"
+        " in order to access the global halyard GCS bucket.",
+    )
 
-  add_parser_argument(
-      parser, 'spinnaker_repository',
-      defaults, 'https://dl.bintray.com/spinnaker-releases/debians',
-      help='The location of the spinnaker debian repository.')
+    add_parser_argument(
+        parser,
+        "spinnaker_repository",
+        defaults,
+        "https://dl.bintray.com/spinnaker-releases/debians",
+        help="The location of the spinnaker debian repository.",
+    )
 
-  add_parser_argument(
-      parser, 'spinnaker_registry', defaults, 'gcr.io/spinnaker-community',
-      help='The location of the spinnaker container registry.')
+    add_parser_argument(
+        parser,
+        "spinnaker_registry",
+        defaults,
+        "gcr.io/spinnaker-community",
+        help="The location of the spinnaker container registry.",
+    )
 
-  add_parser_argument(
-      parser, 'deploy_spinnaker_type', defaults, None,
-      choices=SUPPORTED_DEPLOYMENT_TYPES,
-      help='The type of spinnaker deployment to create.')
+    add_parser_argument(
+        parser,
+        "deploy_spinnaker_type",
+        defaults,
+        None,
+        choices=SUPPORTED_DEPLOYMENT_TYPES,
+        help="The type of spinnaker deployment to create.",
+    )
 
-  add_parser_argument(
-      parser, 'deploy_hal_platform', defaults, None,
-      choices=['gce', 'ec2', 'azure'],
-      help='Platform to deploy Halyard onto.'
-           ' Halyard will then deploy Spinnaker.')
+    add_parser_argument(
+        parser,
+        "deploy_hal_platform",
+        defaults,
+        None,
+        choices=["gce", "ec2", "azure"],
+        help="Platform to deploy Halyard onto." " Halyard will then deploy Spinnaker.",
+    )
 
-  add_parser_argument(
-      parser, 'deploy_hal_user', defaults, os.environ.get('LOGNAME'),
-      help='User name on deployed hal_platform for deploying hal.'
-           ' This is used to scp and ssh from this machine.')
+    add_parser_argument(
+        parser,
+        "deploy_hal_user",
+        defaults,
+        os.environ.get("LOGNAME"),
+        help="User name on deployed hal_platform for deploying hal."
+        " This is used to scp and ssh from this machine.",
+    )
 
-  add_parser_argument(
-      parser, 'deploy_distributed_platform', defaults, 'kubernetes_v2',
-      choices=SUPPORTED_DISTRIBUTED_PLATFORMS,
-      help='The platform to deploy spinnaker to when'
-           ' --deploy_spinnaker_type=distributed')
+    add_parser_argument(
+        parser,
+        "deploy_distributed_platform",
+        defaults,
+        "kubernetes_v2",
+        choices=SUPPORTED_DISTRIBUTED_PLATFORMS,
+        help="The platform to deploy spinnaker to when"
+        " --deploy_spinnaker_type=distributed",
+    )
 
-  add_parser_argument(
-      parser, 'deploy_version', defaults, 'master-latest-unvalidated',
-      help='Spinnaker version to deploy. The default is "master-latest-unverified".')
+    add_parser_argument(
+        parser,
+        "deploy_version",
+        defaults,
+        "master-latest-unvalidated",
+        help='Spinnaker version to deploy. The default is "master-latest-unverified".',
+    )
 
-  add_parser_argument(
-      parser, 'deploy_deploy', defaults, True, type=bool,
-      help='Actually perform the deployment.'
-           ' This is for facilitating debugging with this script.')
+    add_parser_argument(
+        parser,
+        "deploy_deploy",
+        defaults,
+        True,
+        type=bool,
+        help="Actually perform the deployment."
+        " This is for facilitating debugging with this script.",
+    )
 
-  add_parser_argument(
-      parser, 'deploy_undeploy', defaults, True, type=bool,
-      help='Actually perform the undeployment.'
-           ' This is for facilitating debugging with this script.')
+    add_parser_argument(
+        parser,
+        "deploy_undeploy",
+        defaults,
+        True,
+        type=bool,
+        help="Actually perform the undeployment."
+        " This is for facilitating debugging with this script.",
+    )
 
-  add_parser_argument(
-      parser, 'deploy_always_collect_logs', defaults, False, type=bool,
-      help='Always collect logs.'
-           'By default logs are only collected when deploy_undeploy is True.')
+    add_parser_argument(
+        parser,
+        "deploy_always_collect_logs",
+        defaults,
+        False,
+        type=bool,
+        help="Always collect logs."
+        "By default logs are only collected when deploy_undeploy is True.",
+    )
 
-  AwsValidateBomDeployer.init_platform_argument_parser(parser, defaults)
-  AzureValidateBomDeployer.init_platform_argument_parser(parser, defaults)
-  GoogleValidateBomDeployer.init_platform_argument_parser(parser, defaults)
-  KubernetesV2ValidateBomDeployer.init_platform_argument_parser(parser, defaults)
+    AwsValidateBomDeployer.init_platform_argument_parser(parser, defaults)
+    AzureValidateBomDeployer.init_platform_argument_parser(parser, defaults)
+    GoogleValidateBomDeployer.init_platform_argument_parser(parser, defaults)
+    KubernetesV2ValidateBomDeployer.init_platform_argument_parser(parser, defaults)

--- a/dev/validate_bom__main.py
+++ b/dev/validate_bom__main.py
@@ -63,11 +63,10 @@ import yaml
 from buildtool.__main__ import (
     STANDARD_LOG_LEVELS,
     preprocess_args,
-    add_standard_parser_args)
+    add_standard_parser_args,
+)
 from buildtool.metrics import MetricsManager
-from buildtool import (
-    add_parser_argument,
-    run_subprocess)
+from buildtool import add_parser_argument, run_subprocess
 
 
 import validate_bom__config
@@ -76,136 +75,148 @@ import validate_bom__test
 
 
 def build_report(test_controller):
-  """Report on the test results."""
-  options = test_controller.options
-  citest_log_dir = os.path.join(options.log_dir, 'citest_logs')
-  if not os.path.exists(citest_log_dir):
-    logging.warning('%s does not exist -- no citest logs.', citest_log_dir)
-    return None
+    """Report on the test results."""
+    options = test_controller.options
+    citest_log_dir = os.path.join(options.log_dir, "citest_logs")
+    if not os.path.exists(citest_log_dir):
+        logging.warning("%s does not exist -- no citest logs.", citest_log_dir)
+        return None
 
-  retcode, stdout = run_subprocess(
-      'python -m citest.reporting.generate_html_report --index *.journal',
-      shell=True,
-      cwd=citest_log_dir)
+    retcode, stdout = run_subprocess(
+        "python -m citest.reporting.generate_html_report --index *.journal",
+        shell=True,
+        cwd=citest_log_dir,
+    )
 
-  if retcode != 0:
-    logging.error('Error building report: %s', stdout)
-  logging.info('Logging information is in %s', options.log_dir)
+    if retcode != 0:
+        logging.error("Error building report: %s", stdout)
+    logging.info("Logging information is in %s", options.log_dir)
 
-  return test_controller.build_summary()
+    return test_controller.build_summary()
 
 
 def get_options(args):
-  """Resolve all the command-line options."""
+    """Resolve all the command-line options."""
 
-  args, defaults = preprocess_args(
-      args, default_home_path_filename='validate_bom.yml')
+    args, defaults = preprocess_args(
+        args, default_home_path_filename="validate_bom.yml"
+    )
 
-  parser = argparse.ArgumentParser(prog='validate_bom.sh')
-  add_standard_parser_args(parser, defaults)
-# DEPRECATED - use output_dir instead
-  add_parser_argument(parser, 'log_dir', defaults, './validate_bom_results',
-                      help='Path to root directory for report output.')
+    parser = argparse.ArgumentParser(prog="validate_bom.sh")
+    add_standard_parser_args(parser, defaults)
+    # DEPRECATED - use output_dir instead
+    add_parser_argument(
+        parser,
+        "log_dir",
+        defaults,
+        "./validate_bom_results",
+        help="Path to root directory for report output.",
+    )
 
-  MetricsManager.init_argument_parser(parser, defaults)
-  validate_bom__config.init_argument_parser(parser, defaults)
-  validate_bom__deploy.init_argument_parser(parser, defaults)
-  validate_bom__test.init_argument_parser(parser, defaults)
+    MetricsManager.init_argument_parser(parser, defaults)
+    validate_bom__config.init_argument_parser(parser, defaults)
+    validate_bom__deploy.init_argument_parser(parser, defaults)
+    validate_bom__test.init_argument_parser(parser, defaults)
 
-  options = parser.parse_args(args)
-  options.program = 'validate_bom'
-  options.command = 'validate_bom'        # metrics assumes a "command" value.
-  options.log_dir = options.output_dir    # deprecated
-  validate_bom__config.validate_options(options)
-  validate_bom__test.validate_options(options)
+    options = parser.parse_args(args)
+    options.program = "validate_bom"
+    options.command = "validate_bom"  # metrics assumes a "command" value.
+    options.log_dir = options.output_dir  # deprecated
+    validate_bom__config.validate_options(options)
+    validate_bom__test.validate_options(options)
 
-  if not os.path.exists(options.log_dir):
-    os.makedirs(options.log_dir)
+    if not os.path.exists(options.log_dir):
+        os.makedirs(options.log_dir)
 
-  if options.influxdb_database == 'SpinnakerBuildTool':
-    options.influxdb_database = 'SpinnakerValidate'
+    if options.influxdb_database == "SpinnakerBuildTool":
+        options.influxdb_database = "SpinnakerValidate"
 
-  # Add platform/spinnaker_type to each metric we produce.
-  # We'll use this to distinguish what was being tested.
-  context_labels = 'platform=%s,deployment_type=%s' % (
-      validate_bom__deploy.determine_deployment_platform(options),
-      options.deploy_spinnaker_type)
-  latest_unvalidated_suffix = '-latest-unvalidated'
-  if options.deploy_version.endswith(latest_unvalidated_suffix):
-    bom_series = options.deploy_version[:-len(latest_unvalidated_suffix)]
-  else:
-    bom_series = options.deploy_version[:options.deploy_version.rfind('-')]
-  context_labels += ',version=%s' % bom_series
+    # Add platform/spinnaker_type to each metric we produce.
+    # We'll use this to distinguish what was being tested.
+    context_labels = "platform=%s,deployment_type=%s" % (
+        validate_bom__deploy.determine_deployment_platform(options),
+        options.deploy_spinnaker_type,
+    )
+    latest_unvalidated_suffix = "-latest-unvalidated"
+    if options.deploy_version.endswith(latest_unvalidated_suffix):
+        bom_series = options.deploy_version[: -len(latest_unvalidated_suffix)]
+    else:
+        bom_series = options.deploy_version[: options.deploy_version.rfind("-")]
+    context_labels += ",version=%s" % bom_series
 
-  if options.monitoring_context_labels:
-    context_labels += ',' + options.monitoring_context_labels
-  options.monitoring_context_labels = context_labels
+    if options.monitoring_context_labels:
+        context_labels += "," + options.monitoring_context_labels
+    options.monitoring_context_labels = context_labels
 
-  return options
+    return options
 
 
 def main(options, metrics):
-  """The main controller."""
-  outcome_success = False
-  deployer = validate_bom__deploy.make_deployer(options, metrics)
-  test_controller = validate_bom__test.ValidateBomTestController(deployer)
-  if options.deploy_deploy:
-    validate_bom__config.setup_environment(options)
-  init_script, config_script = validate_bom__config.make_scripts(options)
-  file_set = validate_bom__config.get_files_to_upload(options)
+    """The main controller."""
+    outcome_success = False
+    deployer = validate_bom__deploy.make_deployer(options, metrics)
+    test_controller = validate_bom__test.ValidateBomTestController(deployer)
+    if options.deploy_deploy:
+        validate_bom__config.setup_environment(options)
+    init_script, config_script = validate_bom__config.make_scripts(options)
+    file_set = validate_bom__config.get_files_to_upload(options)
 
-  try:
-    deployer.deploy(init_script, config_script, file_set)
-    _, failed, _ = test_controller.run_tests()
-    outcome_success = not failed
-  finally:
-    if sys.exc_info()[0] is not None:
-      logging.error('Caught Exception')
-      logging.exception('Caught Exception')
-    if options.deploy_undeploy or options.deploy_always_collect_logs:
-      deployer.collect_logs()
-    if options.deploy_undeploy:
-      try:
-        deployer.undeploy()
-      finally:
-        validate_bom__config.teardown_environment(options)
-    else:
-      logging.info('Skipping undeploy because --deploy_undeploy=false')
+    try:
+        deployer.deploy(init_script, config_script, file_set)
+        _, failed, _ = test_controller.run_tests()
+        outcome_success = not failed
+    finally:
+        if sys.exc_info()[0] is not None:
+            logging.error("Caught Exception")
+            logging.exception("Caught Exception")
+        if options.deploy_undeploy or options.deploy_always_collect_logs:
+            deployer.collect_logs()
+        if options.deploy_undeploy:
+            try:
+                deployer.undeploy()
+            finally:
+                validate_bom__config.teardown_environment(options)
+        else:
+            logging.info("Skipping undeploy because --deploy_undeploy=false")
 
-    summary = build_report(test_controller)
-    if summary:
-      print(summary)
+        summary = build_report(test_controller)
+        if summary:
+            print(summary)
 
-    if options.testing_enabled or not outcome_success:
-      # Only record the outcome if we were testing
-      # or if we failed [to deploy/undeploy].
-      metrics.inc_counter('ValidationControllerOutcome',
-                          {'success': outcome_success})
+        if options.testing_enabled or not outcome_success:
+            # Only record the outcome if we were testing
+            # or if we failed [to deploy/undeploy].
+            metrics.inc_counter(
+                "ValidationControllerOutcome", {"success": outcome_success}
+            )
 
-  logging.info('Exiting with code=%d', test_controller.exit_code)
-  return test_controller.exit_code
+    logging.info("Exiting with code=%d", test_controller.exit_code)
+    return test_controller.exit_code
 
 
 def wrapped_main():
-  options = get_options(sys.argv[1:])
+    options = get_options(sys.argv[1:])
 
-  logging.basicConfig(
-      format='%(levelname).1s %(asctime)s.%(msecs)03d'
-             ' [%(threadName)s.%(process)d] %(message)s',
-      datefmt='%H:%M:%S',
-      level=STANDARD_LOG_LEVELS[options.log_level])
+    logging.basicConfig(
+        format="%(levelname).1s %(asctime)s.%(msecs)03d"
+        " [%(threadName)s.%(process)d] %(message)s",
+        datefmt="%H:%M:%S",
+        level=STANDARD_LOG_LEVELS[options.log_level],
+    )
 
-  logging.debug(
-      'Running with options:\n   %s',
-      '\n   '.join(yaml.safe_dump(vars(options), default_flow_style=False)
-                   .split('\n')))
+    logging.debug(
+        "Running with options:\n   %s",
+        "\n   ".join(
+            yaml.safe_dump(vars(options), default_flow_style=False).split("\n")
+        ),
+    )
 
-  metrics = MetricsManager.startup_metrics(options)
-  try:
-    return main(options, metrics)
-  finally:
-    MetricsManager.shutdown_metrics()
+    metrics = MetricsManager.startup_metrics(options)
+    try:
+        return main(options, metrics)
+    finally:
+        MetricsManager.shutdown_metrics()
 
 
-if __name__ == '__main__':
-  sys.exit(wrapped_main())
+if __name__ == "__main__":
+    sys.exit(wrapped_main())

--- a/dev/validate_bom__test.py
+++ b/dev/validate_bom__test.py
@@ -92,10 +92,10 @@ import traceback
 import yaml
 
 try:
-  from urllib2 import urlopen, Request, HTTPError, URLError
+    from urllib2 import urlopen, Request, HTTPError, URLError
 except ImportError:
-  from urllib.request import urlopen, Request
-  from urllib.error import HTTPError, URLError
+    from urllib.request import urlopen, Request
+    from urllib.error import HTTPError, URLError
 
 
 from buildtool import (
@@ -107,1075 +107,1287 @@ from buildtool import (
     ConfigError,
     ResponseError,
     TimeoutError,
-    UnexpectedError)
+    UnexpectedError,
+)
 
 from validate_bom__deploy import replace_ha_services
 
 from iap_generate_google_auth_token import (
     generate_auth_token,
-    get_service_account_email)
+    get_service_account_email,
+)
 
-ForwardedPort = collections.namedtuple('ForwardedPort', ['child', 'port'])
+ForwardedPort = collections.namedtuple("ForwardedPort", ["child", "port"])
 
 
 def _unused_port():
-  """Find a port that is not currently in use."""
-  # pylint: disable=unused-variable
-  sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-  sock.bind(('localhost', 0))
-  addr, port = sock.getsockname()
-  sock.close()
-  return port
+    """Find a port that is not currently in use."""
+    # pylint: disable=unused-variable
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("localhost", 0))
+    addr, port = sock.getsockname()
+    sock.close()
+    return port
 
 
 class QuotaTracker(object):
-  """Manages quota for individual resources.
+    """Manages quota for individual resources.
 
-  Note that this quota tracker is purely logical. It does not relate to the
-  real world. Others may be using the actual quota we have. This is only
-  regulating the test's use of the quota.
-  """
-
-  MAX_QUOTA_METRIC_NAME = 'ResourceQuotaMax'
-  FREE_QUOTA_METRIC_NAME = 'ResourceQuotaAvailable'
-  INSUFFICIENT_QUOTA_METRIC_NAME = 'ResourceQuotaShortage'
-
-  def __init__(self, max_counts, metrics):
-    """Constructor.
-
-    Args:
-      max_counts: [dict] The list of resources and quotas to manage.
+    Note that this quota tracker is purely logical. It does not relate to the
+    real world. Others may be using the actual quota we have. This is only
+    regulating the test's use of the quota.
     """
-    self.__counts = dict(max_counts)
-    self.__max_counts = dict(max_counts)
-    self.__condition_variable = threading.Condition()
-    self.__metrics = metrics
 
-    for name, value in max_counts.items():
-      labels = {'resource': name}
-      self.__metrics.set(self.MAX_QUOTA_METRIC_NAME, labels, value)
-      self.__metrics.set(self.FREE_QUOTA_METRIC_NAME, labels, value)
+    MAX_QUOTA_METRIC_NAME = "ResourceQuotaMax"
+    FREE_QUOTA_METRIC_NAME = "ResourceQuotaAvailable"
+    INSUFFICIENT_QUOTA_METRIC_NAME = "ResourceQuotaShortage"
 
-  def acquire_all_safe(self, who, quota):
-    """Acquire the desired quota, if any.
+    def __init__(self, max_counts, metrics):
+        """Constructor.
 
-    This is thread-safe and will block until it can be satisified.
+        Args:
+          max_counts: [dict] The list of resources and quotas to manage.
+        """
+        self.__counts = dict(max_counts)
+        self.__max_counts = dict(max_counts)
+        self.__condition_variable = threading.Condition()
+        self.__metrics = metrics
 
-    Args:
-      who: [string] Who is asking, for logging purposes.
-      quota: [dict] The desired quota for each keyed resource, if any.
-    Returns:
-      The quota acquired.
-    """
-    got = None
-    with self.__condition_variable:
-      got = self.acquire_all_or_none_unsafe(who, quota)
-      while got is None:
-        logging.info('"%s" waiting on quota %s', who, quota)
-        self.__condition_variable.wait()
-        got = self.acquire_all_or_none_unsafe(who, quota)
-    return got
+        for name, value in max_counts.items():
+            labels = {"resource": name}
+            self.__metrics.set(self.MAX_QUOTA_METRIC_NAME, labels, value)
+            self.__metrics.set(self.FREE_QUOTA_METRIC_NAME, labels, value)
 
-  def acquire_all_or_none_safe(self, who, quota):
-    """Acquire the desired quota, if any.
+    def acquire_all_safe(self, who, quota):
+        """Acquire the desired quota, if any.
 
-    This is thread-safe, however will return None rather than block.
+        This is thread-safe and will block until it can be satisified.
 
-    Args:
-      who: [string] Who is asking, for logging purposes.
-      quota: [dict] The desired quota for each keyed resource, if any.
-    Returns:
-      The quota acquired if successful, or None if not.
-    """
-    with self.__condition_variable:
-      return self.acquire_all_or_none_unsafe(who, quota)
+        Args:
+          who: [string] Who is asking, for logging purposes.
+          quota: [dict] The desired quota for each keyed resource, if any.
+        Returns:
+          The quota acquired.
+        """
+        got = None
+        with self.__condition_variable:
+            got = self.acquire_all_or_none_unsafe(who, quota)
+            while got is None:
+                logging.info('"%s" waiting on quota %s', who, quota)
+                self.__condition_variable.wait()
+                got = self.acquire_all_or_none_unsafe(who, quota)
+        return got
 
-  def acquire_all_or_none_unsafe(self, who, quota):
-    """Acquire the desired quota, if any.
+    def acquire_all_or_none_safe(self, who, quota):
+        """Acquire the desired quota, if any.
 
-    This is not thread-safe so should be called while locked.
+        This is thread-safe, however will return None rather than block.
 
-    Args:
-      who: [string] Who is asking, for logging purposes.
-      quota: [dict] The desired quota for each keyed resource, if any.
-    Returns:
-      The quota acquired if successful, or None if not.
-    """
-    if not quota:
-      return {}
-    logging.info('"%s" attempting to acquire quota %s', who, quota)
-    acquired = {}
-    have_all = True
-    for key, value in quota.items():
-      got = self.__acquire_resource_or_none(key, value)
-      if not got:
-        have_all = False  # Be lazy so we can record all the missing quota
-      else:
-        acquired[key] = got
+        Args:
+          who: [string] Who is asking, for logging purposes.
+          quota: [dict] The desired quota for each keyed resource, if any.
+        Returns:
+          The quota acquired if successful, or None if not.
+        """
+        with self.__condition_variable:
+            return self.acquire_all_or_none_unsafe(who, quota)
 
-    if have_all:
-      return acquired
+    def acquire_all_or_none_unsafe(self, who, quota):
+        """Acquire the desired quota, if any.
 
-    self.release_all_unsafe(who, acquired)
-    return None
+        This is not thread-safe so should be called while locked.
 
-  def release_all_safe(self, who, quota):
-    """Release all the resource quota.
+        Args:
+          who: [string] Who is asking, for logging purposes.
+          quota: [dict] The desired quota for each keyed resource, if any.
+        Returns:
+          The quota acquired if successful, or None if not.
+        """
+        if not quota:
+            return {}
+        logging.info('"%s" attempting to acquire quota %s', who, quota)
+        acquired = {}
+        have_all = True
+        for key, value in quota.items():
+            got = self.__acquire_resource_or_none(key, value)
+            if not got:
+                have_all = False  # Be lazy so we can record all the missing quota
+            else:
+                acquired[key] = got
 
-    Args:
-      who: [string] Who is releasing, for logging purposes.
-      quota: [dict] The non-None result from an acquire_all* method.
-    """
-    with self.__condition_variable:
-      self.release_all_unsafe(who, quota)
-      self.__condition_variable.notify_all()
+        if have_all:
+            return acquired
 
-  def release_all_unsafe(self, who, quota):
-    """Release all the resource quota.
+        self.release_all_unsafe(who, acquired)
+        return None
 
-    This is not thread-safe so should be called while locked.
+    def release_all_safe(self, who, quota):
+        """Release all the resource quota.
 
-    Args:
-      who: [string] Who is releasing, for logging purposes.
-      quota: [dict] The non-None result from an acquire_all* method.
-    """
-    if not quota:
-      return
-    logging.debug('"%s" releasing quota %s', who, quota)
-    for key, value in quota.items():
-      self.__release_resource(key, value)
+        Args:
+          who: [string] Who is releasing, for logging purposes.
+          quota: [dict] The non-None result from an acquire_all* method.
+        """
+        with self.__condition_variable:
+            self.release_all_unsafe(who, quota)
+            self.__condition_variable.notify_all()
 
-  def __acquire_resource_or_none(self, name, count):
-    """Attempt to acquire some amount of quota.
+    def release_all_unsafe(self, who, quota):
+        """Release all the resource quota.
 
-    Args:
-      name: [string] The name of the resource we're acquiring.
-      count: [int] The amount of the resource
+        This is not thread-safe so should be called while locked.
 
-    Returns:
-      The amount we were given. This is either all or none. If non-zero
-      but less than we asked for, then it gave us the max quota it has.
-      In order for this to be the case, it must have all the quota available.
-      Otherwise it will return 0.
-    """
-    have = self.__counts.get(name)
-    if have is None:
-      return count
-    if have >= count:
-      self.__counts[name] = have - count
-      self.__metrics.set(
-          self.FREE_QUOTA_METRIC_NAME, {'resource': name}, self.__counts[name])
-      return count
-    max_count = self.__max_counts[name]
-    if have == max_count:
-      logging.warning('Quota %s has a max of %d but %d is desired.'
-                      ' Acquiring all the quota as a best effort.',
-                      name, max_count, count)
-      self.__counts[name] = 0
-      self.__metrics.set(
-          self.FREE_QUOTA_METRIC_NAME, {'resource': name}, 0)
-      return have
-    logging.warning('Quota %s has %d remaining, but %d are needed.'
-                    ' Rejecting the request for now.',
-                    name, have, count)
-    self.__metrics.inc_counter(
-        self.INSUFFICIENT_QUOTA_METRIC_NAME, {'resource': name},
-        amount=count - have)
-    return 0
+        Args:
+          who: [string] Who is releasing, for logging purposes.
+          quota: [dict] The non-None result from an acquire_all* method.
+        """
+        if not quota:
+            return
+        logging.debug('"%s" releasing quota %s', who, quota)
+        for key, value in quota.items():
+            self.__release_resource(key, value)
 
-  def __release_resource(self, name, count):
-    """Restores previously acquired resource quota."""
-    have = self.__counts.get(name, None)
-    if have is not None:
-      self.__counts[name] = have + count
-      self.__metrics.set(
-          self.FREE_QUOTA_METRIC_NAME, {'resource': name}, self.__counts[name])
+    def __acquire_resource_or_none(self, name, count):
+        """Attempt to acquire some amount of quota.
+
+        Args:
+          name: [string] The name of the resource we're acquiring.
+          count: [int] The amount of the resource
+
+        Returns:
+          The amount we were given. This is either all or none. If non-zero
+          but less than we asked for, then it gave us the max quota it has.
+          In order for this to be the case, it must have all the quota available.
+          Otherwise it will return 0.
+        """
+        have = self.__counts.get(name)
+        if have is None:
+            return count
+        if have >= count:
+            self.__counts[name] = have - count
+            self.__metrics.set(
+                self.FREE_QUOTA_METRIC_NAME, {"resource": name}, self.__counts[name]
+            )
+            return count
+        max_count = self.__max_counts[name]
+        if have == max_count:
+            logging.warning(
+                "Quota %s has a max of %d but %d is desired."
+                " Acquiring all the quota as a best effort.",
+                name,
+                max_count,
+                count,
+            )
+            self.__counts[name] = 0
+            self.__metrics.set(self.FREE_QUOTA_METRIC_NAME, {"resource": name}, 0)
+            return have
+        logging.warning(
+            "Quota %s has %d remaining, but %d are needed."
+            " Rejecting the request for now.",
+            name,
+            have,
+            count,
+        )
+        self.__metrics.inc_counter(
+            self.INSUFFICIENT_QUOTA_METRIC_NAME, {"resource": name}, amount=count - have
+        )
+        return 0
+
+    def __release_resource(self, name, count):
+        """Restores previously acquired resource quota."""
+        have = self.__counts.get(name, None)
+        if have is not None:
+            self.__counts[name] = have + count
+            self.__metrics.set(
+                self.FREE_QUOTA_METRIC_NAME, {"resource": name}, self.__counts[name]
+            )
 
 
 class ValidateBomTestController(object):
-  """The test controller runs integration tests against a deployment."""
+    """The test controller runs integration tests against a deployment."""
 
-  @property
-  def test_suite(self):
-    """Returns the main test suite loaded from --test_suite."""
-    return self.__test_suite
+    @property
+    def test_suite(self):
+        """Returns the main test suite loaded from --test_suite."""
+        return self.__test_suite
 
-  @property
-  def options(self):
-    """The configuration options."""
-    return self.__deployer.options
+    @property
+    def options(self):
+        """The configuration options."""
+        return self.__deployer.options
 
-  @property
-  def passed(self):
-    """Returns the passed tests and reasons."""
-    return self.__passed
+    @property
+    def passed(self):
+        """Returns the passed tests and reasons."""
+        return self.__passed
 
-  @property
-  def failed(self):
-    """Returns the failed tests and reasons."""
-    return self.__failed
+    @property
+    def failed(self):
+        """Returns the failed tests and reasons."""
+        return self.__failed
 
-  @property
-  def skipped(self):
-    """Returns the skipped tests and reasons."""
-    return self.__skipped
+    @property
+    def skipped(self):
+        """Returns the skipped tests and reasons."""
+        return self.__skipped
 
-  @property
-  def exit_code(self):
-    """Determine final exit code for all tests."""
-    return -1 if self.failed else 0
+    @property
+    def exit_code(self):
+        """Determine final exit code for all tests."""
+        return -1 if self.failed else 0
 
-  def __close_forwarded_ports(self):
-    for forwarding in self.__forwarded_ports.values():
-      try:
-        forwarding[0].kill()
-      except Exception as ex:
-        logging.error('Error terminating child: %s', ex)
+    def __close_forwarded_ports(self):
+        for forwarding in self.__forwarded_ports.values():
+            try:
+                forwarding[0].kill()
+            except Exception as ex:
+                logging.error("Error terminating child: %s", ex)
 
-  def __collect_gce_quota(self, gcloud_account, project, region,
-                          project_percent=100.0, region_percent=100.0):
-    project_info_json = check_subprocess(
-        'gcloud compute project-info describe'
-        ' --account {gcloud_account}'
-        ' --format yaml'
-        ' --project {project}'
-        .format(
-          project=project,
-          gcloud_account=gcloud_account))
-    project_info = yaml.safe_load(project_info_json)
-    # Sometimes gce returns entries and leaves out the a "metric" it was for.
-    # We'll ignore those and stick them in 'UNKNOWN' for simplicity.
-    project_quota = {'gce_global_%s' % info.get('metric', 'UNKNOWN'):
-                          int(max(1, math.floor(
-                              project_percent * (info['limit'] - info['usage']))))
-                     for info in project_info['quotas']}
+    def __collect_gce_quota(
+        self,
+        gcloud_account,
+        project,
+        region,
+        project_percent=100.0,
+        region_percent=100.0,
+    ):
+        project_info_json = check_subprocess(
+            "gcloud compute project-info describe"
+            " --account {gcloud_account}"
+            " --format yaml"
+            " --project {project}".format(
+                project=project, gcloud_account=gcloud_account
+            )
+        )
+        project_info = yaml.safe_load(project_info_json)
+        # Sometimes gce returns entries and leaves out the a "metric" it was for.
+        # We'll ignore those and stick them in 'UNKNOWN' for simplicity.
+        project_quota = {
+            "gce_global_%s"
+            % info.get("metric", "UNKNOWN"): int(
+                max(1, math.floor(project_percent * (info["limit"] - info["usage"])))
+            )
+            for info in project_info["quotas"]
+        }
 
-    region_info_json = check_subprocess(
-        'gcloud compute regions describe'
-        ' --account {gcloud_account}'
-        ' --format yaml'
-        ' --project {project}'
-        ' {region}'
-        .format(
-            gcloud_account=gcloud_account,
-            project=project,
-            region=region))
-    region_info = yaml.safe_load(region_info_json)
-    region_quota = {
-        'gce_region_%s' % info.get('metric', 'UNKNOWN'): int(max(
-            1, math.floor(region_percent * (info['limit'] - info['usage']))))
-        for info in region_info['quotas']
-    }
-    return project_quota, region_quota
+        region_info_json = check_subprocess(
+            "gcloud compute regions describe"
+            " --account {gcloud_account}"
+            " --format yaml"
+            " --project {project}"
+            " {region}".format(
+                gcloud_account=gcloud_account, project=project, region=region
+            )
+        )
+        region_info = yaml.safe_load(region_info_json)
+        region_quota = {
+            "gce_region_%s"
+            % info.get("metric", "UNKNOWN"): int(
+                max(1, math.floor(region_percent * (info["limit"] - info["usage"])))
+            )
+            for info in region_info["quotas"]
+        }
+        return project_quota, region_quota
 
-  def __init__(self, deployer):
-    options = deployer.options
-    quota_spec = {}
+    def __init__(self, deployer):
+        options = deployer.options
+        quota_spec = {}
 
-    if options.google_account_project:
-      project_quota, region_quota = self.__collect_gce_quota(
-          options.deploy_hal_google_service_account,
-          options.google_account_project, options.test_gce_quota_region,
-          project_percent=options.test_gce_project_quota_factor,
-          region_percent=options.test_gce_region_quota_factor)
-      quota_spec.update(project_quota)
-      quota_spec.update(region_quota)
+        if options.google_account_project:
+            project_quota, region_quota = self.__collect_gce_quota(
+                options.deploy_hal_google_service_account,
+                options.google_account_project,
+                options.test_gce_quota_region,
+                project_percent=options.test_gce_project_quota_factor,
+                region_percent=options.test_gce_region_quota_factor,
+            )
+            quota_spec.update(project_quota)
+            quota_spec.update(region_quota)
 
-    if options.test_default_quota:
-      quota_spec.update({
-          parts[0].strip(): int(parts[1])
-          for parts in [entry.split('=')
-                        for entry in options.test_default_quota.split(',')]
-      })
+        if options.test_default_quota:
+            quota_spec.update(
+                {
+                    parts[0].strip(): int(parts[1])
+                    for parts in [
+                        entry.split("=")
+                        for entry in options.test_default_quota.split(",")
+                    ]
+                }
+            )
 
-    if options.test_quota:
-      quota_spec.update(
-          {parts[0].strip(): int(parts[1])
-           for parts in [entry.split('=')
-                         for entry in options.test_quota.split(',')]})
+        if options.test_quota:
+            quota_spec.update(
+                {
+                    parts[0].strip(): int(parts[1])
+                    for parts in [
+                        entry.split("=") for entry in options.test_quota.split(",")
+                    ]
+                }
+            )
 
-    self.__quota_tracker = QuotaTracker(quota_spec, deployer.metrics)
-    self.__deployer = deployer
-    self.__lock = threading.Lock()
-    self.__passed = []  # Resulted in success
-    self.__failed = []  # Resulted in failure
-    self.__skipped = []  # Will not run at all
-    with open(options.test_profiles, 'r') as fd:
-      self.__test_suite = yaml.safe_load(fd)
-    self.__extra_test_bindings = (
-        self.__load_bindings(options.test_extra_profile_bindings)
-        if options.test_extra_profile_bindings
-        else {}
-    )
+        self.__quota_tracker = QuotaTracker(quota_spec, deployer.metrics)
+        self.__deployer = deployer
+        self.__lock = threading.Lock()
+        self.__passed = []  # Resulted in success
+        self.__failed = []  # Resulted in failure
+        self.__skipped = []  # Will not run at all
+        with open(options.test_profiles, "r") as fd:
+            self.__test_suite = yaml.safe_load(fd)
+        self.__extra_test_bindings = (
+            self.__load_bindings(options.test_extra_profile_bindings)
+            if options.test_extra_profile_bindings
+            else {}
+        )
 
-    num_concurrent = len(self.__test_suite.get('tests')) or 1
-    num_concurrent = int(min(num_concurrent,
-                             options.test_concurrency or num_concurrent))
-    self.__semaphore = threading.Semaphore(num_concurrent)
+        num_concurrent = len(self.__test_suite.get("tests")) or 1
+        num_concurrent = int(
+            min(num_concurrent, options.test_concurrency or num_concurrent)
+        )
+        self.__semaphore = threading.Semaphore(num_concurrent)
 
-    # dictionary of service -> ForwardedPort
-    self.__forwarded_ports = {}
-    atexit.register(self.__close_forwarded_ports)
+        # dictionary of service -> ForwardedPort
+        self.__forwarded_ports = {}
+        atexit.register(self.__close_forwarded_ports)
 
-    # Map of service names to native ports.
-    self.__service_port_map = {
-        # These are critical to most tests.
-        'clouddriver': 7002,
-        'clouddriver-caching': 7002,
-        'clouddriver-rw': 7002,
-        'clouddriver-ro': 7002,
-        'clouddriver-ro-deck': 7002,
-        'gate': 8084,
-        'front50': 8080,
+        # Map of service names to native ports.
+        self.__service_port_map = {
+            # These are critical to most tests.
+            "clouddriver": 7002,
+            "clouddriver-caching": 7002,
+            "clouddriver-rw": 7002,
+            "clouddriver-ro": 7002,
+            "clouddriver-ro-deck": 7002,
+            "gate": 8084,
+            "front50": 8080,
+            # Some tests needed these too.
+            "orca": 8083,
+            "rosco": 8087,
+            "igor": 8088,
+            "echo": 8089,
+            "echo-scheduler": 8089,
+            "echo-worker": 8089,
+        }
 
-        # Some tests needed these too.
-        'orca': 8083,
-        'rosco': 8087,
-        'igor': 8088,
-        'echo': 8089,
-        'echo-scheduler': 8089,
-        'echo-worker': 8089
-    }
+        # Map of services with provided endpoints and credentials.
+        self.__public_service_configs = {}
+        self.__add_gate_service_config(self.__public_service_configs)
 
-    # Map of services with provided endpoints and credentials.
-    self.__public_service_configs = {}
-    self.__add_gate_service_config(self.__public_service_configs)
+    def __add_gate_service_config(self, configs):
+        if not self.options.test_gate_service_base_url:
+            return
+        service_config = {
+            "base_url": self.options.test_gate_service_base_url,
+        }
+        credentials_path = (
+            self.options.test_gate_iap_credentials
+        )  # This can be None, which would mean we use the Application Default Credentials
+        client_id = self.options.test_gate_iap_client_id
+        impersonated_service_account = (
+            self.options.test_gate_iap_impersonated_service_account
+        )
+        if client_id:
+            service_config[
+                "service_account_email"
+            ] = impersonated_service_account or get_service_account_email(
+                credentials_path
+            )
+            service_config["bearer_auth_token"] = generate_auth_token(
+                client_id,
+                service_account_file=credentials_path,
+                impersonate_service_account_email=impersonated_service_account,
+            )
+        configs["gate"] = service_config
 
-  def __add_gate_service_config(self, configs):
-    if not self.options.test_gate_service_base_url:
-      return
-    service_config = {
-      'base_url': self.options.test_gate_service_base_url,
-    }
-    credentials_path = self.options.test_gate_iap_credentials  # This can be None, which would mean we use the Application Default Credentials
-    client_id = self.options.test_gate_iap_client_id
-    impersonated_service_account = self.options.test_gate_iap_impersonated_service_account
-    if client_id:
-      service_config['service_account_email'] = impersonated_service_account or get_service_account_email(credentials_path)
-      service_config['bearer_auth_token'] = generate_auth_token(client_id,
-          service_account_file=credentials_path,
-          impersonate_service_account_email=impersonated_service_account)
-    configs['gate'] = service_config
+    def __bearer_auth_token_or_none(
+        self, service_name, client_id, credentials_path=None
+    ):
+        return generate_auth_token(client_id, credentials_path)
 
-  def __bearer_auth_token_or_none(self, service_name, client_id, credentials_path=None):
-    return generate_auth_token(client_id, credentials_path)
+    def __replace_ha_api_service(self, service, options):
+        transform_map = {}
+        if options.ha_clouddriver_enabled:
+            transform_map["clouddriver"] = "clouddriver-rw"
+        if options.ha_echo_enabled:
+            transform_map["echo"] = ["echo-worker"]
 
-  def __replace_ha_api_service(self, service, options):
-    transform_map = {}
-    if options.ha_clouddriver_enabled:
-      transform_map['clouddriver'] = 'clouddriver-rw'
-    if options.ha_echo_enabled:
-      transform_map['echo'] = ['echo-worker']
+        return transform_map.get(service, service)
 
-    return transform_map.get(service, service)
+    def __load_bindings(self, path):
+        with open(path, "r") as stream:
+            content = stream.read()
+        result = {}
+        for line in content.split("\n"):
+            match = re.match("^([a-zA-Z][^=])+=(.*)", line)
+            if match:
+                result[match.group(1).strip()] = match.group(2).strip()
 
-  def __load_bindings(self, path):
-    with open(path, 'r') as stream:
-      content = stream.read()
-    result = {}
-    for line in content.split('\n'):
-      match = re.match('^([a-zA-Z][^=])+=(.*)', line)
-      if match:
-        result[match.group(1).strip()] = match.group(2).strip()
+    def __forward_port_to_service(self, service_name):
+        """Forward ports to the deployed service.
 
-  def __forward_port_to_service(self, service_name):
-    """Forward ports to the deployed service.
+        This is private to ensure that it is called with the lock.
+        The lock is needed to mitigate a race condition. See the
+        inline comment around the Popen call.
+        """
+        local_port = _unused_port()
+        remote_port = self.__service_port_map[service_name]
 
-    This is private to ensure that it is called with the lock.
-    The lock is needed to mitigate a race condition. See the
-    inline comment around the Popen call.
-    """
-    local_port = _unused_port()
-    remote_port = self.__service_port_map[service_name]
+        command = self.__deployer.make_port_forward_command(
+            service_name, local_port, remote_port
+        )
 
-    command = self.__deployer.make_port_forward_command(
-        service_name, local_port, remote_port)
+        logging.info(
+            "Establishing connection to %s with port %d", service_name, local_port
+        )
 
-    logging.info('Establishing connection to %s with port %d',
-                 service_name, local_port)
+        # There seems to be an intermittent race condition here.
+        # Not sure if it is gcloud or python.
+        # Locking the individual calls seems to work around it.
+        #
+        # We dont need to lock because this function is called from within
+        # the lock already.
+        logging.debug("RUNNING %s", " ".join(command))
 
-    # There seems to be an intermittent race condition here.
-    # Not sure if it is gcloud or python.
-    # Locking the individual calls seems to work around it.
-    #
-    # We dont need to lock because this function is called from within
-    # the lock already.
-    logging.debug('RUNNING %s', ' '.join(command))
+        # Redirect stdout to prevent buffer overflows (at least in k8s)
+        # but keep errors for failures.
+        class KeepAlive(threading.Thread):
+            def run(self):
+                while True:
+                    try:
+                        urlopen(
+                            "http://localhost:{port}/health".format(port=local_port)
+                        )
+                    except Exception as ex:
+                        logging.info("KeepAlive %s -> %s", service_name, ex)
 
-    # Redirect stdout to prevent buffer overflows (at least in k8s)
-    # but keep errors for failures.
-    class KeepAlive(threading.Thread):
-      def run(self):
-        while True:
-          try:
-            urlopen('http://localhost:{port}/health'
-                          .format(port=local_port))
-          except Exception as ex:
-            logging.info('KeepAlive %s -> %s', service_name, ex)
+                    time.sleep(20)
 
-          time.sleep(20)
+        if self.options.deploy_spinnaker_type == "distributed":
+            # For now, distributed deployments are k8s
+            # and K8s port forwarding with kubectl requires keep alive.
+            hack = KeepAlive()
+            hack.setDaemon(True)
+            hack.start()
 
-    if self.options.deploy_spinnaker_type == 'distributed':
-      # For now, distributed deployments are k8s
-      # and K8s port forwarding with kubectl requires keep alive.
-      hack = KeepAlive()
-      hack.setDaemon(True)
-      hack.start()
+        logfile = os.path.join(
+            self.options.output_dir,
+            "port_forward_%s-%d.log" % (service_name, os.getpid()),
+        )
+        stream = open(logfile, "w")
+        stream.write(str(command) + "\n\n")
+        logging.debug('Logging "%s" port forwarding to %s', service_name, logfile)
+        child = subprocess.Popen(command, stderr=subprocess.STDOUT, stdout=stream)
+        return ForwardedPort(child, local_port)
 
-    logfile = os.path.join(
-        self.options.output_dir,
-        'port_forward_%s-%d.log' % (service_name, os.getpid()))
-    stream = open(logfile, 'w')
-    stream.write(str(command) + '\n\n')
-    logging.debug('Logging "%s" port forwarding to %s', service_name, logfile)
-    child = subprocess.Popen(
-        command,
-        stderr=subprocess.STDOUT,
-        stdout=stream)
-    return ForwardedPort(child, local_port)
+    def build_summary(self):
+        """Return a summary of all the test results."""
 
-  def build_summary(self):
-    """Return a summary of all the test results."""
-    def append_list_summary(summary, name, entries):
-      """Write out all the names from the test results."""
-      if not entries:
-        return
-      summary.append('{0}:'.format(name))
-      for entry in entries:
-        summary.append('  * {0}'.format(entry[0]))
+        def append_list_summary(summary, name, entries):
+            """Write out all the names from the test results."""
+            if not entries:
+                return
+            summary.append("{0}:".format(name))
+            for entry in entries:
+                summary.append("  * {0}".format(entry[0]))
 
-    options = self.options
-    if not options.testing_enabled:
-      return 'No test output: testing was disabled.', 0
+        options = self.options
+        if not options.testing_enabled:
+            return "No test output: testing was disabled.", 0
 
-    summary = ['\nSummary:']
-    append_list_summary(summary, 'SKIPPED', self.skipped)
-    append_list_summary(summary, 'PASSED', self.passed)
-    append_list_summary(summary, 'FAILED', self.failed)
+        summary = ["\nSummary:"]
+        append_list_summary(summary, "SKIPPED", self.skipped)
+        append_list_summary(summary, "PASSED", self.passed)
+        append_list_summary(summary, "FAILED", self.failed)
 
-    num_skipped = len(self.skipped)
-    num_passed = len(self.passed)
-    num_failed = len(self.failed)
+        num_skipped = len(self.skipped)
+        num_passed = len(self.passed)
+        num_failed = len(self.failed)
 
-    summary.append('')
-    if num_failed:
-      summary.append(
-          'FAILED {0} of {1}, skipped {2}'.format(
-              num_failed, (num_failed + num_passed), num_skipped))
-    else:
-      summary.append('PASSED {0}, skipped {1}'.format(num_passed, num_skipped))
-    return '\n'.join(summary)
+        summary.append("")
+        if num_failed:
+            summary.append(
+                "FAILED {0} of {1}, skipped {2}".format(
+                    num_failed, (num_failed + num_passed), num_skipped
+                )
+            )
+        else:
+            summary.append("PASSED {0}, skipped {1}".format(num_passed, num_skipped))
+        return "\n".join(summary)
 
-  def wait_on_service(self, service_name, port=None, timeout=None):
-    """Wait for the given service to be available on the specified port.
+    def wait_on_service(self, service_name, port=None, timeout=None):
+        """Wait for the given service to be available on the specified port.
 
-    Args:
-      service_name: [string] The service name we we are waiting on.
-      port: [int] The remote port the service is at.
-      timeout: [int] How much time to wait before giving up.
+        Args:
+          service_name: [string] The service name we we are waiting on.
+          port: [int] The remote port the service is at.
+          timeout: [int] How much time to wait before giving up.
 
-    Returns:
-      The ForwardedPort entry for this service.
-    """
-    try:
-      with self.__lock:
-        forwarding = self.__forwarded_ports.get(service_name)
-        if forwarding is None:
-          forwarding = self.__forward_port_to_service(service_name)
-        self.__forwarded_ports[service_name] = forwarding
-    except Exception:
-      logging.exception('Exception while attempting to forward ports to "%s"',
-                        service_name)
-      raise
+        Returns:
+          The ForwardedPort entry for this service.
+        """
+        try:
+            with self.__lock:
+                forwarding = self.__forwarded_ports.get(service_name)
+                if forwarding is None:
+                    forwarding = self.__forward_port_to_service(service_name)
+                self.__forwarded_ports[service_name] = forwarding
+        except Exception:
+            logging.exception(
+                'Exception while attempting to forward ports to "%s"', service_name
+            )
+            raise
 
-    timeout = timeout or self.options.test_service_startup_timeout
-    end_time = time.time() + timeout
-    logging.info('Waiting on "%s"...', service_name)
-    if port is None:
-      port = self.__service_port_map[service_name]
+        timeout = timeout or self.options.test_service_startup_timeout
+        end_time = time.time() + timeout
+        logging.info('Waiting on "%s"...', service_name)
+        if port is None:
+            port = self.__service_port_map[service_name]
 
-    # It seems we have a race condition in the poll
-    # where it thinks the jobs have terminated.
-    # I've only seen this happen once.
-    time.sleep(1)
+        # It seems we have a race condition in the poll
+        # where it thinks the jobs have terminated.
+        # I've only seen this happen once.
+        time.sleep(1)
 
-    threadid = hex(threading.current_thread().ident)
-    logging.info('WaitOn polling %s from thread %s', service_name, threadid)
-    while forwarding.child.poll() is None:
-      try:
-        # localhost is hardcoded here because we are port forwarding.
-        # timeout=20 is to appease kubectl port forwarding, which will close
-        #            if left idle for 30s
-        urlopen('http://localhost:{port}/health'
-                .format(port=forwarding.port),
-                timeout=20)
-        logging.info('"%s" is ready on port %d | %s',
-                     service_name, forwarding.port, threadid)
-        return forwarding
-      except HTTPError as error:
-        logging.warning('%s got %s. Ignoring that for now.',
-                        service_name, error)
-        return forwarding
+        threadid = hex(threading.current_thread().ident)
+        logging.info("WaitOn polling %s from thread %s", service_name, threadid)
+        while forwarding.child.poll() is None:
+            try:
+                # localhost is hardcoded here because we are port forwarding.
+                # timeout=20 is to appease kubectl port forwarding, which will close
+                #            if left idle for 30s
+                urlopen(
+                    "http://localhost:{port}/health".format(port=forwarding.port),
+                    timeout=20,
+                )
+                logging.info(
+                    '"%s" is ready on port %d | %s',
+                    service_name,
+                    forwarding.port,
+                    threadid,
+                )
+                return forwarding
+            except HTTPError as error:
+                logging.warning(
+                    "%s got %s. Ignoring that for now.", service_name, error
+                )
+                return forwarding
 
-      except (URLError, Exception) as error:
-        if time.time() >= end_time:
-          logging.error(
-              'Timing out waiting for %s | %s', service_name, threadid)
-          raise_and_log_error(TimeoutError(service_name, cause=service_name))
-        time.sleep(2.0)
+            except (URLError, Exception) as error:
+                if time.time() >= end_time:
+                    logging.error(
+                        "Timing out waiting for %s | %s", service_name, threadid
+                    )
+                    raise_and_log_error(TimeoutError(service_name, cause=service_name))
+                time.sleep(2.0)
 
-    logging.error('It appears %s is no longer available.'
-                  ' Perhaps the tunnel closed.',
-                  service_name)
-    raise_and_log_error(
-        ResponseError('It appears that {0} failed'.format(service_name),
-                      server='tunnel'))
-
-  def __validate_service_base_url(self, service_name, timeout=None):
-    service_config = self.__public_service_configs[service_name]
-    base_url = service_config['base_url']
-
-    timeout = timeout or self.options.test_service_startup_timeout
-    end_time = time.time() + timeout
-    logging.info('Validating base URL of "%s"...', service_name)
-
-    try:
-      url = '{base_url}/health'.format(base_url=base_url)
-      request = Request(url=url)
-      if 'bearer_auth_token' in service_config:
-        request.add_header('Authorization', 'Bearer {}'.format(service_config['bearer_auth_token']))
-      context = None
-      if self.options.test_ignore_ssl_cert_verification:
-        context = ssl._create_unverified_context()
-      urlopen(request, context=context)
-      logging.info('"%s" is ready on service endpoint %s',
-                   service_name, base_url)
-      return
-    except HTTPError as error:
-      logging.error('%s service endpoint got %s.',
-                    service_name, error)
-      raise_and_log_error(
-          ResponseError('{0} service endpoint got {1}'.format(service_name, error),
-                        server=base_url))
-    except Exception as error:
-      raise_and_log_error(
-          ResponseError('{0} service endpoint got {1}'.format(service_name, error),
-                        server=base_url))
-    except URLError as error:
-      if time.time() >= end_time:
         logging.error(
-            'Timing out waiting for %s', service_name)
-        raise_and_log_error(TimeoutError(service_name, cause=service_name))
-      raise
+            "It appears %s is no longer available." " Perhaps the tunnel closed.",
+            service_name,
+        )
+        raise_and_log_error(
+            ResponseError(
+                "It appears that {0} failed".format(service_name), server="tunnel"
+            )
+        )
 
-  def run_tests(self):
-    """The actual controller that coordinates and runs the tests.
+    def __validate_service_base_url(self, service_name, timeout=None):
+        service_config = self.__public_service_configs[service_name]
+        base_url = service_config["base_url"]
 
-    This attempts to process all the tests concurrently across
-    seperate threads, where each test will:
-       (1) Determine whether or not the test is a candidate
-           (passes the --test_include / --test_exclude criteria)
+        timeout = timeout or self.options.test_service_startup_timeout
+        end_time = time.time() + timeout
+        logging.info('Validating base URL of "%s"...', service_name)
 
-       (2) Evaluate the test's requirements.
-           If the configuration requirements are not met then SKIP the test.
+        try:
+            url = "{base_url}/health".format(base_url=base_url)
+            request = Request(url=url)
+            if "bearer_auth_token" in service_config:
+                request.add_header(
+                    "Authorization",
+                    "Bearer {}".format(service_config["bearer_auth_token"]),
+                )
+            context = None
+            if self.options.test_ignore_ssl_cert_verification:
+                context = ssl._create_unverified_context()
+            urlopen(request, context=context)
+            logging.info('"%s" is ready on service endpoint %s', service_name, base_url)
+            return
+        except HTTPError as error:
+            logging.error("%s service endpoint got %s.", service_name, error)
+            raise_and_log_error(
+                ResponseError(
+                    "{0} service endpoint got {1}".format(service_name, error),
+                    server=base_url,
+                )
+            )
+        except Exception as error:
+            raise_and_log_error(
+                ResponseError(
+                    "{0} service endpoint got {1}".format(service_name, error),
+                    server=base_url,
+                )
+            )
+        except URLError as error:
+            if time.time() >= end_time:
+                logging.error("Timing out waiting for %s", service_name)
+                raise_and_log_error(TimeoutError(service_name, cause=service_name))
+            raise
 
-           (a) Attempt to tunnel each of the service tests, sharing existing
-               tunnels used by other tests. The tunnels allocate unused local
-               ports to avoid potential conflict within the local machine.
+    def run_tests(self):
+        """The actual controller that coordinates and runs the tests.
 
-           (b) Wait for the service to be ready. Ideally this means it is
-               healthy, however we'll allow unhealthy services to proceed
-               as well and let those tests run and fail in case they are
-               testing unhealthy service situations.
+        This attempts to process all the tests concurrently across
+        seperate threads, where each test will:
+           (1) Determine whether or not the test is a candidate
+               (passes the --test_include / --test_exclude criteria)
 
-           (c) If there is an error or the service takes too long then
-               outright FAIL the test.
+           (2) Evaluate the test's requirements.
+               If the configuration requirements are not met then SKIP the test.
 
-        (3) Acquire the quota that the test requires.
+               (a) Attempt to tunnel each of the service tests, sharing existing
+                   tunnels used by other tests. The tunnels allocate unused local
+                   ports to avoid potential conflict within the local machine.
 
-            * If the quota is not currently available, then block the
-              thread until it is. Since each test is in its own thread, this
-              will not impact other tests.
+               (b) Wait for the service to be ready. Ideally this means it is
+                   healthy, however we'll allow unhealthy services to proceed
+                   as well and let those tests run and fail in case they are
+                   testing unhealthy service situations.
 
-            * Quota are only internal resources within the controller.
-              This is used for purposes of rate limiting, etc. It does not
-              coordinate with the underlying platforms.
+               (c) If there is an error or the service takes too long then
+                   outright FAIL the test.
 
-            * Quota is governed with --test_quota. If a test requests
-              a resource without a known quota, then the quota is assumed
-              to be infinite.
+            (3) Acquire the quota that the test requires.
 
-        (4) Grab a semaphore used to rate limit running tests.
-            This is controlled by --test_concurrency, which defaults to all.
+                * If the quota is not currently available, then block the
+                  thread until it is. Since each test is in its own thread, this
+                  will not impact other tests.
 
-        (5) Run the test.
+                * Quota are only internal resources within the controller.
+                  This is used for purposes of rate limiting, etc. It does not
+                  coordinate with the underlying platforms.
 
-        (6) Release the quota and semaphore to unblock other tests.
+                * Quota is governed with --test_quota. If a test requests
+                  a resource without a known quota, then the quota is assumed
+                  to be infinite.
 
-        (7) Record the outcome as PASS or FAIL
+            (4) Grab a semaphore used to rate limit running tests.
+                This is controlled by --test_concurrency, which defaults to all.
 
-    If an exception is thrown along the way, the test will automatically
-    be recorded as a FAILURE.
+            (5) Run the test.
 
-    Returns:
-        (#passed, #failed, #skipped)
-    """
-    options = self.options
-    if not options.testing_enabled:
-      logging.info('--testing_enabled=false skips test phase entirely.')
-      return 0, 0, 0
+            (6) Release the quota and semaphore to unblock other tests.
 
-    all_test_profiles = self.test_suite['tests']
+            (7) Record the outcome as PASS or FAIL
 
-    logging.info(
-        'Running tests (concurrency=%s).',
-        options.test_concurrency or 'infinite')
+        If an exception is thrown along the way, the test will automatically
+        be recorded as a FAILURE.
 
-    thread_pool = ThreadPool(len(all_test_profiles))
-    thread_pool.map(self.__run_or_skip_test_profile_entry_wrapper,
-                    all_test_profiles.items())
-    thread_pool.terminate()
+        Returns:
+            (#passed, #failed, #skipped)
+        """
+        options = self.options
+        if not options.testing_enabled:
+            logging.info("--testing_enabled=false skips test phase entirely.")
+            return 0, 0, 0
 
-    logging.info('Finished running tests.')
-    return len(self.__passed), len(self.__failed), len(self.__skipped)
+        all_test_profiles = self.test_suite["tests"]
 
-  def __run_or_skip_test_profile_entry_wrapper(self, args):
-    """Outer wrapper for running tests
+        logging.info(
+            "Running tests (concurrency=%s).", options.test_concurrency or "infinite"
+        )
 
-    Args:
-      args: [dict entry] The name and spec tuple from the mapped element.
-    """
-    test_name = args[0]
-    spec = args[1]
-    metric_labels = {'test_name': test_name, 'skipped': ''}
-    try:
-      self.__run_or_skip_test_profile_entry(test_name, spec, metric_labels)
-    except Exception as ex:
-      logging.error('%s threw an exception:\n%s',
-                    test_name, traceback.format_exc())
-      with self.__lock:
-        self.__failed.append((test_name, 'Caught exception {0}'.format(ex)))
-
-  def __record_skip_test(self, test_name, reason, skip_code, metric_labels):
-    logging.warning(reason)
-    self.__skipped.append((test_name, reason))
-
-    copy_labels = dict(metric_labels)
-    copy_labels['skipped'] = skip_code
-    copy_labels['success'] = 'Skipped'
-    self.__deployer.metrics.observe_timer(
-        'RunTestScript' + '_Outcome', copy_labels, 0.0)
-
-  def __run_or_skip_test_profile_entry(self, test_name, spec, metric_labels):
-    """Runs a test from within the thread-pool map() function.
-
-    Args:
-      test_name: [string] The name of the test.
-      spec: [dict] The test profile specification.
-    """
-    options = self.options
-    if not re.search(options.test_include, test_name):
-      reason = ('Skipped test "{name}" because it does not match explicit'
-                ' --test_include criteria "{criteria}".'
-                .format(name=test_name, criteria=options.test_include))
-      self.__record_skip_test(test_name, reason,
-                              'NotExplicitInclude', metric_labels)
-      return
-    if options.test_exclude and re.search(options.test_exclude, test_name):
-      reason = ('Skipped test "{name}" because it matches explicit'
-                ' --test_exclude criteria "{criteria}".'
-                .format(name=test_name, criteria=options.test_exclude))
-      self.__record_skip_test(test_name, reason,
-                              'ExplicitExclude', metric_labels)
-      return
-
-    # This can raise an exception
-    self.run_test_profile_helper(test_name, spec, metric_labels)
-
-  def validate_test_requirements(self, test_name, spec, metric_labels):
-    """Determine whether or not the test requirements are satisfied.
-
-    If not, record the reason a skip or failure.
-    This may throw exceptions, which are immediate failure.
-
-    Args:
-      test_name: [string] The name of the test.
-      spec: [dict] The profile specification containing requirements.
-            This argument will be pruned as values are consumed from it.
-
-    Returns:
-      True if requirements are satisfied, False if not.
-    """
-    if not 'api' in spec:
-      raise_and_log_error(
-          UnexpectedError('Test "{name}" is missing an "api" spec.'.format(
-              name=test_name)))
-
-    requires = spec.pop('requires', {})
-    configuration = requires.pop('configuration', {})
-    our_config = vars(self.options)
-    for key, value in configuration.items():
-      if key not in our_config:
-        message = ('Unknown configuration key "{0}" for test "{1}"'
-                   .format(key, test_name))
-        raise_and_log_error(ConfigError(message))
-      if value != our_config[key]:
-        reason = ('Skipped test {name} because {key}={want} != {have}'
-                  .format(name=test_name, key=key,
-                          want=value, have=our_config[key]))
-        with self.__lock:
-          self.__record_skip_test(test_name, reason,
-                                  'IncompatableConfig', metric_labels)
-        return False
-
-    services = set(replace_ha_services(
-        requires.pop('services', []), self.options))
-
-    services.add(self.__replace_ha_api_service(
-        spec.pop('api'), self.options))
-
-    if requires:
-      raise_and_log_error(
-          ConfigError('Unexpected fields in {name}.requires: {remaining}'
-                      .format(name=test_name, remaining=requires)))
-    if spec:
-      raise_and_log_error(
-          ConfigError('Unexpected fields in {name} specification: {remaining}'
-                      .format(name=test_name, remaining=spec)))
-
-    for service in self.__public_service_configs:
-      self.__validate_service_base_url(service)
-
-    if self.options.test_wait_on_services:
-      def wait_on_services(services):
-        thread_pool = ThreadPool(len(services))
-        thread_pool.map(self.wait_on_service, services)
+        thread_pool = ThreadPool(len(all_test_profiles))
+        thread_pool.map(
+            self.__run_or_skip_test_profile_entry_wrapper, all_test_profiles.items()
+        )
         thread_pool.terminate()
 
-      self.__deployer.metrics.track_and_time_call(
-          'WaitingOnServiceAvailability',
-          metric_labels, self.__deployer.metrics.default_determine_outcome_labels,
-          wait_on_services, services)
-    else:
-      logging.warning('Skipping waiting for services')
+        logging.info("Finished running tests.")
+        return len(self.__passed), len(self.__failed), len(self.__skipped)
 
-    return True
+    def __run_or_skip_test_profile_entry_wrapper(self, args):
+        """Outer wrapper for running tests
 
-  def add_extra_arguments(self, test_name, args, commandline):
-    """Add extra arguments to the commandline.
+        Args:
+          args: [dict entry] The name and spec tuple from the mapped element.
+        """
+        test_name = args[0]
+        spec = args[1]
+        metric_labels = {"test_name": test_name, "skipped": ""}
+        try:
+            self.__run_or_skip_test_profile_entry(test_name, spec, metric_labels)
+        except Exception as ex:
+            logging.error(
+                "%s threw an exception:\n%s", test_name, traceback.format_exc()
+            )
+            with self.__lock:
+                self.__failed.append((test_name, "Caught exception {0}".format(ex)))
 
-    Args:
-      test_name: [string] Name of test specifying the options.
-      args: [dict] Specification of additioanl arguments to pass.
-         Each key is the name of the argument, the value is the value to pass.
-         If the value is preceeded with a '$' then it refers to the value of
-         an option. If the value is None then just add the key without an arg.
-      commandline: [list] The list of command line arguments to append to.
-    """
-    option_dict = vars(self.options)
-    aliases_dict = self.test_suite.get('aliases', {})
-    for key, value in args.items():
-      if isinstance(value, (int, bool)):
-        value = str(value)
-      if key == 'alias':
-        for alias_name in value:
-          if not alias_name in aliases_dict:
-            raise_and_log_error(ConfigError(
-                'Unknown alias "{name}" referenced in args for "{test}"'
-                .format(name=alias_name, test=test_name)))
-          self.add_extra_arguments(
-              test_name, aliases_dict[alias_name], commandline)
-        continue
-      elif value is None:
-        pass
-      elif value.startswith('$'):
-        option_name = value[1:]
-        if option_name in option_dict:
-          value = option_dict[option_name] or '""'
-        elif option_name in self.__extra_test_bindings:
-          value = self.__extra_test_bindings[option_name] or '""'
-        elif option_name in os.environ:
-          value = os.environ[option_name]
+    def __record_skip_test(self, test_name, reason, skip_code, metric_labels):
+        logging.warning(reason)
+        self.__skipped.append((test_name, reason))
+
+        copy_labels = dict(metric_labels)
+        copy_labels["skipped"] = skip_code
+        copy_labels["success"] = "Skipped"
+        self.__deployer.metrics.observe_timer(
+            "RunTestScript" + "_Outcome", copy_labels, 0.0
+        )
+
+    def __run_or_skip_test_profile_entry(self, test_name, spec, metric_labels):
+        """Runs a test from within the thread-pool map() function.
+
+        Args:
+          test_name: [string] The name of the test.
+          spec: [dict] The test profile specification.
+        """
+        options = self.options
+        if not re.search(options.test_include, test_name):
+            reason = (
+                'Skipped test "{name}" because it does not match explicit'
+                ' --test_include criteria "{criteria}".'.format(
+                    name=test_name, criteria=options.test_include
+                )
+            )
+            self.__record_skip_test(
+                test_name, reason, "NotExplicitInclude", metric_labels
+            )
+            return
+        if options.test_exclude and re.search(options.test_exclude, test_name):
+            reason = (
+                'Skipped test "{name}" because it matches explicit'
+                ' --test_exclude criteria "{criteria}".'.format(
+                    name=test_name, criteria=options.test_exclude
+                )
+            )
+            self.__record_skip_test(test_name, reason, "ExplicitExclude", metric_labels)
+            return
+
+        # This can raise an exception
+        self.run_test_profile_helper(test_name, spec, metric_labels)
+
+    def validate_test_requirements(self, test_name, spec, metric_labels):
+        """Determine whether or not the test requirements are satisfied.
+
+        If not, record the reason a skip or failure.
+        This may throw exceptions, which are immediate failure.
+
+        Args:
+          test_name: [string] The name of the test.
+          spec: [dict] The profile specification containing requirements.
+                This argument will be pruned as values are consumed from it.
+
+        Returns:
+          True if requirements are satisfied, False if not.
+        """
+        if not "api" in spec:
+            raise_and_log_error(
+                UnexpectedError(
+                    'Test "{name}" is missing an "api" spec.'.format(name=test_name)
+                )
+            )
+
+        requires = spec.pop("requires", {})
+        configuration = requires.pop("configuration", {})
+        our_config = vars(self.options)
+        for key, value in configuration.items():
+            if key not in our_config:
+                message = 'Unknown configuration key "{0}" for test "{1}"'.format(
+                    key, test_name
+                )
+                raise_and_log_error(ConfigError(message))
+            if value != our_config[key]:
+                reason = "Skipped test {name} because {key}={want} != {have}".format(
+                    name=test_name, key=key, want=value, have=our_config[key]
+                )
+                with self.__lock:
+                    self.__record_skip_test(
+                        test_name, reason, "IncompatableConfig", metric_labels
+                    )
+                return False
+
+        services = set(replace_ha_services(requires.pop("services", []), self.options))
+
+        services.add(self.__replace_ha_api_service(spec.pop("api"), self.options))
+
+        if requires:
+            raise_and_log_error(
+                ConfigError(
+                    "Unexpected fields in {name}.requires: {remaining}".format(
+                        name=test_name, remaining=requires
+                    )
+                )
+            )
+        if spec:
+            raise_and_log_error(
+                ConfigError(
+                    "Unexpected fields in {name} specification: {remaining}".format(
+                        name=test_name, remaining=spec
+                    )
+                )
+            )
+
+        for service in self.__public_service_configs:
+            self.__validate_service_base_url(service)
+
+        if self.options.test_wait_on_services:
+
+            def wait_on_services(services):
+                thread_pool = ThreadPool(len(services))
+                thread_pool.map(self.wait_on_service, services)
+                thread_pool.terminate()
+
+            self.__deployer.metrics.track_and_time_call(
+                "WaitingOnServiceAvailability",
+                metric_labels,
+                self.__deployer.metrics.default_determine_outcome_labels,
+                wait_on_services,
+                services,
+            )
         else:
-          raise_and_log_error(ConfigError(
-              'Unknown option "{name}" referenced in args for "{test}"'
-              .format(name=option_name, test=test_name)))
-      if value is None:
-        commandline.append('--' + key)
-      else:
-        commandline.extend(['--' + key, value])
+            logging.warning("Skipping waiting for services")
 
-  def make_test_command_or_none(self, test_name, spec, metric_labels):
-    """Returns the command to run the test, or None to skip.
+        return True
 
-    Args:
-       test_name: The test to run.
-       spec: The test specification profile.
-             This argument will be pruned as values are consumed from it.
+    def add_extra_arguments(self, test_name, args, commandline):
+        """Add extra arguments to the commandline.
 
-    Returns:
-      The command line argument list, or None to skip.
-      This may throw an exception if the spec is invalid.
-      This does not consider quota, which is checked later.
-    """
-    options = self.options
-    microservice_api = self.__replace_ha_api_service(spec.get('api'), options)
-    test_rel_path = spec.pop('path', None) or os.path.join(
-        'citest', 'tests', '{0}.py'.format(test_name))
-    args = spec.pop('args', {})
+        Args:
+          test_name: [string] Name of test specifying the options.
+          args: [dict] Specification of additioanl arguments to pass.
+             Each key is the name of the argument, the value is the value to pass.
+             If the value is preceeded with a '$' then it refers to the value of
+             an option. If the value is None then just add the key without an arg.
+          commandline: [list] The list of command line arguments to append to.
+        """
+        option_dict = vars(self.options)
+        aliases_dict = self.test_suite.get("aliases", {})
+        for key, value in args.items():
+            if isinstance(value, (int, bool)):
+                value = str(value)
+            if key == "alias":
+                for alias_name in value:
+                    if not alias_name in aliases_dict:
+                        raise_and_log_error(
+                            ConfigError(
+                                'Unknown alias "{name}" referenced in args for "{test}"'.format(
+                                    name=alias_name, test=test_name
+                                )
+                            )
+                        )
+                    self.add_extra_arguments(
+                        test_name, aliases_dict[alias_name], commandline
+                    )
+                continue
+            elif value is None:
+                pass
+            elif value.startswith("$"):
+                option_name = value[1:]
+                if option_name in option_dict:
+                    value = option_dict[option_name] or '""'
+                elif option_name in self.__extra_test_bindings:
+                    value = self.__extra_test_bindings[option_name] or '""'
+                elif option_name in os.environ:
+                    value = os.environ[option_name]
+                else:
+                    raise_and_log_error(
+                        ConfigError(
+                            'Unknown option "{name}" referenced in args for "{test}"'.format(
+                                name=option_name, test=test_name
+                            )
+                        )
+                    )
+            if value is None:
+                commandline.append("--" + key)
+            else:
+                commandline.extend(["--" + key, value])
 
-    if not self.validate_test_requirements(test_name, spec, metric_labels):
-      return None
+    def make_test_command_or_none(self, test_name, spec, metric_labels):
+        """Returns the command to run the test, or None to skip.
 
-    testing_root_dir = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), '..', 'testing'))
-    test_path = os.path.join(testing_root_dir, test_rel_path)
+        Args:
+           test_name: The test to run.
+           spec: The test specification profile.
+                 This argument will be pruned as values are consumed from it.
 
-    citest_log_dir = os.path.join(options.log_dir, 'citest_logs')
-    if not os.path.exists(citest_log_dir):
-      try:
-        os.makedirs(citest_log_dir)
-      except:
-        # check for race condition
+        Returns:
+          The command line argument list, or None to skip.
+          This may throw an exception if the spec is invalid.
+          This does not consider quota, which is checked later.
+        """
+        options = self.options
+        microservice_api = self.__replace_ha_api_service(spec.get("api"), options)
+        test_rel_path = spec.pop("path", None) or os.path.join(
+            "citest", "tests", "{0}.py".format(test_name)
+        )
+        args = spec.pop("args", {})
+
+        if not self.validate_test_requirements(test_name, spec, metric_labels):
+            return None
+
+        testing_root_dir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "testing")
+        )
+        test_path = os.path.join(testing_root_dir, test_rel_path)
+
+        citest_log_dir = os.path.join(options.log_dir, "citest_logs")
         if not os.path.exists(citest_log_dir):
-          raise
+            try:
+                os.makedirs(citest_log_dir)
+            except:
+                # check for race condition
+                if not os.path.exists(citest_log_dir):
+                    raise
 
-    command = [
-        'python', test_path,
-        '--log_dir', citest_log_dir,
-        '--log_filebase', test_name,
-        '--ignore_ssl_cert_verification', str(options.test_ignore_ssl_cert_verification)
-    ]
-    if microservice_api in self.__public_service_configs:
-      service_config = self.__public_service_configs[microservice_api]
-      command.extend([
-          '--native_base_url', service_config['base_url']
-      ])
-      if 'bearer_auth_token' in service_config:
-        command.extend([
-            '--bearer_auth_token', service_config['bearer_auth_token']
-        ])
-      if 'service_account_email' in service_config:
-        command.extend([
-            '--test_user', service_config['service_account_email']
-        ])
-    else:
-      command.extend([
-          '--native_host', 'localhost',
-          '--native_port', str(self.__forwarded_ports[microservice_api].port)
-      ])
+        command = [
+            "python",
+            test_path,
+            "--log_dir",
+            citest_log_dir,
+            "--log_filebase",
+            test_name,
+            "--ignore_ssl_cert_verification",
+            str(options.test_ignore_ssl_cert_verification),
+        ]
+        if microservice_api in self.__public_service_configs:
+            service_config = self.__public_service_configs[microservice_api]
+            command.extend(["--native_base_url", service_config["base_url"]])
+            if "bearer_auth_token" in service_config:
+                command.extend(
+                    ["--bearer_auth_token", service_config["bearer_auth_token"]]
+                )
+            if "service_account_email" in service_config:
+                command.extend(["--test_user", service_config["service_account_email"]])
+        else:
+            command.extend(
+                [
+                    "--native_host",
+                    "localhost",
+                    "--native_port",
+                    str(self.__forwarded_ports[microservice_api].port),
+                ]
+            )
 
-    if options.test_stack:
-      command.extend(['--test_stack', str(options.test_stack)])
+        if options.test_stack:
+            command.extend(["--test_stack", str(options.test_stack)])
 
-    self.add_extra_arguments(test_name, args, command)
-    return command
+        self.add_extra_arguments(test_name, args, command)
+        return command
 
-  def __execute_test_command(self, test_name, command, metric_labels):
-    metrics = self.__deployer.metrics
-    logging.debug('Running %s', ' '.join(command))
-    def run_and_log_test_script(command):
-      logfile = os.path.join(self.options.output_dir, 'citest_logs',
-                             '%s-%s.console.log' % (test_name, os.getpid()))
-      logging.info('Logging test "%s" to %s', test_name, logfile)
-      try:
-        check_subprocesses_to_logfile('running test', logfile, [command])
-        retcode = 0
-        logging.info('Test %s PASSED -- see %s', test_name, logfile)
-      except:
-        retcode = -1
-        logging.info('Test %s FAILED -- see %s', test_name, logfile)
+    def __execute_test_command(self, test_name, command, metric_labels):
+        metrics = self.__deployer.metrics
+        logging.debug("Running %s", " ".join(command))
 
-      return retcode, logfile
+        def run_and_log_test_script(command):
+            logfile = os.path.join(
+                self.options.output_dir,
+                "citest_logs",
+                "%s-%s.console.log" % (test_name, os.getpid()),
+            )
+            logging.info('Logging test "%s" to %s', test_name, logfile)
+            try:
+                check_subprocesses_to_logfile("running test", logfile, [command])
+                retcode = 0
+                logging.info("Test %s PASSED -- see %s", test_name, logfile)
+            except:
+                retcode = -1
+                logging.info("Test %s FAILED -- see %s", test_name, logfile)
 
-    return metrics.track_and_time_call(
-        'RunTestScript',
-        metric_labels, determine_subprocess_outcome_labels,
-        run_and_log_test_script, ' '.join(command))
+            return retcode, logfile
 
-  def run_test_profile_helper(self, test_name, spec, metric_labels):
-    """Helper function for running an individual test.
+        return metrics.track_and_time_call(
+            "RunTestScript",
+            metric_labels,
+            determine_subprocess_outcome_labels,
+            run_and_log_test_script,
+            " ".join(command),
+        )
 
-    The caller wraps this to trap and handle exceptions.
+    def run_test_profile_helper(self, test_name, spec, metric_labels):
+        """Helper function for running an individual test.
 
-    Args:
-      test_name: The test being run.
-      spec: The test specification profile.
-            This argument will be pruned as values are consumed from it.
-    """
-    quota = spec.pop('quota', {})
-    command = self.make_test_command_or_none(test_name, spec, metric_labels)
-    if command is None:
-      return
+        The caller wraps this to trap and handle exceptions.
 
-    logging.info('Acquiring quota for test "%s"...', test_name)
-    quota_tracker = self.__quota_tracker
-    metrics = self.__deployer.metrics
-    acquired_quota = metrics.track_and_time_call(
-        'ResourceQuotaWait',
-        metric_labels, metrics.default_determine_outcome_labels,
-        quota_tracker.acquire_all_safe, test_name, quota)
-    if acquired_quota:
-      logging.info('"%s" acquired quota %s', test_name, acquired_quota)
+        Args:
+          test_name: The test being run.
+          spec: The test specification profile.
+                This argument will be pruned as values are consumed from it.
+        """
+        quota = spec.pop("quota", {})
+        command = self.make_test_command_or_none(test_name, spec, metric_labels)
+        if command is None:
+            return
 
-    execute_time = None
-    start_time = time.time()
-    try:
-      logging.info('Scheduling "%s"...', test_name)
+        logging.info('Acquiring quota for test "%s"...', test_name)
+        quota_tracker = self.__quota_tracker
+        metrics = self.__deployer.metrics
+        acquired_quota = metrics.track_and_time_call(
+            "ResourceQuotaWait",
+            metric_labels,
+            metrics.default_determine_outcome_labels,
+            quota_tracker.acquire_all_safe,
+            test_name,
+            quota,
+        )
+        if acquired_quota:
+            logging.info('"%s" acquired quota %s', test_name, acquired_quota)
 
-      # This will block. Note that we already acquired quota, thus
-      # we are blocking holding onto that quota. However since we are
-      # blocked awaiting a thread, nobody else can execute either,
-      # so it doesnt matter that we might be starving them of quota.
-      self.__semaphore.acquire(True)
-      execute_time = time.time()
-      wait_time = int(execute_time - start_time + 0.5)
-      if wait_time > 1:
-        logging.info('"%s" had a semaphore contention for %d secs.',
-                     test_name, wait_time)
-      logging.info('Executing "%s"...', test_name)
-      retcode, logfile_path = self.__execute_test_command(
-          test_name, command, metric_labels)
-    finally:
-      logging.info('Finished executing "%s"...', test_name)
-      self.__semaphore.release()
-      if acquired_quota:
-        quota_tracker.release_all_safe(test_name, acquired_quota)
+        execute_time = None
+        start_time = time.time()
+        try:
+            logging.info('Scheduling "%s"...', test_name)
 
-    end_time = time.time()
-    delta_time = int(end_time - execute_time + 0.5)
+            # This will block. Note that we already acquired quota, thus
+            # we are blocking holding onto that quota. However since we are
+            # blocked awaiting a thread, nobody else can execute either,
+            # so it doesnt matter that we might be starving them of quota.
+            self.__semaphore.acquire(True)
+            execute_time = time.time()
+            wait_time = int(execute_time - start_time + 0.5)
+            if wait_time > 1:
+                logging.info(
+                    '"%s" had a semaphore contention for %d secs.', test_name, wait_time
+                )
+            logging.info('Executing "%s"...', test_name)
+            retcode, logfile_path = self.__execute_test_command(
+                test_name, command, metric_labels
+            )
+        finally:
+            logging.info('Finished executing "%s"...', test_name)
+            self.__semaphore.release()
+            if acquired_quota:
+                quota_tracker.release_all_safe(test_name, acquired_quota)
 
-    with self.__lock:
-      if not retcode:
-        logging.info('%s PASSED after %d secs', test_name, delta_time)
-        self.__passed.append((test_name, logfile_path))
-      else:
-        logging.info('FAILED %s after %d secs', test_name, delta_time)
-        self.__failed.append((test_name, logfile_path))
+        end_time = time.time()
+        delta_time = int(end_time - execute_time + 0.5)
+
+        with self.__lock:
+            if not retcode:
+                logging.info("%s PASSED after %d secs", test_name, delta_time)
+                self.__passed.append((test_name, logfile_path))
+            else:
+                logging.info("FAILED %s after %d secs", test_name, delta_time)
+                self.__failed.append((test_name, logfile_path))
 
 
 def init_argument_parser(parser, defaults):
-  """Add testing related command-line parameters."""
-  add_parser_argument(
-      parser, 'test_profiles',
-      defaults, os.path.join(os.path.dirname(__file__), 'all_tests.yaml'),
-      help='The path to the set of test profiles.')
+    """Add testing related command-line parameters."""
+    add_parser_argument(
+        parser,
+        "test_profiles",
+        defaults,
+        os.path.join(os.path.dirname(__file__), "all_tests.yaml"),
+        help="The path to the set of test profiles.",
+    )
 
-  add_parser_argument(
-      parser, 'test_extra_profile_bindings', defaults, None,
-      help='Path to a file with additional bindings that the --test_profiles'
-           ' file may reference.')
+    add_parser_argument(
+        parser,
+        "test_extra_profile_bindings",
+        defaults,
+        None,
+        help="Path to a file with additional bindings that the --test_profiles"
+        " file may reference.",
+    )
 
-  add_parser_argument(
-      parser, 'test_concurrency', defaults, None, type=int,
-      help='Limits how many tests to run at a time. Default is unbounded')
+    add_parser_argument(
+        parser,
+        "test_concurrency",
+        defaults,
+        None,
+        type=int,
+        help="Limits how many tests to run at a time. Default is unbounded",
+    )
 
-  add_parser_argument(
-      parser, 'test_service_startup_timeout', defaults, 600, type=int,
-      help='Number of seconds to permit services to startup before giving up.')
+    add_parser_argument(
+        parser,
+        "test_service_startup_timeout",
+        defaults,
+        600,
+        type=int,
+        help="Number of seconds to permit services to startup before giving up.",
+    )
 
-  add_parser_argument(
-      parser, 'test_gce_project_quota_factor', defaults, 1.0, type=float,
-      help='Default percentage of available project quota to make available'
-           ' for tests.')
+    add_parser_argument(
+        parser,
+        "test_gce_project_quota_factor",
+        defaults,
+        1.0,
+        type=float,
+        help="Default percentage of available project quota to make available"
+        " for tests.",
+    )
 
-  add_parser_argument(
-      parser, 'test_gce_region_quota_factor', defaults, 1.0, type=float,
-      help='Default percentage of available region quota to make available'
-           ' for tests.')
+    add_parser_argument(
+        parser,
+        "test_gce_region_quota_factor",
+        defaults,
+        1.0,
+        type=float,
+        help="Default percentage of available region quota to make available"
+        " for tests.",
+    )
 
-  add_parser_argument(
-      parser, 'test_gce_quota_region', defaults, 'us-central1',
-      help='GCE Compute Region to gather region quota limits from.')
+    add_parser_argument(
+        parser,
+        "test_gce_quota_region",
+        defaults,
+        "us-central1",
+        help="GCE Compute Region to gather region quota limits from.",
+    )
 
-  add_parser_argument(
-      parser, 'test_default_quota',
-      defaults, '',
-      help='Default quota parameters for values used in the --test_profiles.'
-           ' This does not include GCE quota values, which are determined'
-           ' at runtime. These value can be further overriden by --test_quota.'
-           ' These are meant as built-in defaults, where --test_quota as'
-           ' per-execution overriden.')
+    add_parser_argument(
+        parser,
+        "test_default_quota",
+        defaults,
+        "",
+        help="Default quota parameters for values used in the --test_profiles."
+        " This does not include GCE quota values, which are determined"
+        " at runtime. These value can be further overriden by --test_quota."
+        " These are meant as built-in defaults, where --test_quota as"
+        " per-execution overriden.",
+    )
 
-  add_parser_argument(
-      parser, 'test_quota', defaults, '',
-      help='Comma-delimited name=value list of quota overrides.')
+    add_parser_argument(
+        parser,
+        "test_quota",
+        defaults,
+        "",
+        help="Comma-delimited name=value list of quota overrides.",
+    )
 
-  add_parser_argument(
-      parser, 'testing_enabled', defaults, True, type=bool,
-      help='If false then do not run the testing phase.')
+    add_parser_argument(
+        parser,
+        "testing_enabled",
+        defaults,
+        True,
+        type=bool,
+        help="If false then do not run the testing phase.",
+    )
 
-  add_parser_argument(
-      parser, 'test_disable', defaults, False, action='store_true',
-      dest='testing_enabled',
-      help='DEPRECATED: Use --testing_enabled=false.')
+    add_parser_argument(
+        parser,
+        "test_disable",
+        defaults,
+        False,
+        action="store_true",
+        dest="testing_enabled",
+        help="DEPRECATED: Use --testing_enabled=false.",
+    )
 
-  add_parser_argument(
-      parser, 'test_wait_on_services', defaults, True, type=bool,
-      help='If false then do not wait on services to be ready during'
-           ' testing phase.')
+    add_parser_argument(
+        parser,
+        "test_wait_on_services",
+        defaults,
+        True,
+        type=bool,
+        help="If false then do not wait on services to be ready during"
+        " testing phase.",
+    )
 
-  add_parser_argument(
-      parser, 'test_include', defaults, '.*',
-      help='Regular expression of tests to run or None for all.')
+    add_parser_argument(
+        parser,
+        "test_include",
+        defaults,
+        ".*",
+        help="Regular expression of tests to run or None for all.",
+    )
 
-  add_parser_argument(
-      parser, 'test_exclude', defaults, None,
-      help='Regular expression of otherwise runnable tests to skip.')
+    add_parser_argument(
+        parser,
+        "test_exclude",
+        defaults,
+        None,
+        help="Regular expression of otherwise runnable tests to skip.",
+    )
 
-  add_parser_argument(
-      parser, 'test_stack', defaults, None,
-      help='The --test_stack to pass through to tests indicating which'
-           ' Spinnaker application "stack" to use. This is typically'
-           ' to help trace the source of resources created within the'
-           ' tests.')
+    add_parser_argument(
+        parser,
+        "test_stack",
+        defaults,
+        None,
+        help="The --test_stack to pass through to tests indicating which"
+        ' Spinnaker application "stack" to use. This is typically'
+        " to help trace the source of resources created within the"
+        " tests.",
+    )
 
-  add_parser_argument(
-      parser, 'test_jenkins_job_name', defaults, 'TriggerBake',
-      help='The Jenkins job name to use in tests.')
+    add_parser_argument(
+        parser,
+        "test_jenkins_job_name",
+        defaults,
+        "TriggerBake",
+        help="The Jenkins job name to use in tests.",
+    )
 
-  add_parser_argument(
-      parser, 'test_gate_service_base_url', defaults, None,
-      help='Gate base URL (including protocol, host, and port) to use'
-           ' rather than port-forwarding.')
+    add_parser_argument(
+        parser,
+        "test_gate_service_base_url",
+        defaults,
+        None,
+        help="Gate base URL (including protocol, host, and port) to use"
+        " rather than port-forwarding.",
+    )
 
-  add_parser_argument(
-      parser, 'test_gate_iap_client_id', defaults, None,
-      help='IAP client ID used to authenticate requests to an'
-           ' IAP-protected Spinnaker. The inclusion of this flag'
-           ' indicates that the Gate service is IAP-protected.')
+    add_parser_argument(
+        parser,
+        "test_gate_iap_client_id",
+        defaults,
+        None,
+        help="IAP client ID used to authenticate requests to an"
+        " IAP-protected Spinnaker. The inclusion of this flag"
+        " indicates that the Gate service is IAP-protected.",
+    )
 
-  add_parser_argument(
-      parser, 'test_gate_iap_credentials', defaults, None,
-      help='Path to google credentials file to authenticate requests'
-           ' to an IAP-protected Spinnaker. This must be used with the'
-           ' test_gate_iap_client_id flag.'
-           ' If left empty then use Application Default Credentials.')
+    add_parser_argument(
+        parser,
+        "test_gate_iap_credentials",
+        defaults,
+        None,
+        help="Path to google credentials file to authenticate requests"
+        " to an IAP-protected Spinnaker. This must be used with the"
+        " test_gate_iap_client_id flag."
+        " If left empty then use Application Default Credentials.",
+    )
 
-  add_parser_argument(
-      parser, 'test_gate_iap_impersonated_service_account', defaults, None,
-      help='Service account to impersonate to receive the credentials'
-           ' to make authenticated requests to an IAP-protected Spinnaker.'
-           ' If test_gate_iap_credentials is provided, the service account'
-           ' specified by test_gate_iap_credentials will impersonate this'
-           ' service account. If test_gate_iap_credentials is not provided,'
-           ' the Application Default Credentials will be used to impersonate'
-           ' this service account. This must be used with the'
-           ' test_gate_iap_client_id flag.'
-           ' If left empty then no service account will be impersonated.')
+    add_parser_argument(
+        parser,
+        "test_gate_iap_impersonated_service_account",
+        defaults,
+        None,
+        help="Service account to impersonate to receive the credentials"
+        " to make authenticated requests to an IAP-protected Spinnaker."
+        " If test_gate_iap_credentials is provided, the service account"
+        " specified by test_gate_iap_credentials will impersonate this"
+        " service account. If test_gate_iap_credentials is not provided,"
+        " the Application Default Credentials will be used to impersonate"
+        " this service account. This must be used with the"
+        " test_gate_iap_client_id flag."
+        " If left empty then no service account will be impersonated.",
+    )
 
-  add_parser_argument(
-      parser, 'test_ignore_ssl_cert_verification', defaults, False, type=bool,
-      help='Whether or not to ignore SSL certificate verification when making'
-           ' requests to Spinnaker. This is False by default.')
+    add_parser_argument(
+        parser,
+        "test_ignore_ssl_cert_verification",
+        defaults,
+        False,
+        type=bool,
+        help="Whether or not to ignore SSL certificate verification when making"
+        " requests to Spinnaker. This is False by default.",
+    )
 
-  add_parser_argument(
-      parser, 'test_appengine_region', defaults, 'us-central',
-      help='Region to use for AppEngine tests.')
+    add_parser_argument(
+        parser,
+        "test_appengine_region",
+        defaults,
+        "us-central",
+        help="Region to use for AppEngine tests.",
+    )
+
 
 def validate_options(options):
-  """Validate testing related command-line parameters."""
-  if not os.path.exists(options.test_profiles):
-    raise_and_log_error(
-        ConfigError('--test_profiles "{0}" does not exist.'.format(
-            options.test_profiles)))
+    """Validate testing related command-line parameters."""
+    if not os.path.exists(options.test_profiles):
+        raise_and_log_error(
+            ConfigError(
+                '--test_profiles "{0}" does not exist.'.format(options.test_profiles)
+            )
+        )

--- a/dev/validate_bom__test.py
+++ b/dev/validate_bom__test.py
@@ -879,7 +879,7 @@ class ValidateBomTestController(object):
         Returns:
           True if requirements are satisfied, False if not.
         """
-        if not "api" in spec:
+        if "api" not in spec:
             raise_and_log_error(
                 UnexpectedError(
                     'Test "{name}" is missing an "api" spec.'.format(name=test_name)
@@ -966,7 +966,7 @@ class ValidateBomTestController(object):
                 value = str(value)
             if key == "alias":
                 for alias_name in value:
-                    if not alias_name in aliases_dict:
+                    if alias_name not in aliases_dict:
                         raise_and_log_error(
                             ConfigError(
                                 'Unknown alias "{name}" referenced in args for "{test}"'.format(

--- a/google/dev/delete_resources.py
+++ b/google/dev/delete_resources.py
@@ -285,9 +285,9 @@ def get_options():
 def delete(resource_obj, resource_instance, params, dry_run):
   """Delete the resource_instance."""
   decorator = '[dry run] ' if dry_run else ''
-  print '{decorator}DELETE {name} [{time}] FROM {params}'.format(
+  print('{decorator}DELETE {name} [{time}] FROM {params}'.format(
       decorator=decorator, name=resource_instance.get('name'),
-      time=determine_timestamp(resource_instance), params=params)
+      time=determine_timestamp(resource_instance), params=params))
   if dry_run:
     return
 

--- a/google/dev/delete_resources.py
+++ b/google/dev/delete_resources.py
@@ -68,335 +68,382 @@ from oauth2client.client import GoogleCredentials
 from oauth2client.service_account import ServiceAccountCredentials
 
 
-PLATFORM_FULL_SCOPE = 'https://www.googleapis.com/auth/cloud-platform'
+PLATFORM_FULL_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 
 
 def get_metadata(relative_url):
-  """Return metadata value.
+    """Return metadata value.
 
-  Args:
-    relative_url: [string] Metadata url to fetch relative to base metadata URL.
-  """
-  base_url = 'http://metadata/computeMetadata/v1/'
-  url = urlparse.urljoin(base_url, relative_url)
-  headers = {'Metadata-Flavor': 'Google'}
-  return urllib2.urlopen(urllib2.Request(url, headers=headers)).read()
+    Args:
+      relative_url: [string] Metadata url to fetch relative to base metadata URL.
+    """
+    base_url = "http://metadata/computeMetadata/v1/"
+    url = urlparse.urljoin(base_url, relative_url)
+    headers = {"Metadata-Flavor": "Google"}
+    return urllib2.urlopen(urllib2.Request(url, headers=headers)).read()
 
 
 def make_service(api, version, credentials_path=None):
-  """Create Google Service stub.
+    """Create Google Service stub.
 
-  Args:
-    api: [string] Google API name
-    version: [string] Google API version
-    credentials_path: [string] Path to credentials file, or none for default.
-  """
-  if credentials_path:
-    credentials = ServiceAccountCredentials.from_json_keyfile_name(
-        credentials_path, scopes=PLATFORM_FULL_SCOPE)
-  else:
-    credentials = GoogleCredentials.get_application_default()
-  http = credentials.authorize(httplib2.Http())
-  return apiclient.discovery.build(api, version, http=http)
+    Args:
+      api: [string] Google API name
+      version: [string] Google API version
+      credentials_path: [string] Path to credentials file, or none for default.
+    """
+    if credentials_path:
+        credentials = ServiceAccountCredentials.from_json_keyfile_name(
+            credentials_path, scopes=PLATFORM_FULL_SCOPE
+        )
+    else:
+        credentials = GoogleCredentials.get_application_default()
+    http = credentials.authorize(httplib2.Http())
+    return apiclient.discovery.build(api, version, http=http)
 
 
 def determine_version(api):
-  """Determine current version of Google API
+    """Determine current version of Google API
 
-  Args:
-    api: [string] Google API name
-  """
-  discovery = make_service('discovery', 'v1')
-  response = discovery.apis().list(name=api, preferred=True).execute()
-  if not response.get('items'):
-    raise ValueError('Unknown API "{0}".'.format(api))
-  return response['items'][0]['version']
+    Args:
+      api: [string] Google API name
+    """
+    discovery = make_service("discovery", "v1")
+    response = discovery.apis().list(name=api, preferred=True).execute()
+    if not response.get("items"):
+        raise ValueError('Unknown API "{0}".'.format(api))
+    return response["items"][0]["version"]
 
 
 def determine_timestamp(item):
-  """Determine the timestamp of the given item
+    """Determine the timestamp of the given item
 
-  Args:
-  item: [dict] Specifies an resource instance created by an API
-  """
-  # There is no standard for this.
-  # The following are common to some APIs.
-  for key in ['creationTimestamp', 'timeCreated']:
-    if key in item:
-      return item[key]
-  raise ValueError('Could not determine timestamp key for {0}'
-                   .format(item.get('kind', item)))
+    Args:
+    item: [dict] Specifies an resource instance created by an API
+    """
+    # There is no standard for this.
+    # The following are common to some APIs.
+    for key in ["creationTimestamp", "timeCreated"]:
+        if key in item:
+            return item[key]
+    raise ValueError(
+        "Could not determine timestamp key for {0}".format(item.get("kind", item))
+    )
 
 
 def __determine_resource_obj(service, resource):
-  """Find the desired resource object method container from the service.
+    """Find the desired resource object method container from the service.
 
-  Args:
-    service: [stub] Google API stub object.
-    resource: [string]  '.' delimited resource name in service API.
-  """
-  path = resource.split('.')
-  node = service
-  for elem in path:
-    try:
-      node = getattr(node, elem)()
-    except AttributeError:
-      raise AttributeError('"{0}" has no attribute "{1}"'.format(
-          '.'.join(path[0:path.index(elem)]), elem))
-  return node
+    Args:
+      service: [stub] Google API stub object.
+      resource: [string]  '.' delimited resource name in service API.
+    """
+    path = resource.split(".")
+    node = service
+    for elem in path:
+        try:
+            node = getattr(node, elem)()
+        except AttributeError:
+            raise AttributeError(
+                '"{0}" has no attribute "{1}"'.format(
+                    ".".join(path[0 : path.index(elem)]), elem
+                )
+            )
+    return node
 
 
 def __filter_items(items, name_filter, before_str):
-  """
-  Args:
-    items: [list of dict] List of item candidates.
-    name_filter: [re] Regex for matching resource instance names.
-    before_str: [string] Specifies newest time to consider (non-inclusive).
-  """
-  result = []
-  for item in items:
-    if not name_filter.match(item.get('name')):
-      continue
+    """
+    Args:
+      items: [list of dict] List of item candidates.
+      name_filter: [re] Regex for matching resource instance names.
+      before_str: [string] Specifies newest time to consider (non-inclusive).
+    """
+    result = []
+    for item in items:
+        if not name_filter.match(item.get("name")):
+            continue
 
-    # Compare strings to keep this simple since there
-    # isnt easy support to parse dates. This is only approximate
-    # before we arent interpreting the time zone correctly. But it
-    # is good enough.
-    if before_str is None or determine_timestamp(item) < before_str:
-      result.append(item)
-  return result
+        # Compare strings to keep this simple since there
+        # isnt easy support to parse dates. This is only approximate
+        # before we arent interpreting the time zone correctly. But it
+        # is good enough.
+        if before_str is None or determine_timestamp(item) < before_str:
+            result.append(item)
+    return result
 
 
 def collect(resource_obj, list_kwargs, name_filter, before_str=None):
-  """"Helper function that actually collects and filters the desired items.
+    """ "Helper function that actually collects and filters the desired items.
 
-  Args:
-    resource_obj: [obj] The API container object for the resource.
-    list_kwargs: [dict] Parameters for the API list method.
-    name_filter: [re] Regex for matching resource instance names.
-    before_str: [string] Specifies newest time to consider (non-inclusive).
-  """
-  result = []
-  request = resource_obj.list(**list_kwargs)
-  while request:
-    response = request.execute()
-    result.extend(__filter_items(response.get('items', []),
-                                 name_filter, before_str))
-    try:
-      request = resource_obj.list_next(request, response)
-    except AttributeError:
-      request = None
-  return result
+    Args:
+      resource_obj: [obj] The API container object for the resource.
+      list_kwargs: [dict] Parameters for the API list method.
+      name_filter: [re] Regex for matching resource instance names.
+      before_str: [string] Specifies newest time to consider (non-inclusive).
+    """
+    result = []
+    request = resource_obj.list(**list_kwargs)
+    while request:
+        response = request.execute()
+        result.extend(
+            __filter_items(response.get("items", []), name_filter, before_str)
+        )
+        try:
+            request = resource_obj.list_next(request, response)
+        except AttributeError:
+            request = None
+    return result
 
 
-def collect_aggregated(resource_obj, items_list_key,
-                       list_kwargs, name_filter, before_str=None):
-  """"Helper function that actually collects and filters the desired items.
+def collect_aggregated(
+    resource_obj, items_list_key, list_kwargs, name_filter, before_str=None
+):
+    """ "Helper function that actually collects and filters the desired items.
 
-  Args:
-    resource_obj: [obj] The API container object for the resource.
-    list_kwargs: [dict] Parameters for the API list method.
-    name_filter: [re] Regex for matching resource instance names.
-    before_str: [string] Specifies newest time to consider (non-inclusive).
-  """
-  result = []
-  request = resource_obj.aggregatedList(**list_kwargs)
-  while request:
-    response = request.execute()
-    items = response.get('items', [])
-    for key, key_item in items.items():
-      filtered_items = __filter_items(key_item.get(items_list_key, []),
-                                      name_filter, before_str)
-      result.extend([(key, value) for value in filtered_items])
-    try:
-      request = resource_obj.list_next(request, response)
-    except AttributeError:
-      request = None
-  return result
+    Args:
+      resource_obj: [obj] The API container object for the resource.
+      list_kwargs: [dict] Parameters for the API list method.
+      name_filter: [re] Regex for matching resource instance names.
+      before_str: [string] Specifies newest time to consider (non-inclusive).
+    """
+    result = []
+    request = resource_obj.aggregatedList(**list_kwargs)
+    while request:
+        response = request.execute()
+        items = response.get("items", [])
+        for key, key_item in items.items():
+            filtered_items = __filter_items(
+                key_item.get(items_list_key, []), name_filter, before_str
+            )
+            result.extend([(key, value) for value in filtered_items])
+        try:
+            request = resource_obj.list_next(request, response)
+        except AttributeError:
+            request = None
+    return result
 
 
 def make_resource_object(resource_type, credentials_path):
-  """Creates and configures the service object for operating on resources.
+    """Creates and configures the service object for operating on resources.
 
-  Args:
-    resource_type: [string] The Google API resource type to operate on.
-    credentials_path: [string] Path to credentials file, or none for default.
-  """
-  try:
-    api_name, resource = resource_type.split('.', 1)
-  except ValueError:
-    raise ValueError('resource_type "{0}" is not in form <api>.<resource>'
-                     .format(resource_type))
-  version = determine_version(api_name)
-  service = make_service(api_name, version, credentials_path)
-
-  path = resource.split('.')
-  node = service
-  for elem in path:
+    Args:
+      resource_type: [string] The Google API resource type to operate on.
+      credentials_path: [string] Path to credentials file, or none for default.
+    """
     try:
-      node = getattr(node, elem)()
-    except AttributeError:
-      path_str = '.'.join(path[0:path.index(elem)])
-      raise AttributeError('"{0}{1}" has no attribute "{2}"'.format(
-          api_name, '.' + path_str if path_str else '', elem))
-  return node
+        api_name, resource = resource_type.split(".", 1)
+    except ValueError:
+        raise ValueError(
+            'resource_type "{0}" is not in form <api>.<resource>'.format(resource_type)
+        )
+    version = determine_version(api_name)
+    service = make_service(api_name, version, credentials_path)
+
+    path = resource.split(".")
+    node = service
+    for elem in path:
+        try:
+            node = getattr(node, elem)()
+        except AttributeError:
+            path_str = ".".join(path[0 : path.index(elem)])
+            raise AttributeError(
+                '"{0}{1}" has no attribute "{2}"'.format(
+                    api_name, "." + path_str if path_str else "", elem
+                )
+            )
+    return node
 
 
 def get_options():
-  """Process commandline arguments."""
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-      '--project', default=None,
-      help='The project owning the resources to consider.'
-      ' This should only be specified if the resource API requires a project'
-      ' (e.g. compute.images, but not storage.objects).'
-      ' An empty string means the local GCP project.'
-      '\nThis is a shortcut for adding the project into --delete_kwargs.')
+    """Process commandline arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--project",
+        default=None,
+        help="The project owning the resources to consider."
+        " This should only be specified if the resource API requires a project"
+        " (e.g. compute.images, but not storage.objects)."
+        " An empty string means the local GCP project."
+        "\nThis is a shortcut for adding the project into --delete_kwargs.",
+    )
 
-  parser.add_argument('resource', nargs=1,
-                      help='The resource to delete.')
-  parser.add_argument('--age', default=None, type=int,
-                      help='The number of recent days to keep.'
-                           ' The default is none.')
-  parser.add_argument('--name', default='.*',
-                      help='The regular expression for names to remove.'
-                           ' The default is ".*" (everything)')
-  parser.add_argument('--credentials', default=None,
-                      help='Path to JSON credentials to use.'
-                           ' The default is application default credentials')
-  parser.add_argument('--aggregated', default=False, action='store_true',
-                      help='Use aggregated_list() method.')
-  parser.add_argument('--dry_run', default=False, action='store_true',
-                      help='Show proposed delete, dont actually do them.')
-  parser.add_argument(
-      '--delete_kwargs', default=None,
-      help='The extra arguments to pass to delete.'
-           ' This is a comma-delimted list of name=value.'
-           ' For more info, see https://developers.google.com/apis-explorer/#p/')
-  parser.add_argument(
-      '--list_kwargs', default=None,
-      help='The extra arguments to pass to list,'
-           ' beyond those in --delete_kwargs (which are added automatically).'
-           ' This is a comma-delimted list of name=value.')
+    parser.add_argument("resource", nargs=1, help="The resource to delete.")
+    parser.add_argument(
+        "--age",
+        default=None,
+        type=int,
+        help="The number of recent days to keep." " The default is none.",
+    )
+    parser.add_argument(
+        "--name",
+        default=".*",
+        help="The regular expression for names to remove."
+        ' The default is ".*" (everything)',
+    )
+    parser.add_argument(
+        "--credentials",
+        default=None,
+        help="Path to JSON credentials to use."
+        " The default is application default credentials",
+    )
+    parser.add_argument(
+        "--aggregated",
+        default=False,
+        action="store_true",
+        help="Use aggregated_list() method.",
+    )
+    parser.add_argument(
+        "--dry_run",
+        default=False,
+        action="store_true",
+        help="Show proposed delete, dont actually do them.",
+    )
+    parser.add_argument(
+        "--delete_kwargs",
+        default=None,
+        help="The extra arguments to pass to delete."
+        " This is a comma-delimted list of name=value."
+        " For more info, see https://developers.google.com/apis-explorer/#p/",
+    )
+    parser.add_argument(
+        "--list_kwargs",
+        default=None,
+        help="The extra arguments to pass to list,"
+        " beyond those in --delete_kwargs (which are added automatically)."
+        " This is a comma-delimted list of name=value.",
+    )
 
-  return parser.parse_args()
+    return parser.parse_args()
 
 
 def delete(resource_obj, resource_instance, params, dry_run):
-  """Delete the resource_instance."""
-  decorator = '[dry run] ' if dry_run else ''
-  print('{decorator}DELETE {name} [{time}] FROM {params}'.format(
-      decorator=decorator, name=resource_instance.get('name'),
-      time=determine_timestamp(resource_instance), params=params))
-  if dry_run:
-    return
+    """Delete the resource_instance."""
+    decorator = "[dry run] " if dry_run else ""
+    print(
+        "{decorator}DELETE {name} [{time}] FROM {params}".format(
+            decorator=decorator,
+            name=resource_instance.get("name"),
+            time=determine_timestamp(resource_instance),
+            params=params,
+        )
+    )
+    if dry_run:
+        return
 
-  resource_obj.delete(**params).execute()
+    resource_obj.delete(**params).execute()
 
 
 def __kwargs_option_to_dict(raw_value):
-  """Convert comma-delimted kwargs argument into a normalized dictionary.
+    """Convert comma-delimted kwargs argument into a normalized dictionary.
 
-  Args:
-    raw_value: [string] Comma-delimited key=value bindings.
-  """
-  kwargs = {}
-  if raw_value:
-    for binding in raw_value.split(','):
-      name, value = binding.split('=')
-      if value.lower() == 'true':
-        value = True
-      elif value.lower() == 'false':
-        value = False
-      elif value.isdigit():
-        value = int(value)
-      kwargs[name] = value
-  return kwargs
+    Args:
+      raw_value: [string] Comma-delimited key=value bindings.
+    """
+    kwargs = {}
+    if raw_value:
+        for binding in raw_value.split(","):
+            name, value = binding.split("=")
+            if value.lower() == "true":
+                value = True
+            elif value.lower() == "false":
+                value = False
+            elif value.isdigit():
+                value = int(value)
+            kwargs[name] = value
+    return kwargs
 
 
 def __determine_delete_kwargs(options):
-  """Determine the standard keyword arguments to pass to delete() method."""
-  delete_kwargs = __kwargs_option_to_dict(options.delete_kwargs)
-  project = delete_kwargs.get('project', options.project)
-  if project == '':
-    try:
-      project = get_metadata('project/project-id')
-    except:
-      raise ValueError('project is required when not running on GCP')
+    """Determine the standard keyword arguments to pass to delete() method."""
+    delete_kwargs = __kwargs_option_to_dict(options.delete_kwargs)
+    project = delete_kwargs.get("project", options.project)
+    if project == "":
+        try:
+            project = get_metadata("project/project-id")
+        except:
+            raise ValueError("project is required when not running on GCP")
 
-  delete_kwargs['project'] = project
-  return delete_kwargs
+    delete_kwargs["project"] = project
+    return delete_kwargs
 
 
 def __determine_list_kwargs(options):
-  """Determine the standard keyword arguments to pass to list() method."""
-  list_kwargs = __determine_delete_kwargs(options)
-  list_kwargs.update(__kwargs_option_to_dict(options.list_kwargs))
-  return list_kwargs
+    """Determine the standard keyword arguments to pass to list() method."""
+    list_kwargs = __determine_delete_kwargs(options)
+    list_kwargs.update(__kwargs_option_to_dict(options.list_kwargs))
+    return list_kwargs
 
 
 def __determine_before_str(options):
-  """Determine the date string for the newest timestamp to filter by."""
-  now = datetime.datetime.utcnow()
-  today = datetime.datetime(now.year, now.month, now.day)
-  day_offset = options.age
-  before_str = ((today - datetime.timedelta(day_offset)).isoformat()
-                if day_offset is not None
-                else None)
-  return before_str
+    """Determine the date string for the newest timestamp to filter by."""
+    now = datetime.datetime.utcnow()
+    today = datetime.datetime(now.year, now.month, now.day)
+    day_offset = options.age
+    before_str = (
+        (today - datetime.timedelta(day_offset)).isoformat()
+        if day_offset is not None
+        else None
+    )
+    return before_str
 
 
 def main():
-  """The main program."""
-  options = get_options()
-  options.resource = options.resource[0]  # Treat as singluar string for now
-  before_str = __determine_before_str(options)
+    """The main program."""
+    options = get_options()
+    options.resource = options.resource[0]  # Treat as singluar string for now
+    before_str = __determine_before_str(options)
 
-  resource_basename = options.resource[options.resource.rfind('.') + 1:]
-  resource_id_key = (resource_basename[:-1]
-                     if resource_basename[-1] == 's'
-                     else resource_basename)
+    resource_basename = options.resource[options.resource.rfind(".") + 1 :]
+    resource_id_key = (
+        resource_basename[:-1] if resource_basename[-1] == "s" else resource_basename
+    )
 
-  delete_kwargs = __determine_delete_kwargs(options)
-  list_kwargs = __determine_list_kwargs(options)
+    delete_kwargs = __determine_delete_kwargs(options)
+    list_kwargs = __determine_list_kwargs(options)
 
-  resource_obj = make_resource_object(options.resource, options.credentials)
-  num_errors = 0
-  if options.aggregated:
-    elems = collect_aggregated(
-        resource_obj, resource_basename,
-        list_kwargs, name_filter=re.compile(options.name),
-        before_str=before_str)
+    resource_obj = make_resource_object(options.resource, options.credentials)
+    num_errors = 0
+    if options.aggregated:
+        elems = collect_aggregated(
+            resource_obj,
+            resource_basename,
+            list_kwargs,
+            name_filter=re.compile(options.name),
+            before_str=before_str,
+        )
 
-    for keyvalue, resource_instance in elems:
-      key, value = keyvalue.split('/')
-      delete_kwargs[key[:-1]] = value
-      delete_kwargs[resource_id_key] = resource_instance['name']
-      try:
-        delete(resource_obj, resource_instance, delete_kwargs, options.dry_run)
-      except IOError as error:
-        sys.stderr.write(str(error) + '\n')
-        num_errors += 1
+        for keyvalue, resource_instance in elems:
+            key, value = keyvalue.split("/")
+            delete_kwargs[key[:-1]] = value
+            delete_kwargs[resource_id_key] = resource_instance["name"]
+            try:
+                delete(resource_obj, resource_instance, delete_kwargs, options.dry_run)
+            except IOError as error:
+                sys.stderr.write(str(error) + "\n")
+                num_errors += 1
 
-  else:
-    elems = collect(
-        resource_obj, list_kwargs, name_filter=re.compile(options.name),
-        before_str=before_str)
-    for resource_instance in elems:
-      delete_kwargs[resource_id_key] = resource_instance['name']
-      try:
-        delete(resource_obj, resource_instance, delete_kwargs, options.dry_run)
-      except IOError as error:
-        sys.stderr.write(str(error) + '\n')
-        num_errors += 1
+    else:
+        elems = collect(
+            resource_obj,
+            list_kwargs,
+            name_filter=re.compile(options.name),
+            before_str=before_str,
+        )
+        for resource_instance in elems:
+            delete_kwargs[resource_id_key] = resource_instance["name"]
+            try:
+                delete(resource_obj, resource_instance, delete_kwargs, options.dry_run)
+            except IOError as error:
+                sys.stderr.write(str(error) + "\n")
+                num_errors += 1
 
-  return 0 if num_errors == 0 else -1
+    return 0 if num_errors == 0 else -1
 
 
-if __name__ == '__main__':
-  # pylint: disable=broad-except
-  try:
-    exit(main())
-  except Exception as error:
-    sys.stderr.write(error.message + '\n')
-    exit(-1)
+if __name__ == "__main__":
+    # pylint: disable=broad-except
+    try:
+        exit(main())
+    except Exception as error:
+        sys.stderr.write(error.message + "\n")
+        exit(-1)

--- a/google/dev/google_install_loader.py
+++ b/google/dev/google_install_loader.py
@@ -220,7 +220,7 @@ def __unpack_and_run():
         f.write('#!/bin/bash\ncd /opt/spinnaker/install\n{command}\n'
                 .format(command=command))
 
-    os.chmod('__startup_script__.sh', 0555)
+    os.chmod('__startup_script__.sh', 0o555)
     write_instance_metadata('startup-script',
                             '/opt/spinnaker/install/__startup_script__.sh')
     clear_instance_metadata('startup_command')

--- a/google/dev/google_install_loader.py
+++ b/google/dev/google_install_loader.py
@@ -95,7 +95,7 @@ def fetch(url, google=False):
 
 def get_zone():
     global _MY_ZONE
-    if _MY_ZONE != None:
+    if _MY_ZONE is not None:
         return _MY_ZONE
     code, output = fetch(
         "{url}/zone".format(url=GOOGLE_INSTANCE_METADATA_URL), google=True
@@ -124,7 +124,7 @@ def get_instance_metadata_attribute(name):
 
 def clear_metadata_to_file(name, path):
     value = get_instance_metadata_attribute(name)
-    if value != None:
+    if value is not None:
         with open(os.path.join("/opt/spinnaker/install", path), "w") as f:
             f.write(value)
         clear_instance_metadata(name)

--- a/google/dev/google_install_loader.py
+++ b/google/dev/google_install_loader.py
@@ -75,46 +75,47 @@ import sys
 import urllib2
 
 
-GOOGLE_METADATA_URL = 'http://metadata.google.internal/computeMetadata/v1'
-GOOGLE_INSTANCE_METADATA_URL = '{url}/instance'.format(url=GOOGLE_METADATA_URL)
+GOOGLE_METADATA_URL = "http://metadata.google.internal/computeMetadata/v1"
+GOOGLE_INSTANCE_METADATA_URL = "{url}/instance".format(url=GOOGLE_METADATA_URL)
 _MY_ZONE = None
 
 
 def fetch(url, google=False):
     request = urllib2.Request(url)
     if google:
-      request.add_header('Metadata-Flavor', 'Google')
+        request.add_header("Metadata-Flavor", "Google")
     try:
-      response = urllib2.urlopen(request)
-      return response.getcode(), response.read()
+        response = urllib2.urlopen(request)
+        return response.getcode(), response.read()
     except urllib2.HTTPError as e:
-      return e.code, str(e.reason)
+        return e.code, str(e.reason)
     except urllib2.URLError as e:
-      return -1, str(e.reason)
+        return -1, str(e.reason)
 
 
 def get_zone():
     global _MY_ZONE
     if _MY_ZONE != None:
         return _MY_ZONE
-    code, output = fetch('{url}/zone'.format(url=GOOGLE_INSTANCE_METADATA_URL),
-                         google=True)
+    code, output = fetch(
+        "{url}/zone".format(url=GOOGLE_INSTANCE_METADATA_URL), google=True
+    )
     if code == 200:
-       _MY_ZONE = os.path.basename(output)
+        _MY_ZONE = os.path.basename(output)
     else:
-       _MY_ZONE = ''
+        _MY_ZONE = ""
     return _MY_ZONE
 
 
 def running_on_gce():
-    return get_zone() != ''
+    return get_zone() != ""
 
 
 def get_instance_metadata_attribute(name):
     code, output = fetch(
-        '{url}/attributes/{name}'.format(url=GOOGLE_INSTANCE_METADATA_URL,
-                                         name=name),
-        google=True)
+        "{url}/attributes/{name}".format(url=GOOGLE_INSTANCE_METADATA_URL, name=name),
+        google=True,
+    )
     if code == 200:
         return output
     else:
@@ -124,31 +125,35 @@ def get_instance_metadata_attribute(name):
 def clear_metadata_to_file(name, path):
     value = get_instance_metadata_attribute(name)
     if value != None:
-      with open(os.path.join('/opt/spinnaker/install', path), 'w') as f:
-        f.write(value)
-      clear_instance_metadata(name)
+        with open(os.path.join("/opt/spinnaker/install", path), "w") as f:
+            f.write(value)
+        clear_instance_metadata(name)
 
 
 def clear_instance_metadata(name):
-    p = subprocess.Popen('gcloud compute instances remove-metadata'
-                         ' {hostname} --zone={zone} --keys={name}'
-                         .format(hostname=socket.gethostname(),
-                                 zone=get_zone(),
-                                 name=name),
-                         shell=True, close_fds=True)
+    p = subprocess.Popen(
+        "gcloud compute instances remove-metadata"
+        " {hostname} --zone={zone} --keys={name}".format(
+            hostname=socket.gethostname(), zone=get_zone(), name=name
+        ),
+        shell=True,
+        close_fds=True,
+    )
     if p.wait():
-        raise SystemExit('Unexpected failure clearing metadata.')
+        raise SystemExit("Unexpected failure clearing metadata.")
 
 
 def write_instance_metadata(name, value):
-    p = subprocess.Popen('gcloud compute instances add-metadata'
-                         ' {hostname} --zone={zone} --metadata={name}={value}'
-                         .format(hostname=socket.gethostname(),
-                                 zone=get_zone(),
-                                 name=name, value=value),
-                         shell=True, close_fds=True)
+    p = subprocess.Popen(
+        "gcloud compute instances add-metadata"
+        " {hostname} --zone={zone} --metadata={name}={value}".format(
+            hostname=socket.gethostname(), zone=get_zone(), name=name, value=value
+        ),
+        shell=True,
+        close_fds=True,
+    )
     if p.wait():
-        raise SystemExit('Unexpected failure writing metadata.')
+        raise SystemExit("Unexpected failure writing metadata.")
 
 
 def unpack_files(key_list):
@@ -166,14 +171,14 @@ def unpack_files(key_list):
     """
 
     for key in key_list:
-      underscore = key.find('_')
-      if underscore <= 0:
-          filename = key if underscore < 0 else key[1:]
-      else:
-        filename = '{basename}.{ext}'.format(
-            basename = key[underscore + 1:],
-            ext=key[:underscore])
-      clear_metadata_to_file(key, filename)
+        underscore = key.find("_")
+        if underscore <= 0:
+            filename = key if underscore < 0 else key[1:]
+        else:
+            filename = "{basename}.{ext}".format(
+                basename=key[underscore + 1 :], ext=key[:underscore]
+            )
+        clear_metadata_to_file(key, filename)
 
 
 def __unpack_and_run():
@@ -199,13 +204,13 @@ def __unpack_and_run():
     unpacked. The python command itself is ommited and will be added here.
     """
 
-    script_keys = get_instance_metadata_attribute('startup_loader_files')
-    key_list = script_keys.split('+') if script_keys else []
+    script_keys = get_instance_metadata_attribute("startup_loader_files")
+    key_list = script_keys.split("+") if script_keys else []
     unpack_files(key_list)
     if script_keys:
-      clear_instance_metadata('startup_loader_files')
+        clear_instance_metadata("startup_loader_files")
 
-    startup_command = get_instance_metadata_attribute('startup_command')
+    startup_command = get_instance_metadata_attribute("startup_command")
     if not startup_command:
         sys.stderr.write('No "startup_command" metadata key.\n')
         raise SystemExit('No "startup_command" metadata key.')
@@ -213,17 +218,22 @@ def __unpack_and_run():
     # Change the startup script to the final command that we run
     # so that future boots will just run that command. And take down
     # the rest of the boostrap metadata since we dont need it anymore.
-    command = ('chmod gou+rx /opt/spinnaker/install/*.sh; '
-               + startup_command.replace('+', ' '))
+    command = "chmod gou+rx /opt/spinnaker/install/*.sh; " + startup_command.replace(
+        "+", " "
+    )
 
-    with open('__startup_script__.sh', 'w') as f:
-        f.write('#!/bin/bash\ncd /opt/spinnaker/install\n{command}\n'
-                .format(command=command))
+    with open("__startup_script__.sh", "w") as f:
+        f.write(
+            "#!/bin/bash\ncd /opt/spinnaker/install\n{command}\n".format(
+                command=command
+            )
+        )
 
-    os.chmod('__startup_script__.sh', 0o555)
-    write_instance_metadata('startup-script',
-                            '/opt/spinnaker/install/__startup_script__.sh')
-    clear_instance_metadata('startup_command')
+    os.chmod("__startup_script__.sh", 0o555)
+    write_instance_metadata(
+        "startup-script", "/opt/spinnaker/install/__startup_script__.sh"
+    )
+    clear_instance_metadata("startup_command")
 
     # Now run the command (which is also the future startup script).
     p = subprocess.Popen(command, shell=True, close_fds=True)
@@ -231,23 +241,25 @@ def __unpack_and_run():
     return p.returncode
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if not running_on_gce():
-        sys.stderr.write('You do not appear to be on Google Compute Engine.\n')
+        sys.stderr.write("You do not appear to be on Google Compute Engine.\n")
         sys.exit(-1)
 
     try:
-      os.makedirs('/opt/spinnaker/install')
-      os.chdir('/opt/spinnaker/install')
+        os.makedirs("/opt/spinnaker/install")
+        os.chdir("/opt/spinnaker/install")
     except OSError as e:
-      sys.stderr.write('Startup mkdir failed: {e}'.format(e=e))
+        sys.stderr.write("Startup mkdir failed: {e}".format(e=e))
 
     # Copy this script to /opt/spinnaker/install as install_loader.py
     # since other scripts will reference it that way.
-    try :
-      shutil.copyfile('/var/run/google.startup.script',
-                      '/opt/spinnaker/install/google_install_loader.py')
+    try:
+        shutil.copyfile(
+            "/var/run/google.startup.script",
+            "/opt/spinnaker/install/google_install_loader.py",
+        )
     except IOError as e:
-      sys.stderr.write('Startup script copy failed: {e}'.format(e=e))
+        sys.stderr.write("Startup script copy failed: {e}".format(e=e))
 
     sys.exit(__unpack_and_run())

--- a/google/release/ha_image_janitor.py
+++ b/google/release/ha_image_janitor.py
@@ -36,167 +36,252 @@ be run periodically to reap old, unreferenced images.
 """
 
 
-RELEASED_VERSION_MATCHER = re.compile('^[0-9]+\.[0-9]+\.[0-9]+\.yml$')
+RELEASED_VERSION_MATCHER = re.compile("^[0-9]+\.[0-9]+\.[0-9]+\.yml$")
 
 SERVICES = [
-  'clouddriver',
-  'deck',
-  'echo',
-  'front50',
-  'gate',
-  'igor',
-  'orca',
-  'rosco',
-  'fiat'
+    "clouddriver",
+    "deck",
+    "echo",
+    "front50",
+    "gate",
+    "igor",
+    "orca",
+    "rosco",
+    "fiat",
 ]
 
-PUBLISHED_TAG_KEY = 'published'
+PUBLISHED_TAG_KEY = "published"
 
 
 def __partition_boms(gcs_client, bucket_name):
-  def __bom_to_tag(bom_blob):
-    name = os.path.basename(bom_blob.name)
-    return RELEASED_VERSION_MATCHER.match(name)
+    def __bom_to_tag(bom_blob):
+        name = os.path.basename(bom_blob.name)
+        return RELEASED_VERSION_MATCHER.match(name)
 
-  def __bom_to_version(bom_blob):
-    return os.path.basename(bom_blob.name).replace('.yml', '')
+    def __bom_to_version(bom_blob):
+        return os.path.basename(bom_blob.name).replace(".yml", "")
 
-  bucket = gcs_client.get_bucket(bucket_name)
-  all_bom_blobs = [b for b in bucket.list_blobs(prefix='bom') if b.name.endswith('.yml')]
-  bom_contents_by_name = {__bom_to_version(b): b.download_as_string() for b in all_bom_blobs}
+    bucket = gcs_client.get_bucket(bucket_name)
+    all_bom_blobs = [
+        b for b in bucket.list_blobs(prefix="bom") if b.name.endswith(".yml")
+    ]
+    bom_contents_by_name = {
+        __bom_to_version(b): b.download_as_string() for b in all_bom_blobs
+    }
 
-  versions_to_tag = [__bom_to_version(bom) for bom in all_bom_blobs if __bom_to_tag(bom)]
-  possible_versions_to_delete = [__bom_to_version(bom) for bom in all_bom_blobs if not __bom_to_tag(bom)]
-  return (versions_to_tag, possible_versions_to_delete, bom_contents_by_name)
+    versions_to_tag = [
+        __bom_to_version(bom) for bom in all_bom_blobs if __bom_to_tag(bom)
+    ]
+    possible_versions_to_delete = [
+        __bom_to_version(bom) for bom in all_bom_blobs if not __bom_to_tag(bom)
+    ]
+    return (versions_to_tag, possible_versions_to_delete, bom_contents_by_name)
 
 
 def __image_age_days(image_json):
-  # HACK: Cut off the timezone because strptime() can't deal with timezones.
-  # Timezone offset is 5 characters of the form: +00:00 or -00:00.
-  timestamp = image_json['creationTimestamp'][:len(image_json['creationTimestamp'])-6]
-  time_created = datetime.datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%f')
-  now = datetime.datetime.utcnow()
-  return (now - time_created).days
+    # HACK: Cut off the timezone because strptime() can't deal with timezones.
+    # Timezone offset is 5 characters of the form: +00:00 or -00:00.
+    timestamp = image_json["creationTimestamp"][
+        : len(image_json["creationTimestamp"]) - 6
+    ]
+    time_created = datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f")
+    now = datetime.datetime.utcnow()
+    return (now - time_created).days
 
 
-def __tag_images(versions_to_tag, project, account, project_images, bom_contents_by_name):
-  images_to_tag = set([])
-  for bom_version in versions_to_tag:
-    to_tag = [i for i in __derive_images_from_bom(bom_version, bom_contents_by_name) if i in project_images]
-    images_to_tag.update(to_tag)
-  for image in images_to_tag:
-    return_code, stdout = run_subprocess(
-        'gcloud compute images describe'
-        ' --project={project} --account={account} --format=json {image}'
-        .format(project=project, account=account, image=image), echo=False)
-    # Adding labels is idempotent, adding the same label again doesn't break anything.
-    if not return_code:
-      payload_str = stdout.strip()
-      timestamp = json.loads(payload_str)['creationTimestamp']
-      timestamp = timestamp[:timestamp.index('T')]
-      check_subprocess(
-        'gcloud compute images add-labels --project={project} --account={account} --labels={key}={timestamp} {image}'
-        .format(project=project, account=account, key=PUBLISHED_TAG_KEY, timestamp=timestamp, image=image))
+def __tag_images(
+    versions_to_tag, project, account, project_images, bom_contents_by_name
+):
+    images_to_tag = set([])
+    for bom_version in versions_to_tag:
+        to_tag = [
+            i
+            for i in __derive_images_from_bom(bom_version, bom_contents_by_name)
+            if i in project_images
+        ]
+        images_to_tag.update(to_tag)
+    for image in images_to_tag:
+        return_code, stdout = run_subprocess(
+            "gcloud compute images describe"
+            " --project={project} --account={account} --format=json {image}".format(
+                project=project, account=account, image=image
+            ),
+            echo=False,
+        )
+        # Adding labels is idempotent, adding the same label again doesn't break anything.
+        if not return_code:
+            payload_str = stdout.strip()
+            timestamp = json.loads(payload_str)["creationTimestamp"]
+            timestamp = timestamp[: timestamp.index("T")]
+            check_subprocess(
+                "gcloud compute images add-labels --project={project} --account={account} --labels={key}={timestamp} {image}".format(
+                    project=project,
+                    account=account,
+                    key=PUBLISHED_TAG_KEY,
+                    timestamp=timestamp,
+                    image=image,
+                )
+            )
 
 
-def __write_image_delete_script(possible_versions_to_delete, days_before, project,
-                                account, project_images, bom_contents_by_name):
-  images_to_delete = set([])
-  print('Calculating images for {} versions to delete.'.format(len(possible_versions_to_delete)))
-  for bom_version in possible_versions_to_delete:
-    deletable = [i for i in __derive_images_from_bom(bom_version, bom_contents_by_name) if i in project_images]
-    images_to_delete.update(deletable)
-  delete_script_lines = []
-  for image in images_to_delete:
-    return_code, stdout = run_subprocess(
-        'gcloud compute images describe'
-        ' --project={project} --account={account} --format=json {image}'
-        .format(project=project, account=account, image=image), echo=False)
-    json_str = ''
-    if return_code:
-      # Some BOMs may refer to service versions without HA images.
-      print('Lookup for image {image} in project {project} failed, ignoring'.format(image=image, project=project))
-      continue
-    else:
-      json_str = stdout.strip()
-    payload = json.loads(json_str)
+def __write_image_delete_script(
+    possible_versions_to_delete,
+    days_before,
+    project,
+    account,
+    project_images,
+    bom_contents_by_name,
+):
+    images_to_delete = set([])
+    print(
+        "Calculating images for {} versions to delete.".format(
+            len(possible_versions_to_delete)
+        )
+    )
+    for bom_version in possible_versions_to_delete:
+        deletable = [
+            i
+            for i in __derive_images_from_bom(bom_version, bom_contents_by_name)
+            if i in project_images
+        ]
+        images_to_delete.update(deletable)
+    delete_script_lines = []
+    for image in images_to_delete:
+        return_code, stdout = run_subprocess(
+            "gcloud compute images describe"
+            " --project={project} --account={account} --format=json {image}".format(
+                project=project, account=account, image=image
+            ),
+            echo=False,
+        )
+        json_str = ""
+        if return_code:
+            # Some BOMs may refer to service versions without HA images.
+            print(
+                "Lookup for image {image} in project {project} failed, ignoring".format(
+                    image=image, project=project
+                )
+            )
+            continue
+        else:
+            json_str = stdout.strip()
+        payload = json.loads(json_str)
 
-    if __image_age_days(payload) > days_before:
-      labels = payload.get('labels', None)
-      if not labels or not PUBLISHED_TAG_KEY in labels:
-        line = 'gcloud compute images delete --project={project} --account={account} {image} -q'.format(project=project, account=account, image=image)
-        delete_script_lines.append(line)
-  delete_script = '\n'.join(delete_script_lines)
-  timestamp = '{:%Y%m%d%H%M%S}'.format(datetime.datetime.utcnow())
-  script_name = 'delete-images-{}'.format(timestamp)
-  with open(script_name, 'w') as script:
-    script.write(delete_script)
-  print('Wrote image janitor script to {}'.format(script_name))
+        if __image_age_days(payload) > days_before:
+            labels = payload.get("labels", None)
+            if not labels or not PUBLISHED_TAG_KEY in labels:
+                line = "gcloud compute images delete --project={project} --account={account} {image} -q".format(
+                    project=project, account=account, image=image
+                )
+                delete_script_lines.append(line)
+    delete_script = "\n".join(delete_script_lines)
+    timestamp = "{:%Y%m%d%H%M%S}".format(datetime.datetime.utcnow())
+    script_name = "delete-images-{}".format(timestamp)
+    with open(script_name, "w") as script:
+        script.write(delete_script)
+    print("Wrote image janitor script to {}".format(script_name))
 
 
 def __derive_images_from_bom(bom_version, contents_by_name):
-  bom_content_str = contents_by_name[bom_version]
-  bom_dict = yaml.safe_load(bom_content_str)
-  service_entries = bom_dict['services']
-  return [__format_image_name(s, service_entries) for s in SERVICES]
+    bom_content_str = contents_by_name[bom_version]
+    bom_dict = yaml.safe_load(bom_content_str)
+    service_entries = bom_dict["services"]
+    return [__format_image_name(s, service_entries) for s in SERVICES]
 
 
 def __format_image_name(service_name, service_entries):
-  service_version = service_entries[service_name]['version']
-  dash_version = service_version.replace('.', '-')
-  return 'spinnaker-{service}-{version}'.format(service=service_name,
-                                                version=dash_version)
+    service_version = service_entries[service_name]["version"]
+    dash_version = service_version.replace(".", "-")
+    return "spinnaker-{service}-{version}".format(
+        service=service_name, version=dash_version
+    )
 
 
 def __delete_unused_bom_images(options):
-  client = None
-  if options.json_path:
-    client = storage.Client.from_service_account_json(options.json_path)
-  else:
-    client = storage.Client()
-  versions_to_tag, possible_versions_to_delete, bom_contents_by_name = __partition_boms(client, options.bom_bucket_name)
-  if options.additional_boms_to_tag:
-    additional_boms_to_tag = options.additional_boms_to_tag.split(',')
-    print('Adding additional BOM versions to tag: {}'.format(additional_boms_to_tag))
-    versions_to_tag.extend(additional_boms_to_tag)
-  print('Tagging versions: {}'.format(versions_to_tag))
-  print('Deleting versions: {}'.format(possible_versions_to_delete))
+    client = None
+    if options.json_path:
+        client = storage.Client.from_service_account_json(options.json_path)
+    else:
+        client = storage.Client()
+    (
+        versions_to_tag,
+        possible_versions_to_delete,
+        bom_contents_by_name,
+    ) = __partition_boms(client, options.bom_bucket_name)
+    if options.additional_boms_to_tag:
+        additional_boms_to_tag = options.additional_boms_to_tag.split(",")
+        print(
+            "Adding additional BOM versions to tag: {}".format(additional_boms_to_tag)
+        )
+        versions_to_tag.extend(additional_boms_to_tag)
+    print("Tagging versions: {}".format(versions_to_tag))
+    print("Deleting versions: {}".format(possible_versions_to_delete))
 
-  project = options.project
-  service_account = options.service_account
-  image_list_str = check_subprocess('gcloud compute images list --format=json --project={project} --account={account}'
-                                   .format(project=project, account=service_account), echo=False)
-  image_list = json.loads(image_list_str)
-  project_images = set([image['name'] for image in image_list])
-  __tag_images(versions_to_tag, project, service_account, project_images,
-               bom_contents_by_name)
-  __write_image_delete_script(possible_versions_to_delete, options.days_before, project,
-                              service_account, project_images,
-                              bom_contents_by_name)
+    project = options.project
+    service_account = options.service_account
+    image_list_str = check_subprocess(
+        "gcloud compute images list --format=json --project={project} --account={account}".format(
+            project=project, account=service_account
+        ),
+        echo=False,
+    )
+    image_list = json.loads(image_list_str)
+    project_images = set([image["name"] for image in image_list])
+    __tag_images(
+        versions_to_tag, project, service_account, project_images, bom_contents_by_name
+    )
+    __write_image_delete_script(
+        possible_versions_to_delete,
+        options.days_before,
+        project,
+        service_account,
+        project_images,
+        bom_contents_by_name,
+    )
 
 
 def init_argument_parser(parser):
-  parser.add_argument('--additional_boms_to_tag', default='',
-                      help='Comma-delimited list of additional BOM versions to tag'
-                      'to avoid deletion.')
-  parser.add_argument('--bom_bucket_name', default='halconfig',
-                      help='The name of the Halyard bucket storing the BOMs.')
-  parser.add_argument('--days_before', default=14,
-                      help='Max age in days of nightly build BOMs to save.')
-  parser.add_argument('--json_path', default='',
-                      help='Path to the service account credentials with access to the BOM bucket.')
-  parser.add_argument('--project', default='', required=True,
-                      help='GCP project the HA images are stored in.')
-  parser.add_argument('--service_account', default='', required=True,
-                      help='Name of the service account to manipulate images with.')
+    parser.add_argument(
+        "--additional_boms_to_tag",
+        default="",
+        help="Comma-delimited list of additional BOM versions to tag"
+        "to avoid deletion.",
+    )
+    parser.add_argument(
+        "--bom_bucket_name",
+        default="halconfig",
+        help="The name of the Halyard bucket storing the BOMs.",
+    )
+    parser.add_argument(
+        "--days_before",
+        default=14,
+        help="Max age in days of nightly build BOMs to save.",
+    )
+    parser.add_argument(
+        "--json_path",
+        default="",
+        help="Path to the service account credentials with access to the BOM bucket.",
+    )
+    parser.add_argument(
+        "--project",
+        default="",
+        required=True,
+        help="GCP project the HA images are stored in.",
+    )
+    parser.add_argument(
+        "--service_account",
+        default="",
+        required=True,
+        help="Name of the service account to manipulate images with.",
+    )
 
 
 def main():
-  parser = argparse.ArgumentParser()
-  init_argument_parser(parser)
-  options = parser.parse_args()
-  __delete_unused_bom_images(options)
+    parser = argparse.ArgumentParser()
+    init_argument_parser(parser)
+    options = parser.parse_args()
+    __delete_unused_bom_images(options)
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/google/release/ha_image_janitor.py
+++ b/google/release/ha_image_janitor.py
@@ -102,7 +102,7 @@ def __tag_images(versions_to_tag, project, account, project_images, bom_contents
 def __write_image_delete_script(possible_versions_to_delete, days_before, project,
                                 account, project_images, bom_contents_by_name):
   images_to_delete = set([])
-  print 'Calculating images for {} versions to delete.'.format(len(possible_versions_to_delete))
+  print('Calculating images for {} versions to delete.'.format(len(possible_versions_to_delete)))
   for bom_version in possible_versions_to_delete:
     deletable = [i for i in __derive_images_from_bom(bom_version, bom_contents_by_name) if i in project_images]
     images_to_delete.update(deletable)
@@ -131,7 +131,7 @@ def __write_image_delete_script(possible_versions_to_delete, days_before, projec
   script_name = 'delete-images-{}'.format(timestamp)
   with open(script_name, 'w') as script:
     script.write(delete_script)
-  print 'Wrote image janitor script to {}'.format(script_name)
+  print('Wrote image janitor script to {}'.format(script_name))
 
 
 def __derive_images_from_bom(bom_version, contents_by_name):

--- a/google/release/ha_image_janitor.py
+++ b/google/release/ha_image_janitor.py
@@ -169,7 +169,7 @@ def __write_image_delete_script(
 
         if __image_age_days(payload) > days_before:
             labels = payload.get("labels", None)
-            if not labels or not PUBLISHED_TAG_KEY in labels:
+            if not labels or PUBLISHED_TAG_KEY not in labels:
                 line = "gcloud compute images delete --project={project} --account={account} {image} -q".format(
                     project=project, account=account, image=image
                 )

--- a/testing/citest/citest_contrib/dcos_testing/dcos_contract.py
+++ b/testing/citest/citest_contrib/dcos_testing/dcos_contract.py
@@ -24,125 +24,138 @@ import citest.json_predicate as jp
 import citest.json_contract as jc
 from citest.service_testing import cli_agent
 
+
 class DcosObjectObserver(jc.ObjectObserver):
-  """Observe DC/OS resources."""
+    """Observe DC/OS resources."""
 
-  def __init__(self, dcoscli, args, filter=None):
-    """Construct observer.
+    def __init__(self, dcoscli, args, filter=None):
+        """Construct observer.
 
-    Args:
-      dcoscli: DcosCliAgent instance to use.
-      args: Command-line argument list to execute.
-    """
-    super(DcosObjectObserver, self).__init__(filter)
-    self.__dcoscli = dcoscli
-    self.__args = args
+        Args:
+          dcoscli: DcosCliAgent instance to use.
+          args: Command-line argument list to execute.
+        """
+        super(DcosObjectObserver, self).__init__(filter)
+        self.__dcoscli = dcoscli
+        self.__args = args
 
-  def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotableEntity interface."""
-    snapshot.edge_builder.make_control(entity, 'Args', self.__args)
-    super(DcosObjectObserver, self).export_to_json_snapshot(snapshot, entity)
+    def export_to_json_snapshot(self, snapshot, entity):
+        """Implements JsonSnapshotableEntity interface."""
+        snapshot.edge_builder.make_control(entity, "Args", self.__args)
+        super(DcosObjectObserver, self).export_to_json_snapshot(snapshot, entity)
 
-  def __str__(self):
-    return 'DcosObjectObserver({0})'.format(self.__args)
+    def __str__(self):
+        return "DcosObjectObserver({0})".format(self.__args)
 
-  def collect_observation(self, context, observation):
-    args = context.eval(self.__args)
-    dcos_response = self.__dcoscli.run(args)
-    if not dcos_response.ok():
-      observation.add_error(
-          cli_agent.CliAgentRunError(self.__dcoscli, dcos_response))
-      return []
+    def collect_observation(self, context, observation):
+        args = context.eval(self.__args)
+        dcos_response = self.__dcoscli.run(args)
+        if not dcos_response.ok():
+            observation.add_error(
+                cli_agent.CliAgentRunError(self.__dcoscli, dcos_response)
+            )
+            return []
 
-    decoder = json.JSONDecoder()
-    try:
-      doc = decoder.decode(dcos_response.output)
-      if not isinstance(doc, list):
-        doc = [doc]
-      self.filter_all_objects_to_observation(context, doc, observation)
-    except ValueError as vex:
-      error = 'Invalid JSON in response: %s' % str(dcos_response)
-      logging.getLogger(__name__).info('%s\n%s\n----------------\n',
-                                       error, traceback.format_exc())
-      observation.add_error(jp.JsonError(error, vex))
-      return []
+        decoder = json.JSONDecoder()
+        try:
+            doc = decoder.decode(dcos_response.output)
+            if not isinstance(doc, list):
+                doc = [doc]
+            self.filter_all_objects_to_observation(context, doc, observation)
+        except ValueError as vex:
+            error = "Invalid JSON in response: %s" % str(dcos_response)
+            logging.getLogger(__name__).info(
+                "%s\n%s\n----------------\n", error, traceback.format_exc()
+            )
+            observation.add_error(jp.JsonError(error, vex))
+            return []
 
-    return observation.objects
+        return observation.objects
 
 
 class DcosObjectFactory(object):
-  # pylint: disable=too-few-public-methods
+    # pylint: disable=too-few-public-methods
 
-  def __init__(self, dcoscli):
-    self.__dcoscli = dcoscli
+    def __init__(self, dcoscli):
+        self.__dcoscli = dcoscli
 
-  def new_get_marathon_resources(self, type, action, extra_args=None):
-    """Specify a resource list to be returned later.
+    def new_get_marathon_resources(self, type, action, extra_args=None):
+        """Specify a resource list to be returned later.
 
-    Args:
-      type: dcos's name for the DC/OS resource type.
+        Args:
+          type: dcos's name for the DC/OS resource type.
 
-    Returns:
-      A jc.ObjectObserver to return the specified resource list when called.
-    """
-    if extra_args is None:
-      extra_args = []
+        Returns:
+          A jc.ObjectObserver to return the specified resource list when called.
+        """
+        if extra_args is None:
+            extra_args = []
 
-    cmd = self.__dcoscli.build_dcoscli_command_args(
-        subcommand='marathon', resource=type, action=action, args=['--json'] + extra_args)
-    return DcosObjectObserver(self.__dcoscli, cmd)
+        cmd = self.__dcoscli.build_dcoscli_command_args(
+            subcommand="marathon",
+            resource=type,
+            action=action,
+            args=["--json"] + extra_args,
+        )
+        return DcosObjectObserver(self.__dcoscli, cmd)
 
 
 class DcosClauseBuilder(jc.ContractClauseBuilder):
-  """A ContractClause that facilitates observing DC/OS state."""
+    """A ContractClause that facilitates observing DC/OS state."""
 
-  def __init__(self, title, dcoscli, retryable_for_secs=0, strict=False):
-    """Construct new clause.
+    def __init__(self, title, dcoscli, retryable_for_secs=0, strict=False):
+        """Construct new clause.
 
-    Args:
-      title: The string title for the clause is only for reporting purposes.
-      dcoscli: The DcosCliAgent to make the observation for the clause to
-         verify.
-      retryable_for_secs: Number of seconds that observations can be retried
-         if their verification initially fails.
-      strict: DEPRECATED flag indicating whether the clauses (added later)
-         must be true for all objects (strict) or at least one (not strict).
-         See ValueObservationVerifierBuilder for more information.
-         This is deprecated because in the future this should be on a per
-         constraint basis.
-    """
-    super(DcosClauseBuilder, self).__init__(
-        title=title, retryable_for_secs=retryable_for_secs)
-    self.__factory = DcosObjectFactory(dcoscli)
-    self.__strict = strict
+        Args:
+          title: The string title for the clause is only for reporting purposes.
+          dcoscli: The DcosCliAgent to make the observation for the clause to
+             verify.
+          retryable_for_secs: Number of seconds that observations can be retried
+             if their verification initially fails.
+          strict: DEPRECATED flag indicating whether the clauses (added later)
+             must be true for all objects (strict) or at least one (not strict).
+             See ValueObservationVerifierBuilder for more information.
+             This is deprecated because in the future this should be on a per
+             constraint basis.
+        """
+        super(DcosClauseBuilder, self).__init__(
+            title=title, retryable_for_secs=retryable_for_secs
+        )
+        self.__factory = DcosObjectFactory(dcoscli)
+        self.__strict = strict
 
-  def get_marathon_resources(self, type, extra_args=None):
-    """Observe resources of a particular type.
+    def get_marathon_resources(self, type, extra_args=None):
+        """Observe resources of a particular type.
 
-    This ultimately calls a "dcos marathon |type| |extra_args|"
+        This ultimately calls a "dcos marathon |type| |extra_args|"
 
-    """
-    self.observer = self.__factory.new_get_marathon_resources(
-        type, action='list', extra_args=extra_args)
+        """
+        self.observer = self.__factory.new_get_marathon_resources(
+            type, action="list", extra_args=extra_args
+        )
 
-    get_builder = jc.ValueObservationVerifierBuilder(
-        'Get {0} {1}'.format(type, extra_args), strict=self.__strict)
-    self.verifier_builder.append_verifier_builder(get_builder)
+        get_builder = jc.ValueObservationVerifierBuilder(
+            "Get {0} {1}".format(type, extra_args), strict=self.__strict
+        )
+        self.verifier_builder.append_verifier_builder(get_builder)
 
-    return get_builder
+        return get_builder
 
 
 class DcosContractBuilder(jc.ContractBuilder):
-  """Specialized contract that facilitates observing DC/OS."""
+    """Specialized contract that facilitates observing DC/OS."""
 
-  def __init__(self, dcoscli):
-    """Constructs a new contract.
+    def __init__(self, dcoscli):
+        """Constructs a new contract.
 
-    Args:
-      kubectl: The DcosCliAgent to use for communicating with DC/OS.
-    """
-    super(DcosContractBuilder, self).__init__(
-        lambda title, retryable_for_secs=0, strict=False:
-        DcosClauseBuilder(
-            title, dcoscli=dcoscli,
-            retryable_for_secs=retryable_for_secs, strict=strict))
+        Args:
+          kubectl: The DcosCliAgent to use for communicating with DC/OS.
+        """
+        super(DcosContractBuilder, self).__init__(
+            lambda title, retryable_for_secs=0, strict=False: DcosClauseBuilder(
+                title,
+                dcoscli=dcoscli,
+                retryable_for_secs=retryable_for_secs,
+                strict=strict,
+            )
+        )

--- a/testing/citest/citest_contrib/dcos_testing/dcoscli_agent.py
+++ b/testing/citest/citest_contrib/dcos_testing/dcoscli_agent.py
@@ -19,30 +19,37 @@ import logging
 from citest.service_testing import cli_agent
 from citest.base.json_scrubber import JsonScrubber
 
+
 class DcosCliAgent(cli_agent.CliAgent):
-  """Agent that uses the DC/OS CLI (dcos) program to interact with DC/OS."""
+    """Agent that uses the DC/OS CLI (dcos) program to interact with DC/OS."""
 
-  def __init__(self, logger=None):
-    """Construct instance.
+    def __init__(self, logger=None):
+        """Construct instance.
 
-    Args:
-      logger: The logger to inject if other than the default.
-    """
-    logger = logger or logging.getLogger(__name__)
-    super(DcosCliAgent, self).__init__(
-        'dcos', output_scrubber=JsonScrubber(), logger=logger)
+        Args:
+          logger: The logger to inject if other than the default.
+        """
+        logger = logger or logging.getLogger(__name__)
+        super(DcosCliAgent, self).__init__(
+            "dcos", output_scrubber=JsonScrubber(), logger=logger
+        )
 
-  @staticmethod
-  def build_dcoscli_command_args(subcommand, resource=None, action=None, args=None):
-    """Build commandline for an action.
- 
-    Args:
-      subcommand: The dcos subcommand to execute
-      resource: The dcos resource we are going to operate on (if applicable).
-      action: The action to take on the resource (if applicable).
-      args: The arguments following [gcloud_module, gce_type].
- 
-    Returns:
-      list of complete command line arguments following implied 'dcos'
-    """
-    return [subcommand] + ([resource] if resource else []) + ([action] if action else []) + (args if args else [])
+    @staticmethod
+    def build_dcoscli_command_args(subcommand, resource=None, action=None, args=None):
+        """Build commandline for an action.
+
+        Args:
+          subcommand: The dcos subcommand to execute
+          resource: The dcos resource we are going to operate on (if applicable).
+          action: The action to take on the resource (if applicable).
+          args: The arguments following [gcloud_module, gce_type].
+
+        Returns:
+          list of complete command line arguments following implied 'dcos'
+        """
+        return (
+            [subcommand]
+            + ([resource] if resource else [])
+            + ([action] if action else [])
+            + (args if args else [])
+        )

--- a/testing/citest/spinnaker_testing/__init__.py
+++ b/testing/citest/spinnaker_testing/__init__.py
@@ -17,20 +17,23 @@ from .spinnaker import SpinnakerAgent
 from .spinnaker_test_scenario import SpinnakerTestScenario
 
 # The jenkins_agent implementes Jenkins build triggers
-from .jenkins_agent import(
+from .jenkins_agent import (
     JenkinsOperationStatus,
     JenkinsAgent,
     BaseJenkinsOperation,
-    JenkinsTriggerOperation)
+    JenkinsTriggerOperation,
+)
 
-from .gcs_pubsub_trigger_agent import(
+from .gcs_pubsub_trigger_agent import (
     GcsFileUploadAgent,
     BaseGcsPubsubTriggerOperation,
     GcsPubsubUploadTriggerOperation,
-    GcsPubsubTriggerOperationStatus)
+    GcsPubsubTriggerOperationStatus,
+)
 
 from .kubernetes_manifests import (
     KubernetesManifestFactory,
-    KubernetesManifestPredicateFactory)
+    KubernetesManifestPredicateFactory,
+)
 
 from .pipeline_support import PipelineSupport

--- a/testing/citest/spinnaker_testing/appengine_scenario_support.py
+++ b/testing/citest/spinnaker_testing/appengine_scenario_support.py
@@ -19,67 +19,75 @@ from spinnaker_testing.base_scenario_support import BaseScenarioPlatformSupport
 
 
 class AppEngineScenarioSupport(BaseScenarioPlatformSupport):
-  """Provides SpinnakerScenarioSupport for Google App Engine."""
+    """Provides SpinnakerScenarioSupport for Google App Engine."""
 
-  @classmethod
-  def add_commandline_parameters(cls, scenario_class, builder, defaults):
-    """Implements BaseScenarioPlatformSupport interface.
+    @classmethod
+    def add_commandline_parameters(cls, scenario_class, builder, defaults):
+        """Implements BaseScenarioPlatformSupport interface.
 
-    Args:
-      scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
-      builder: [citest.base.ConfigBindingsBuilder]
-      defaults: [dict] Default binding value overrides.
-         This is used to initialize the default commandline parameters.
-    """
-    #
-    # Operation Parameters
-    #
-    builder.add_argument(
-        '--spinnaker_appengine_account',
-        default=defaults.get('SPINNAKER_APPENGINE_ACCOUNT', None),
-        help='Spinnaker account name to use for test operations against'
-             'App Engine. Only used when managing resources on App Engine.')
+        Args:
+          scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
+          builder: [citest.base.ConfigBindingsBuilder]
+          defaults: [dict] Default binding value overrides.
+             This is used to initialize the default commandline parameters.
+        """
+        #
+        # Operation Parameters
+        #
+        builder.add_argument(
+            "--spinnaker_appengine_account",
+            default=defaults.get("SPINNAKER_APPENGINE_ACCOUNT", None),
+            help="Spinnaker account name to use for test operations against"
+            "App Engine. Only used when managing resources on App Engine.",
+        )
 
-    #
-    # Observer parameters
-    #
-    builder.add_argument(
-        '--appengine_credentials_path',
-        default=defaults.get('APPENGINE_CREDENTIALS_PATH', None),
-        help='A path to the JSON file with credentials to use for observing'
-             ' tests against Google App Engine. Defaults to the value set for'
-             '--gce_credentials_path, which defaults to application default'
-             ' credentials.')
+        #
+        # Observer parameters
+        #
+        builder.add_argument(
+            "--appengine_credentials_path",
+            default=defaults.get("APPENGINE_CREDENTIALS_PATH", None),
+            help="A path to the JSON file with credentials to use for observing"
+            " tests against Google App Engine. Defaults to the value set for"
+            "--gce_credentials_path, which defaults to application default"
+            " credentials.",
+        )
 
-  def __init__(self, scenario):
-    """Constructor.
+    def __init__(self, scenario):
+        """Constructor.
 
-    Args:
-      scenario: [SpinnakerTestScenario] The scenario being supported.
-    """
-    super(AppEngineScenarioSupport, self).__init__("appengine", scenario)
+        Args:
+          scenario: [SpinnakerTestScenario] The scenario being supported.
+        """
+        super(AppEngineScenarioSupport, self).__init__("appengine", scenario)
 
-    bindings = scenario.bindings
+        bindings = scenario.bindings
 
-    if not bindings.get('APPENGINE_PRIMARY_MANAGED_PROJECT_ID'):
-      bindings['APPENGINE_PRIMARY_MANAGED_PROJECT_ID'] = (
-          scenario.agent.deployed_config.get(
-              'providers.appengine.primaryCredentials.project', None))
-      # Fall back on Google project and credentials.
-      if not bindings['APPENGINE_PRIMARY_MANAGED_PROJECT_ID']:
-        bindings['APPENGINE_PRIMARY_MANAGED_PROJECT_ID'] = (
-            bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID'])
-        bindings['APPENGINE_CREDENTIALS_PATH'] = (
-            bindings['GCE_CREDENTIALS_PATH'])
+        if not bindings.get("APPENGINE_PRIMARY_MANAGED_PROJECT_ID"):
+            bindings[
+                "APPENGINE_PRIMARY_MANAGED_PROJECT_ID"
+            ] = scenario.agent.deployed_config.get(
+                "providers.appengine.primaryCredentials.project", None
+            )
+            # Fall back on Google project and credentials.
+            if not bindings["APPENGINE_PRIMARY_MANAGED_PROJECT_ID"]:
+                bindings["APPENGINE_PRIMARY_MANAGED_PROJECT_ID"] = bindings[
+                    "GOOGLE_PRIMARY_MANAGED_PROJECT_ID"
+                ]
+                bindings["APPENGINE_CREDENTIALS_PATH"] = bindings[
+                    "GCE_CREDENTIALS_PATH"
+                ]
 
-  def _make_observer(self):
-    """Implements BaseScenarioPlatformSupport interface."""
-    bindings = self.scenario.bindings
-    if not bindings.get('APPENGINE_PRIMARY_MANAGED_PROJECT_ID'):
-      raise ValueError('There is no "appengine_primary_managed_project_id"')
+    def _make_observer(self):
+        """Implements BaseScenarioPlatformSupport interface."""
+        bindings = self.scenario.bindings
+        if not bindings.get("APPENGINE_PRIMARY_MANAGED_PROJECT_ID"):
+            raise ValueError('There is no "appengine_primary_managed_project_id"')
 
-    return gcp.GcpAppengineAgent.make_agent(
-        scopes=gcp.APPENGINE_FULL_SCOPE,
-        credentials_path=bindings['APPENGINE_CREDENTIALS_PATH'],
-        default_variables={
-            'project': bindings['APPENGINE_PRIMARY_MANAGED_PROJECT_ID']})
+        return gcp.GcpAppengineAgent.make_agent(
+            scopes=gcp.APPENGINE_FULL_SCOPE,
+            credentials_path=bindings["APPENGINE_CREDENTIALS_PATH"],
+            default_variables={
+                "project": bindings["APPENGINE_PRIMARY_MANAGED_PROJECT_ID"]
+            },
+        )

--- a/testing/citest/spinnaker_testing/aws_scenario_support.py
+++ b/testing/citest/spinnaker_testing/aws_scenario_support.py
@@ -22,172 +22,189 @@ from spinnaker_testing.base_scenario_support import BaseScenarioPlatformSupport
 
 
 class AwsScenarioSupport(BaseScenarioPlatformSupport):
-  """Provides SpinnakerScenarioSupport for Amazon Web Services."""
+    """Provides SpinnakerScenarioSupport for Amazon Web Services."""
 
-  @classmethod
-  def add_commandline_parameters(cls, scenario_class, builder, defaults):
-    """Implements BaseScenarioPlatformSupport interface.
+    @classmethod
+    def add_commandline_parameters(cls, scenario_class, builder, defaults):
+        """Implements BaseScenarioPlatformSupport interface.
 
-    Args:
-      scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
-      builder: [citest.base.ConfigBindingsBuilder]
-      defaults: [dict] Default binding value overrides.
-         This is used to initialize the default commandline parameters.
-    """
-    #
-    # Observer parameters
-    #
-    builder.add_argument(
-        '--aws_profile', default=defaults.get('AWS_PROFILE', None),
-        help='aws command-line tool --profile parameter when observing AWS.')
+        Args:
+          scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
+          builder: [citest.base.ConfigBindingsBuilder]
+          defaults: [dict] Default binding value overrides.
+             This is used to initialize the default commandline parameters.
+        """
+        #
+        # Observer parameters
+        #
+        builder.add_argument(
+            "--aws_profile",
+            default=defaults.get("AWS_PROFILE", None),
+            help="aws command-line tool --profile parameter when observing AWS.",
+        )
 
-    #
-    # Operation Parameters
-    #
-    builder.add_argument(
-        '--aws_credentials',
-        dest='spinnaker_aws_account',
-        help='DEPRECATED. Replaced by --spinnaker_aws_account')
+        #
+        # Operation Parameters
+        #
+        builder.add_argument(
+            "--aws_credentials",
+            dest="spinnaker_aws_account",
+            help="DEPRECATED. Replaced by --spinnaker_aws_account",
+        )
 
-    builder.add_argument(
-        '--spinnaker_aws_account',
-        default=defaults.get('SPINNAKER_AWS_ACCOUNT', None),
-        help='Spinnaker account name to use for test operations against AWS.'
-             ' Only used when managing resources on AWS.')
+        builder.add_argument(
+            "--spinnaker_aws_account",
+            default=defaults.get("SPINNAKER_AWS_ACCOUNT", None),
+            help="Spinnaker account name to use for test operations against AWS."
+            " Only used when managing resources on AWS.",
+        )
 
-    builder.add_argument(
-        '--aws_iam_role', default=defaults.get('AWS_IAM_ROLE', None),
-        help='Spinnaker IAM role name for test operations.'
-             ' Only used when managing jobs running on AWS.')
+        builder.add_argument(
+            "--aws_iam_role",
+            default=defaults.get("AWS_IAM_ROLE", None),
+            help="Spinnaker IAM role name for test operations."
+            " Only used when managing jobs running on AWS.",
+        )
 
-    builder.add_argument(
-        '--test_aws_ami',
-        default=defaults.get(
-            'TEST_AWS_AMI',
-            'bitnami-tomcatstack-7.0.63-1-linux-ubuntu-14.04.1-x86_64-ebs'),
-        help='Default Amazon AMI to use when creating test instances.'
-             ' The default image will listen on port 80.')
+        builder.add_argument(
+            "--test_aws_ami",
+            default=defaults.get(
+                "TEST_AWS_AMI",
+                "bitnami-tomcatstack-7.0.63-1-linux-ubuntu-14.04.1-x86_64-ebs",
+            ),
+            help="Default Amazon AMI to use when creating test instances."
+            " The default image will listen on port 80.",
+        )
 
-    builder.add_argument(
-        '--test_aws_region',
-        default=defaults.get('TEST_AWS_REGION', ''),
-        help='The GCE region to test generated instances in (when managing'
-             ' AWS). If not specified, then derive it fro --test_aws_zone.')
+        builder.add_argument(
+            "--test_aws_region",
+            default=defaults.get("TEST_AWS_REGION", ""),
+            help="The GCE region to test generated instances in (when managing"
+            " AWS). If not specified, then derive it fro --test_aws_zone.",
+        )
 
-    builder.add_argument(
-        '--test_aws_security_group_id',
-        default=defaults.get('TEST_AWS_SECURITY_GROUP_ID', None),
-        help='Default AWS SecurityGroupId when creating test resources.')
+        builder.add_argument(
+            "--test_aws_security_group_id",
+            default=defaults.get("TEST_AWS_SECURITY_GROUP_ID", None),
+            help="Default AWS SecurityGroupId when creating test resources.",
+        )
 
-    builder.add_argument(
-        '--test_aws_zone',
-        default=defaults.get('TEST_AWS_ZONE', 'us-east-1c'),
-        help='The AWS zone to test generated instances in (when managing AWS).'
-             ' This implies the AWS region as well.')
+        builder.add_argument(
+            "--test_aws_zone",
+            default=defaults.get("TEST_AWS_ZONE", "us-east-1c"),
+            help="The AWS zone to test generated instances in (when managing AWS)."
+            " This implies the AWS region as well.",
+        )
 
-    builder.add_argument(
-        '--test_aws_vpc_id',
-        default=defaults.get('TEST_AWS_VPC_ID', None),
-        help='Default AWS VpcId to use when creating test resources.')
+        builder.add_argument(
+            "--test_aws_vpc_id",
+            default=defaults.get("TEST_AWS_VPC_ID", None),
+            help="Default AWS VpcId to use when creating test resources.",
+        )
 
-    builder.add_argument(
-        '--test_aws_keypair',
-        default=defaults.get('TEST_AWS_KEYPAIR', None),
-        help='AWS KeyPair for when one is needed by a test.')
+        builder.add_argument(
+            "--test_aws_keypair",
+            default=defaults.get("TEST_AWS_KEYPAIR", None),
+            help="AWS KeyPair for when one is needed by a test.",
+        )
 
-  def _make_observer(self):
-    """Implements BaseScenarioPlatformSupport interface."""
-    bindings = self.scenario.bindings
-    profile = bindings.get('AWS_PROFILE')
-    if not profile:
-      raise ValueError('An AWS Observer requires an AWS_PROFILE')
+    def _make_observer(self):
+        """Implements BaseScenarioPlatformSupport interface."""
+        bindings = self.scenario.bindings
+        profile = bindings.get("AWS_PROFILE")
+        if not profile:
+            raise ValueError("An AWS Observer requires an AWS_PROFILE")
 
-    return aws.AwsPythonAgent(profile)
+        return aws.AwsPythonAgent(profile)
 
-  def __init__(self, scenario):
-    """Constructor.
+    def __init__(self, scenario):
+        """Constructor.
 
-    Args:
-      scenario: [SpinnakerTestScenario] The scenario being supported.
-    """
-    super(AwsScenarioSupport, self).__init__("aws", scenario)
-    self.__aws_observer = None
+        Args:
+          scenario: [SpinnakerTestScenario] The scenario being supported.
+        """
+        super(AwsScenarioSupport, self).__init__("aws", scenario)
+        self.__aws_observer = None
 
-    bindings = scenario.bindings
+        bindings = scenario.bindings
 
-    if not bindings['AWS_IAM_ROLE']:
-      bindings['AWS_IAM_ROLE'] = scenario.agent.deployed_config.get(
-          'providers.aws.defaultIAMRole', None)
+        if not bindings["AWS_IAM_ROLE"]:
+            bindings["AWS_IAM_ROLE"] = scenario.agent.deployed_config.get(
+                "providers.aws.defaultIAMRole", None
+            )
 
-    if not bindings['TEST_AWS_ZONE']:
-      bindings['TEST_AWS_ZONE'] = bindings['AWS_ZONE']
+        if not bindings["TEST_AWS_ZONE"]:
+            bindings["TEST_AWS_ZONE"] = bindings["AWS_ZONE"]
 
-    if not bindings.get('TEST_AWS_REGION', ''):
-      bindings['TEST_AWS_REGION'] = bindings['TEST_AWS_ZONE'][:-1]
+        if not bindings.get("TEST_AWS_REGION", ""):
+            bindings["TEST_AWS_REGION"] = bindings["TEST_AWS_ZONE"][:-1]
 
-    if not bindings.get('TEST_AWS_KEYPAIR', ''):
-      bindings['TEST_AWS_KEYPAIR'] = '{0}-keypair'.format(
-          bindings['SPINNAKER_AWS_ACCOUNT'])
+        if not bindings.get("TEST_AWS_KEYPAIR", ""):
+            bindings["TEST_AWS_KEYPAIR"] = "{0}-keypair".format(
+                bindings["SPINNAKER_AWS_ACCOUNT"]
+            )
 
-    bindings.add_lazy_initializer(
-        'TEST_AWS_VPC_ID', self.__lazy_binding_initializer)
-    bindings.add_lazy_initializer(
-        'TEST_AWS_SECURITY_GROUP_ID', self.__lazy_binding_initializer)
+        bindings.add_lazy_initializer(
+            "TEST_AWS_VPC_ID", self.__lazy_binding_initializer
+        )
+        bindings.add_lazy_initializer(
+            "TEST_AWS_SECURITY_GROUP_ID", self.__lazy_binding_initializer
+        )
 
-  def __lazy_binding_initializer(self, bindings, key):
-    normalized_key = key.upper()
+    def __lazy_binding_initializer(self, bindings, key):
+        normalized_key = key.upper()
 
-    ec2_client = None
+        ec2_client = None
 
-    if normalized_key == 'TEST_AWS_VPC_ID':
-      # We need to figure out a specific aws vpc id to use.
-      logger = logging.getLogger(__name__)
-      logger.info('Determine default AWS VpcId...')
-      if not ec2_client:
-        ec2_client = self.observer.make_boto_client('ec2')
+        if normalized_key == "TEST_AWS_VPC_ID":
+            # We need to figure out a specific aws vpc id to use.
+            logger = logging.getLogger(__name__)
+            logger.info("Determine default AWS VpcId...")
+            if not ec2_client:
+                ec2_client = self.observer.make_boto_client("ec2")
 
-      # If we want the name defaultvpc then do this
-      # filters = [{'Name': 'tag:Name', 'Values': ['defaultvpc']}]
-      # I think we want the VPC that is the default
-      # filters = [{'Name': 'isDefault', 'Values': ['true']}]
-      filters = [{'Name': 'tag:Name', 'Values': ['defaultvpc']}]
+            # If we want the name defaultvpc then do this
+            # filters = [{'Name': 'tag:Name', 'Values': ['defaultvpc']}]
+            # I think we want the VPC that is the default
+            # filters = [{'Name': 'isDefault', 'Values': ['true']}]
+            filters = [{"Name": "tag:Name", "Values": ["defaultvpc"]}]
 
-      response = self.observer.call_method(
-          ExecutionContext(),
-          ec2_client.describe_vpcs,
-          Filters=filters)
+            response = self.observer.call_method(
+                ExecutionContext(), ec2_client.describe_vpcs, Filters=filters
+            )
 
-      vpc_list = response['Vpcs']
-      if not vpc_list:
-        raise ValueError('There is no vpc matching filter {0}'.format(filters))
+            vpc_list = response["Vpcs"]
+            if not vpc_list:
+                raise ValueError("There is no vpc matching filter {0}".format(filters))
 
-      found = vpc_list[0]['VpcId']
-      logger.info('Using discovered default VpcId=%s', str(found))
-      return found
+            found = vpc_list[0]["VpcId"]
+            logger.info("Using discovered default VpcId=%s", str(found))
+            return found
 
-    if normalized_key == 'TEST_AWS_SECURITY_GROUP_ID':
-      # We need to figure out a specific security group that is compatable
-      # with the VpcId we are using.
-      logger = logging.getLogger(__name__)
-      logger.info('Determine default AWS SecurityGroupId...')
-      if not ec2_client:
-        ec2_client = self.observer.make_boto_client('ec2')
-      response = self.observer.call_method(
-          ExecutionContext(),
-          ec2_client.describe_security_groups)
-      sg_list = response['SecurityGroups']
+        if normalized_key == "TEST_AWS_SECURITY_GROUP_ID":
+            # We need to figure out a specific security group that is compatable
+            # with the VpcId we are using.
+            logger = logging.getLogger(__name__)
+            logger.info("Determine default AWS SecurityGroupId...")
+            if not ec2_client:
+                ec2_client = self.observer.make_boto_client("ec2")
+            response = self.observer.call_method(
+                ExecutionContext(), ec2_client.describe_security_groups
+            )
+            sg_list = response["SecurityGroups"]
 
-      found = None
-      vpc_id = bindings['TEST_AWS_VPC_ID']
-      for entry in sg_list:
-        if entry.get('VpcId', None) == vpc_id:
-          found = entry['GroupId']
-          break
-      if not found:
-        raise ValueError('Could not find a security group for AWS_VPC_ID {0}'
-                         .format(vpc_id))
+            found = None
+            vpc_id = bindings["TEST_AWS_VPC_ID"]
+            for entry in sg_list:
+                if entry.get("VpcId", None) == vpc_id:
+                    found = entry["GroupId"]
+                    break
+            if not found:
+                raise ValueError(
+                    "Could not find a security group for AWS_VPC_ID {0}".format(vpc_id)
+                )
 
-      logger.info('Using discovered default SecurityGroupId=%s', str(found))
-      return found
+            logger.info("Using discovered default SecurityGroupId=%s", str(found))
+            return found
 
-    raise KeyError(key)
+        raise KeyError(key)

--- a/testing/citest/spinnaker_testing/azure_scenario_support.py
+++ b/testing/citest/spinnaker_testing/azure_scenario_support.py
@@ -17,79 +17,91 @@
 import citest.azure_testing as az
 from spinnaker_testing.base_scenario_support import BaseScenarioPlatformSupport
 
+
 class AzureScenarioSupport(BaseScenarioPlatformSupport):
-  """Provides SpinnakerScenarioSupport for Azure."""
+    """Provides SpinnakerScenarioSupport for Azure."""
 
-  @classmethod
-  def add_commandline_parameters(cls, scenario_class, builder, defaults):
-    """Implements BaseScenarioPlatformSupport interface.
+    @classmethod
+    def add_commandline_parameters(cls, scenario_class, builder, defaults):
+        """Implements BaseScenarioPlatformSupport interface.
 
-    Args:
-      scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
-      builder: [citest.base.ConfigBindingsBuilder]
-      defaults: [dict] Default binding value overrides.
-         This is used to initialize the default commandline parameters.
-    """
-    #
-    # Operation Parameters
-    #
-    builder.add_argument(
-        '--test_azure_rg_location', 
-        default = defaults.get('TEST_AZURE_RG_LOCATION', 'westus'),
-        help='The location of the azure resource group where test resources should be created.')
-    builder.add_argument(
-        '--test_azure_resource_group', 
-        default = defaults.get('TEST_AZURE_RESOURCE_GROUP', None),
-        help='The name of azure resource group where test resources should be created.')
-    builder.add_argument(
-        '--test_azure_subscription_id', 
-        default = defaults.get('TEST_AZURE_SUBSCRIPTION_ID', None),
-        help='The subscription id of your azure account')
-    builder.add_argument(
-        '--test_azure_vnet', 
-        help='The name of the virtual network that contains the subnets')
-    builder.add_argument(
-        '--test_azure_subnets', 
-        help='The names and addresses of subnets separated by comma')
-    builder.add_argument(
-        '--test_azure_vm_sku', 
-        default = defaults.get('TEST_AZURE_VM_SKU', 'Standard_B1ms'),
-        help='The name of VMSS')
-    builder.add_argument(
-        '--test_azure_baseOS', 
-        default = defaults.get('TEST_AZURE_BASEOS', 'ubuntu-1604'),
-        help='The OS version of the cluster used for deploying')
-    builder.add_argument(
-        '--test_azure_OSType', 
-        default = defaults.get('TEST_AZURE_OSTYPE', 'linux'),
-        help='The OS type of the cluster used for deploying')
-    builder.add_argument(
-        '--azure_storage_account_name', 
-        dest='azure_storage_account_name',
-        help='The name of the Azure storage account used by front50 in Spinnaker.')
-    builder.add_argument(
-        '--azure_storage_account_key', 
-        dest='spinnaker_azure_storage_account_key',
-        help='The key of the Azure storage account used by front50 in Spinnaker.')
+        Args:
+          scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
+          builder: [citest.base.ConfigBindingsBuilder]
+          defaults: [dict] Default binding value overrides.
+             This is used to initialize the default commandline parameters.
+        """
+        #
+        # Operation Parameters
+        #
+        builder.add_argument(
+            "--test_azure_rg_location",
+            default=defaults.get("TEST_AZURE_RG_LOCATION", "westus"),
+            help="The location of the azure resource group where test resources should be created.",
+        )
+        builder.add_argument(
+            "--test_azure_resource_group",
+            default=defaults.get("TEST_AZURE_RESOURCE_GROUP", None),
+            help="The name of azure resource group where test resources should be created.",
+        )
+        builder.add_argument(
+            "--test_azure_subscription_id",
+            default=defaults.get("TEST_AZURE_SUBSCRIPTION_ID", None),
+            help="The subscription id of your azure account",
+        )
+        builder.add_argument(
+            "--test_azure_vnet",
+            help="The name of the virtual network that contains the subnets",
+        )
+        builder.add_argument(
+            "--test_azure_subnets",
+            help="The names and addresses of subnets separated by comma",
+        )
+        builder.add_argument(
+            "--test_azure_vm_sku",
+            default=defaults.get("TEST_AZURE_VM_SKU", "Standard_B1ms"),
+            help="The name of VMSS",
+        )
+        builder.add_argument(
+            "--test_azure_baseOS",
+            default=defaults.get("TEST_AZURE_BASEOS", "ubuntu-1604"),
+            help="The OS version of the cluster used for deploying",
+        )
+        builder.add_argument(
+            "--test_azure_OSType",
+            default=defaults.get("TEST_AZURE_OSTYPE", "linux"),
+            help="The OS type of the cluster used for deploying",
+        )
+        builder.add_argument(
+            "--azure_storage_account_name",
+            dest="azure_storage_account_name",
+            help="The name of the Azure storage account used by front50 in Spinnaker.",
+        )
+        builder.add_argument(
+            "--azure_storage_account_key",
+            dest="spinnaker_azure_storage_account_key",
+            help="The key of the Azure storage account used by front50 in Spinnaker.",
+        )
 
-  def _make_observer(self):
-    """Implements BaseScenarioPlatformSupport interface."""
-    bindings = self.scenario.bindings 
-    if not bindings.get('TEST_AZURE_RG_LOCATION'):
-      raise ValueError('There is no location specified')
+    def _make_observer(self):
+        """Implements BaseScenarioPlatformSupport interface."""
+        bindings = self.scenario.bindings
+        if not bindings.get("TEST_AZURE_RG_LOCATION"):
+            raise ValueError("There is no location specified")
 
-    return az.AzAgent()
+        return az.AzAgent()
 
-  def __init__(self, scenario):
-    """Constructor.
+    def __init__(self, scenario):
+        """Constructor.
 
-    Args:
-      scenario: [SpinnakerTestScenario] The scenario being supported.
-    """
-    super(AzureScenarioSupport, self).__init__("azure", scenario)
-    self.__az_observer = None
+        Args:
+          scenario: [SpinnakerTestScenario] The scenario being supported.
+        """
+        super(AzureScenarioSupport, self).__init__("azure", scenario)
+        self.__az_observer = None
 
-    bindings = scenario.bindings
-    if not bindings['SPINNAKER_AZURE_ACCOUNT']:
-      bindings['SPINNAKER_AZURE_ACCOUNT'] = (scenario.agent.deployed_config.get(
-          'providers.azure.primaryCredentials.name', None))
+        bindings = scenario.bindings
+        if not bindings["SPINNAKER_AZURE_ACCOUNT"]:
+            bindings["SPINNAKER_AZURE_ACCOUNT"] = scenario.agent.deployed_config.get(
+                "providers.azure.primaryCredentials.name", None
+            )

--- a/testing/citest/spinnaker_testing/base_scenario_support.py
+++ b/testing/citest/spinnaker_testing/base_scenario_support.py
@@ -119,5 +119,4 @@ class BaseScenarioPlatformSupport(object):
     This method is called internally as needed when accessing the
     observer property.
     """
-    raise NotImplementedError('{0} not implemented'.format(cls))
-
+    raise NotImplementedError('not implemented')

--- a/testing/citest/spinnaker_testing/dcos_scenario_support.py
+++ b/testing/citest/spinnaker_testing/dcos_scenario_support.py
@@ -19,56 +19,61 @@ from spinnaker_testing.base_scenario_support import BaseScenarioPlatformSupport
 
 
 class DcosScenarioSupport(BaseScenarioPlatformSupport):
-  """Provides SpinnakerScenarioSupport for DC/OS."""
+    """Provides SpinnakerScenarioSupport for DC/OS."""
 
-  @classmethod
-  def add_commandline_parameters(cls, scenario_class, builder, defaults):
-    """Implements BaseScenarioPlatformSupport interface.
+    @classmethod
+    def add_commandline_parameters(cls, scenario_class, builder, defaults):
+        """Implements BaseScenarioPlatformSupport interface.
 
-    Args:
-      scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
-      builder: [citest.base.ConfigBindingsBuilder]
-      defaults: [dict] Default binding value overrides.
-         This is used to initialize the default commandline parameters.
-    """
-    #
-    # Operation Parameters
-    #
-    builder.add_argument(
-        '--spinnaker_dcos_account',
-        default=defaults.get('SPINNAKER_DCOS_ACCOUNT', None),
-        help='Spinnaker account name to use for test operations against'
-             ' DC/OS. Only used when managing jobs running on'
-             ' DC/OS.')
+        Args:
+          scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
+          builder: [citest.base.ConfigBindingsBuilder]
+          defaults: [dict] Default binding value overrides.
+             This is used to initialize the default commandline parameters.
+        """
+        #
+        # Operation Parameters
+        #
+        builder.add_argument(
+            "--spinnaker_dcos_account",
+            default=defaults.get("SPINNAKER_DCOS_ACCOUNT", None),
+            help="Spinnaker account name to use for test operations against"
+            " DC/OS. Only used when managing jobs running on"
+            " DC/OS.",
+        )
 
-    builder.add_argument(
-        '--spinnaker_dcos_cluster',
-        default=defaults.get('SPINNAKER_DCOS_CLUSTER', None),
-        help='The name of the DC/OS cluster to be used. This should be'
-             ' the name of a cluster defined in the Spinnaker account'
-             ' configuration for the account supplied with'
-             ' --spinnaker_dcos_account.')
+        builder.add_argument(
+            "--spinnaker_dcos_cluster",
+            default=defaults.get("SPINNAKER_DCOS_CLUSTER", None),
+            help="The name of the DC/OS cluster to be used. This should be"
+            " the name of a cluster defined in the Spinnaker account"
+            " configuration for the account supplied with"
+            " --spinnaker_dcos_account.",
+        )
 
-    builder.add_argument(
-        '--spinnaker_docker_account',
-        default=defaults.get('SPINNAKER_DOCKER_ACCOUNT', 'my-docker-registry-account'),
-        help='The name of the Spinnaker Docker registry account to use.')
+        builder.add_argument(
+            "--spinnaker_docker_account",
+            default=defaults.get(
+                "SPINNAKER_DOCKER_ACCOUNT", "my-docker-registry-account"
+            ),
+            help="The name of the Spinnaker Docker registry account to use.",
+        )
 
-  def _make_observer(self):
-    """Implements BaseScenarioPlatformSupport interface."""
-    bindings = self.scenario.bindings
-    if not bindings.get('SPINNAKER_DCOS_ACCOUNT'):
-      raise ValueError('There is no "spinnaker_dcos_account"')
+    def _make_observer(self):
+        """Implements BaseScenarioPlatformSupport interface."""
+        bindings = self.scenario.bindings
+        if not bindings.get("SPINNAKER_DCOS_ACCOUNT"):
+            raise ValueError('There is no "spinnaker_dcos_account"')
 
-    if not bindings.get('SPINNAKER_DCOS_CLUSTER'):
-      raise ValueError('There is no "spinnaker_dcos_cluster"')
+        if not bindings.get("SPINNAKER_DCOS_CLUSTER"):
+            raise ValueError('There is no "spinnaker_dcos_cluster"')
 
-    return dcos.DcosCliAgent()
+        return dcos.DcosCliAgent()
 
-  def __init__(self, scenario):
-    """Constructor.
+    def __init__(self, scenario):
+        """Constructor.
 
-    Args:
-      scenario: [SpinnakerTestScenario] The scenario being supported.
-    """
-    super(DcosScenarioSupport, self).__init__("dcos", scenario)
+        Args:
+          scenario: [SpinnakerTestScenario] The scenario being supported.
+        """
+        super(DcosScenarioSupport, self).__init__("dcos", scenario)

--- a/testing/citest/spinnaker_testing/expression_dict.py
+++ b/testing/citest/spinnaker_testing/expression_dict.py
@@ -60,7 +60,7 @@ class ExpressionDict(dict):
 
         This will track down values that reference other keys in the dictionary.
         """
-        if not key in self:
+        if key not in self:
             return default_value
         return self.__resolve_value(key, saw=[], original=key)
 
@@ -69,7 +69,7 @@ class ExpressionDict(dict):
 
         This will track down values that reference other keys in the dictionary.
         """
-        if not key in self:
+        if key not in self:
             raise KeyError(key)
         return self.__resolve_value(key, saw=[], original=key)
 
@@ -86,7 +86,7 @@ class ExpressionDict(dict):
           ValueError if a cycle is encountered.
         """
         value = super(ExpressionDict, self).get(key, None)
-        if value is None and not key in self:
+        if value is None and key not in self:
             raise KeyError(key)
 
         if not isinstance(value, basestring):

--- a/testing/citest/spinnaker_testing/expression_dict.py
+++ b/testing/citest/spinnaker_testing/expression_dict.py
@@ -16,114 +16,114 @@
 
 import re
 import sys
+
 if sys.version_info[0] > 2:
-  basestring = str
+    basestring = str
 
 
 class ExpressionDict(dict):
-  """A specialization of dict where key values can reference other entries.
+    """A specialization of dict where key values can reference other entries.
 
-  The dictionary is a flat name/value dictionary. If a value is in the form
-  ${KEY} then the value is assumed to be the value of a transitive lookup on
-  KEY. If the value is in the form ${KEY:DEFAULT} then the value will be
-  DEFAULT if the KEY is not present.
-  """
-
-  @property
-  def default_value_interpreter(self):
-    """A function mapping a default value into its actual value.
-
-    When an expression specifies a default value, the default value is
-    specified as a string. However if the dictionary contains typed values
-    then it may wish to use this function to interpet the specified string
-    into a typed value.
+    The dictionary is a flat name/value dictionary. If a value is in the form
+    ${KEY} then the value is assumed to be the value of a transitive lookup on
+    KEY. If the value is in the form ${KEY:DEFAULT} then the value will be
+    DEFAULT if the KEY is not present.
     """
-    return self.__default_value_interpreter
 
-  @default_value_interpreter.setter
-  def default_value_interpreter(self, func):
-    """Binds the default_value_interpreter function.
+    @property
+    def default_value_interpreter(self):
+        """A function mapping a default value into its actual value.
 
-    Args:
-      func: [object (string)]: Function turning a string into an object.
-    """
-    self.__default_value_interpreter = func
+        When an expression specifies a default value, the default value is
+        specified as a string. However if the dictionary contains typed values
+        then it may wish to use this function to interpet the specified string
+        into a typed value.
+        """
+        return self.__default_value_interpreter
 
-  def __init__(self, *args, **kwargs):
-    """Overrides standard dictionary constructor."""
-    super(ExpressionDict, self).__init__(*args, **kwargs)
-    self.__default_value_interpreter = lambda x: x
+    @default_value_interpreter.setter
+    def default_value_interpreter(self, func):
+        """Binds the default_value_interpreter function.
 
-  def get(self, key, default_value=None):
-    """Implements dict interface.
+        Args:
+          func: [object (string)]: Function turning a string into an object.
+        """
+        self.__default_value_interpreter = func
 
-    This will track down values that reference other keys in the dictionary.
-    """
-    if not key in self:
-      return default_value
-    return self.__resolve_value(key, saw=[], original=key)
+    def __init__(self, *args, **kwargs):
+        """Overrides standard dictionary constructor."""
+        super(ExpressionDict, self).__init__(*args, **kwargs)
+        self.__default_value_interpreter = lambda x: x
 
-  def __getitem__(self, key):
-    """Implements dict interface.
+    def get(self, key, default_value=None):
+        """Implements dict interface.
 
-    This will track down values that reference other keys in the dictionary.
-    """
-    if not key in self:
-      raise KeyError(key)
-    return self.__resolve_value(key, saw=[], original=key)
+        This will track down values that reference other keys in the dictionary.
+        """
+        if not key in self:
+            return default_value
+        return self.__resolve_value(key, saw=[], original=key)
 
-  def __resolve_value(self, key, saw, original):
-    """Looks up specified key and returns its final value.
+    def __getitem__(self, key):
+        """Implements dict interface.
 
-    Args:
-      key: [string] Specification of the key to retrieve.
-      saw: [list of string] The path of keys we're chasing down for the value.
-      original: [string] The original starting point of the |saw| path.
+        This will track down values that reference other keys in the dictionary.
+        """
+        if not key in self:
+            raise KeyError(key)
+        return self.__resolve_value(key, saw=[], original=key)
 
-    Raises:
-      KeyError if the |key| is not in the dictionary.
-      ValueError if a cycle is encountered.
-    """
-    value = super(ExpressionDict, self).get(key, None)
-    if value is None and not key in self:
-      raise KeyError(key)
+    def __resolve_value(self, key, saw, original):
+        """Looks up specified key and returns its final value.
 
-    if not isinstance(value, basestring):
-      return value
+        Args:
+          key: [string] Specification of the key to retrieve.
+          saw: [list of string] The path of keys we're chasing down for the value.
+          original: [string] The original starting point of the |saw| path.
 
-    if key in saw:
-      raise ValueError('Cycle looking up variable ' + original)
-    saw = saw + [key]
+        Raises:
+          KeyError if the |key| is not in the dictionary.
+          ValueError if a cycle is encountered.
+        """
+        value = super(ExpressionDict, self).get(key, None)
+        if value is None and not key in self:
+            raise KeyError(key)
 
-    expression_re = re.compile(r'\${([\._a-zA-Z0-9]+)(:.*?)?}')
-    exact_match = expression_re.match(value)
-    if exact_match and exact_match.group(0) == value:
-      try:
-        got = self.__resolve_value(exact_match.group(1), saw, original)
-        return got
-      except KeyError:
-        if exact_match.group(2):
-          return self.__default_value_interpreter(exact_match.group(2)[1:])
-        else:
-          return value
+        if not isinstance(value, basestring):
+            return value
 
-    result = []
-    offset = 0
+        if key in saw:
+            raise ValueError("Cycle looking up variable " + original)
+        saw = saw + [key]
 
-    # Look for fragments of ${key} or ${key:default} then resolve them.
-    text = value
-    for match in expression_re.finditer(text):
-      result.append(text[offset:match.start()])
-      try:
-        got = self.__resolve_value(match.group(1), saw, original)
-        result.append(str(got))
-      except KeyError:
-        if match.group(2):
-          result.append(str(match.group(2)[1:]))
-        else:
-          result.append(match.group(0))
-      offset = match.end()  # skip trailing '}'
-    result.append(text[offset:])
+        expression_re = re.compile(r"\${([\._a-zA-Z0-9]+)(:.*?)?}")
+        exact_match = expression_re.match(value)
+        if exact_match and exact_match.group(0) == value:
+            try:
+                got = self.__resolve_value(exact_match.group(1), saw, original)
+                return got
+            except KeyError:
+                if exact_match.group(2):
+                    return self.__default_value_interpreter(exact_match.group(2)[1:])
+                else:
+                    return value
 
-    return ''.join(result)
+        result = []
+        offset = 0
 
+        # Look for fragments of ${key} or ${key:default} then resolve them.
+        text = value
+        for match in expression_re.finditer(text):
+            result.append(text[offset : match.start()])
+            try:
+                got = self.__resolve_value(match.group(1), saw, original)
+                result.append(str(got))
+            except KeyError:
+                if match.group(2):
+                    result.append(str(match.group(2)[1:]))
+                else:
+                    result.append(match.group(0))
+            offset = match.end()  # skip trailing '}'
+        result.append(text[offset:])
+
+        return "".join(result)

--- a/testing/citest/spinnaker_testing/frigga.py
+++ b/testing/citest/spinnaker_testing/frigga.py
@@ -15,29 +15,31 @@
 
 """Implementation of Netflix's Frigga naming convention"""
 
+
 class Naming(object):
-  """Implementation of Netflix's Frigga naming convention"""
+    """Implementation of Netflix's Frigga naming convention"""
 
-  @staticmethod
-  def cluster(app=None, stack=None, detail=None):
-    if not app:
-      raise ValueError('`app` is required for generating names')
+    @staticmethod
+    def cluster(app=None, stack=None, detail=None):
+        if not app:
+            raise ValueError("`app` is required for generating names")
 
-    if not detail and not stack:
-      return app
+        if not detail and not stack:
+            return app
 
-    if not detail:
-      return '{0}-{1}'.format(app, stack)
+        if not detail:
+            return "{0}-{1}".format(app, stack)
 
-    return '{0}-{1}-{2}'.format(app, stack, detail)
+        return "{0}-{1}-{2}".format(app, stack, detail)
 
-  @staticmethod
-  def server_group(app=None, stack=None, detail=None, version='v000'):
-    if not app:
-      raise ValueError('`app` is required for generating names')
+    @staticmethod
+    def server_group(app=None, stack=None, detail=None, version="v000"):
+        if not app:
+            raise ValueError("`app` is required for generating names")
 
-    if not version:
-      raise ValueError('`version` is required for generating names')
+        if not version:
+            raise ValueError("`version` is required for generating names")
 
-    return '{0}-{1}'.format(
-            Naming.cluster(app=app, stack=stack, detail=detail), version)
+        return "{0}-{1}".format(
+            Naming.cluster(app=app, stack=stack, detail=detail), version
+        )

--- a/testing/citest/spinnaker_testing/front50.py
+++ b/testing/citest/spinnaker_testing/front50.py
@@ -17,40 +17,40 @@ import spinnaker_testing.spinnaker as sk
 
 
 class Front50Status(service_testing.HttpOperationStatus):
-  @classmethod
-  def new(cls, operation, original_response):
-    """Factory method.
+    @classmethod
+    def new(cls, operation, original_response):
+        """Factory method.
 
-    Args:
-      operation: [AgentOperation] The operation this status is for.
-      original_response: [string] The original JSON with the status identifier.
+        Args:
+          operation: [AgentOperation] The operation this status is for.
+          original_response: [string] The original JSON with the status identifier.
 
-    Returns:
-      sk.SpinnakerStatus for handling status from a Gate request.
-    """
-    return cls(operation, original_response)
+        Returns:
+          sk.SpinnakerStatus for handling status from a Gate request.
+        """
+        return cls(operation, original_response)
 
 
 class Front50Agent(sk.SpinnakerAgent):
-  pass
+    pass
 
 
 def new_agent(bindings, port=8080):
-  """Create an agent to interact with a Spinnaker Front50 server.
+    """Create an agent to interact with a Spinnaker Front50 server.
 
-  Args:
-    bindings: [dict] Bindings that specify how to connect to the server.
-       The actual parameters used depend on the hosting platform.
-       The hosting platform is specified with 'host_platform'.
-    port: [int] The port the server is listening on.
+    Args:
+      bindings: [dict] Bindings that specify how to connect to the server.
+         The actual parameters used depend on the hosting platform.
+         The hosting platform is specified with 'host_platform'.
+      port: [int] The port the server is listening on.
 
-  Returns:
-    sk.Front50Agent connected to the specified gate server, or None.
-    The agent will have an additional attributes:
-       managed_project: The name of the project Spinnaker is managing.
-       account_name: The account name that Spinnaker is configured to use.
-  """
-  spinnaker = Front50Agent.new_instance_from_bindings(
-      'front50', Front50Status.new, bindings, port)
-  return spinnaker
-
+    Returns:
+      sk.Front50Agent connected to the specified gate server, or None.
+      The agent will have an additional attributes:
+         managed_project: The name of the project Spinnaker is managing.
+         account_name: The account name that Spinnaker is configured to use.
+    """
+    spinnaker = Front50Agent.new_instance_from_bindings(
+        "front50", Front50Status.new, bindings, port
+    )
+    return spinnaker

--- a/testing/citest/spinnaker_testing/gate.py
+++ b/testing/citest/spinnaker_testing/gate.py
@@ -21,372 +21,403 @@ import logging
 
 from . import spinnaker as sk
 
+
 class BaseGateStatus(sk.SpinnakerStatus):
-  """Common base class for gate status objects."""
+    """Common base class for gate status objects."""
 
-  @classmethod
-  def new(cls, operation, original_response):
-    """Factory method.
+    @classmethod
+    def new(cls, operation, original_response):
+        """Factory method.
 
-    Args:
-      operation: [AgentOperation] The operation this status is for.
-      original_response: [string] The original JSON with the status identifier.
+        Args:
+          operation: [AgentOperation] The operation this status is for.
+          original_response: [string] The original JSON with the status identifier.
 
-    Returns:
-      sk.SpinnakerStatus for handling status from a Gate request.
-    """
-    return cls(operation, original_response)
+        Returns:
+          sk.SpinnakerStatus for handling status from a Gate request.
+        """
+        return cls(operation, original_response)
 
-  @property
-  def finished(self):
-    """True if status indicates the request has finished."""
-    return self.current_state not in ['NOT_STARTED', 'RUNNING', None]
+    @property
+    def finished(self):
+        """True if status indicates the request has finished."""
+        return self.current_state not in ["NOT_STARTED", "RUNNING", None]
 
-  @property
-  def finished_ok(self):
-    """True if status indicates the request has finished successfully."""
-    return self.current_state == 'SUCCEEDED'
+    @property
+    def finished_ok(self):
+        """True if status indicates the request has finished successfully."""
+        return self.current_state == "SUCCEEDED"
 
-  def export_summary_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotableEntity"""
-    super(BaseGateStatus, self).export_summary_to_json_snapshot(
-        snapshot, entity)
-    detail = self.detail_doc
-    if not detail:
-      return
+    def export_summary_to_json_snapshot(self, snapshot, entity):
+        """Implements JsonSnapshotableEntity"""
+        super(BaseGateStatus, self).export_summary_to_json_snapshot(snapshot, entity)
+        detail = self.detail_doc
+        if not detail:
+            return
 
-    builder = snapshot.edge_builder
+        builder = snapshot.edge_builder
 
-    if not isinstance(detail, list):
-      base_time = detail.get('startTime', 0)
-      self._export_status_entry_summary_to_json_snapshot(
-          detail, base_time, builder, snapshot, entity)
-      return
+        if not isinstance(detail, list):
+            base_time = detail.get("startTime", 0)
+            self._export_status_entry_summary_to_json_snapshot(
+                detail, base_time, builder, snapshot, entity
+            )
+            return
 
+        base_time = detail[0].get("startTime", 0)
+        self._export_status(detail[0], builder, entity)
+        self._export_time_info(detail[0], base_time, builder, entity)
 
-    base_time = detail[0].get('startTime', 0)
-    self._export_status(detail[0], builder, entity)
-    self._export_time_info(detail[0], base_time, builder, entity)
+        step_list_entity = snapshot.new_entity(summary="{0} parts".format(len(detail)))
 
-    step_list_entity = (snapshot.new_entity(
-        summary='{0} parts'.format(len(detail))))
+        for index, step in enumerate(detail):
+            step_entity = snapshot.new_entity()
+            self._export_status_entry_summary_to_json_snapshot(
+                step, base_time, builder, snapshot, step_entity
+            )
+            builder.make(
+                step_list_entity,
+                "[{0}] {1}".format(index, step.get("name")),
+                step_entity,
+            )
+        builder.make(entity, "Steps", step_list_entity)
 
-    for index, step in enumerate(detail):
-      step_entity = snapshot.new_entity()
-      self._export_status_entry_summary_to_json_snapshot(
-          step, base_time, builder, snapshot, step_entity)
-      builder.make(step_list_entity,
-                   '[{0}] {1}'.format(index, step.get('name')),
-                   step_entity)
-    builder.make(entity, 'Steps', step_list_entity)
+    def _export_status_entry_summary_to_json_snapshot(
+        self, status_entry, base_time, builder, snapshot, entity
+    ):
+        self._export_status(status_entry, builder, entity)
+        self._export_time_info(status_entry, base_time, builder, entity)
+        self._export_error_info(status_entry, builder, entity)
+        if "execution" in status_entry:
+            execution = status_entry["execution"]
+            execution_entity = snapshot.new_entity(summary="Execution Summary")
+            relation = self._STATUS_TO_RELATION.get(execution.get("status"))
+            builder.make(entity, "Execution Info", execution_entity, relation=relation)
+            self._export_status_entry_summary_to_json_snapshot(
+                execution, base_time, builder, snapshot, execution_entity
+            )
+            return
 
-  def _export_status_entry_summary_to_json_snapshot(
-      self, status_entry, base_time, builder, snapshot, entity):
-    self._export_status(status_entry, builder, entity)
-    self._export_time_info(status_entry, base_time, builder, entity)
-    self._export_error_info(status_entry, builder, entity)
-    if 'execution' in status_entry:
-      execution = status_entry['execution']
-      execution_entity = snapshot.new_entity(summary='Execution Summary')
-      relation = self._STATUS_TO_RELATION.get(execution.get('status'))
-      builder.make(entity, 'Execution Info', execution_entity,
-                   relation=relation)
-      self._export_status_entry_summary_to_json_snapshot(
-          execution, base_time, builder, snapshot, execution_entity)
-      return
+        stages = status_entry.get("stages")
+        if not stages:
+            return
+        stage_list_entity = snapshot.new_entity(
+            summary="{0} stages".format(len(stages))
+        )
+        worst_relation_score = self._RELATION_SCORE.get(None)
+        for index, stage in enumerate(stages):
+            stage_entity = snapshot.new_entity()
+            relation = self._export_stage_summary_to_json_snapshot(
+                stage, base_time, builder, snapshot, stage_entity
+            )
+            score = self._RELATION_SCORE.get(relation)
+            if score is not None and (
+                worst_relation_score is None or worst_relation_score < score
+            ):
+                worst_relation_score = score
+            decorator = "(*) " if stage.get("status") == "RUNNING" else ""
+            builder.make(
+                stage_list_entity,
+                "[{0}] {1}{2}".format(index, decorator, stage.get("name")),
+                stage_entity,
+                relation=relation,
+            )
+        builder.make(
+            entity,
+            "Stages",
+            stage_list_entity,
+            relation=self._SCORE_TO_RELATION.get(worst_relation_score),
+        )
 
-    stages = status_entry.get('stages')
-    if not stages:
-      return
-    stage_list_entity = snapshot.new_entity(
-        summary='{0} stages'.format(len(stages)))
-    worst_relation_score = self._RELATION_SCORE.get(None)
-    for index, stage in enumerate(stages):
-      stage_entity = snapshot.new_entity()
-      relation = self._export_stage_summary_to_json_snapshot(
-          stage, base_time, builder, snapshot, stage_entity)
-      score = self._RELATION_SCORE.get(relation)
-      if score is not None and (
-          worst_relation_score is None
-          or worst_relation_score < score):
-        worst_relation_score = score
-      decorator = '(*) ' if stage.get('status') == 'RUNNING' else ''
-      builder.make(stage_list_entity,
-                   '[{0}] {1}{2}'.format(index, decorator, stage.get('name')),
-                   stage_entity,
-                   relation=relation)
-    builder.make(entity, 'Stages', stage_list_entity,
-                 relation=self._SCORE_TO_RELATION.get(worst_relation_score))
+    def _maybe_export_stage_context(self, stage, builder, snapshot, entity):
+        context = stage.get("context")
+        if not context:
+            return
+        ex = context.get("exception")
+        if not ex:
+            return
+        builder.make(
+            entity, "Exception Type", ex.get("exceptionType"), relation="ERROR"
+        )
+        errors = (ex.get("defaults") or ex.get("details", {})).get("errors")
+        if errors:
+            message = "\n".join([" * " + err for err in errors])
+        else:
+            message = ex.get("error")
+        if message:
+            builder.make(entity, "Errors", message, relation="ERROR", format="pre")
 
-  def _maybe_export_stage_context(self, stage, builder, snapshot, entity):
-    context = stage.get('context')
-    if not context:
-      return
-    ex = context.get('exception')
-    if not ex:
-      return
-    builder.make(entity, 'Exception Type', ex.get('exceptionType'),
-                 relation='ERROR')
-    errors = (ex.get('defaults') or ex.get('details', {})).get('errors')
-    if errors:
-      message = '\n'.join([' * ' + err for err in errors])
-    else:
-      message = ex.get('error')
-    if message:
-      builder.make(entity, 'Errors', message, relation='ERROR', format='pre')
+    def _export_stage_summary_to_json_snapshot(
+        self, stage, base_time, builder, snapshot, entity
+    ):
+        stage_relation = self._export_status(stage, builder, entity)
+        self._export_time_info(stage, base_time, builder, entity)
+        self._maybe_export_stage_context(stage, builder, snapshot, entity)
+        tasks = stage.get("tasks")
+        if not tasks:
+            return stage_relation
 
-  def _export_stage_summary_to_json_snapshot(
-      self, stage, base_time, builder, snapshot, entity):
-    stage_relation = self._export_status(stage, builder, entity)
-    self._export_time_info(stage, base_time, builder, entity)
-    self._maybe_export_stage_context(stage, builder, snapshot, entity)
-    tasks = stage.get('tasks')
-    if not tasks:
-      return stage_relation
-
-    task_list_entity = snapshot.new_entity(
-        summary='{0} tasks'.format(len(tasks)))
-    worst_relation_score = self._RELATION_SCORE.get(None)
-    for index, task in enumerate(tasks):
-      task_name = task.get('name')
-      task_entity = snapshot.new_entity()
-      relation = self._export_status(task, builder, task_entity)
-      score = self._RELATION_SCORE.get(relation)
-      if score is not None and (
-          worst_relation_score is None
-          or worst_relation_score < score):
-        worst_relation_score = score
-      self._export_time_info(task, base_time, builder, task_entity)
-      builder.make(task_entity, 'Task Name', task_name)
-      decorator = '(*) ' if task.get('status') == 'RUNNING' else ''
-      builder.make(task_list_entity,
-                   '[{0}] {1}{2}'.format(index, decorator, task_name),
-                   task_entity,
-                   relation=relation)
-    builder.make(entity, 'Tasks', task_list_entity,
-                 relation=self._SCORE_TO_RELATION.get(worst_relation_score))
-    return stage_relation
+        task_list_entity = snapshot.new_entity(summary="{0} tasks".format(len(tasks)))
+        worst_relation_score = self._RELATION_SCORE.get(None)
+        for index, task in enumerate(tasks):
+            task_name = task.get("name")
+            task_entity = snapshot.new_entity()
+            relation = self._export_status(task, builder, task_entity)
+            score = self._RELATION_SCORE.get(relation)
+            if score is not None and (
+                worst_relation_score is None or worst_relation_score < score
+            ):
+                worst_relation_score = score
+            self._export_time_info(task, base_time, builder, task_entity)
+            builder.make(task_entity, "Task Name", task_name)
+            decorator = "(*) " if task.get("status") == "RUNNING" else ""
+            builder.make(
+                task_list_entity,
+                "[{0}] {1}{2}".format(index, decorator, task_name),
+                task_entity,
+                relation=relation,
+            )
+        builder.make(
+            entity,
+            "Tasks",
+            task_list_entity,
+            relation=self._SCORE_TO_RELATION.get(worst_relation_score),
+        )
+        return stage_relation
 
 
 class GateTaskStatus(BaseGateStatus):
-  """Specialization of BaseGateStatus for accessing Gate 'tasks' status."""
+    """Specialization of BaseGateStatus for accessing Gate 'tasks' status."""
 
-  @property
-  def timed_out(self):
-    """True if status indicates the request timed out."""
-    return (self.current_state == 'TERMINAL'
-            and str(self.detail).find(' timed out.') > 0)
+    @property
+    def timed_out(self):
+        """True if status indicates the request timed out."""
+        return (
+            self.current_state == "TERMINAL"
+            and str(self.detail).find(" timed out.") > 0
+        )
 
-  def __init__(self, operation, original_response=None):
-    """Construct a new Gate request status.
+    def __init__(self, operation, original_response=None):
+        """Construct a new Gate request status.
 
-    Args:
-      operation: [AgentOperation] The operation this status is for.
-      original_response: [string] The original JSON with the status identifier.
-    """
-    super(GateTaskStatus, self).__init__(operation, original_response)
+        Args:
+          operation: [AgentOperation] The operation this status is for.
+          original_response: [string] The original JSON with the status identifier.
+        """
+        super(GateTaskStatus, self).__init__(operation, original_response)
 
-    if not original_response.ok():
-      self._bind_error(original_response.error_message)
-      self.current_state = 'HTTP_ERROR'
-      return
+        if not original_response.ok():
+            self._bind_error(original_response.error_message)
+            self.current_state = "HTTP_ERROR"
+            return
 
-    doc = None
-    try:
-      doc = json.JSONDecoder().decode(original_response.output)
-    except (ValueError, TypeError):
-      pass
+        doc = None
+        try:
+            doc = json.JSONDecoder().decode(original_response.output)
+        except (ValueError, TypeError):
+            pass
 
-    if isinstance(doc, dict):
-      self._bind_detail_path(doc['ref'])
-      self._bind_id(self.detail_path)
-    else:
-      self._bind_error("Invalid response='{0}'".format(original_response))
-      self.current_state = 'CITEST_INTERNAL_ERROR'
+        if isinstance(doc, dict):
+            self._bind_detail_path(doc["ref"])
+            self._bind_id(self.detail_path)
+        else:
+            self._bind_error("Invalid response='{0}'".format(original_response))
+            self.current_state = "CITEST_INTERNAL_ERROR"
 
-  def _update_response_from_json(self, doc):
-    """Updates abstract BaseGateStatus attributes from a Gate response.
+    def _update_response_from_json(self, doc):
+        """Updates abstract BaseGateStatus attributes from a Gate response.
 
-    This is called by the base class.
+        This is called by the base class.
 
-    Args:
-       doc: [dict] JSON Document object read from response payload.
-    """
-    self.current_state = doc['status']
-    self._bind_exception_details(None)
+        Args:
+           doc: [dict] JSON Document object read from response payload.
+        """
+        self.current_state = doc["status"]
+        self._bind_exception_details(None)
 
-    exception_details = None
-    gate_exception = None
-    variables = doc.get('variables', None)
-    if variables:
-      for elem in variables:
-        if elem['key'] == 'exception':
-          value = elem['value']
-          exception_details = value['details']
-        elif elem['key'] == 'kato.tasks':
-          value = elem['value']
-          for task in value:
-            if 'exception' in task:
-              gate_exception = task['exception']['message']
-              break
+        exception_details = None
+        gate_exception = None
+        variables = doc.get("variables", None)
+        if variables:
+            for elem in variables:
+                if elem["key"] == "exception":
+                    value = elem["value"]
+                    exception_details = value["details"]
+                elif elem["key"] == "kato.tasks":
+                    value = elem["value"]
+                    for task in value:
+                        if "exception" in task:
+                            gate_exception = task["exception"]["message"]
+                            break
 
-    self._bind_exception_details(exception_details or gate_exception)
+        self._bind_exception_details(exception_details or gate_exception)
 
 
 class GatePipelineStatus(BaseGateStatus):
-  """Specialization of BaseGateStatus for accessing Gate 'pipelines' status.
-  """
+    """Specialization of BaseGateStatus for accessing Gate 'pipelines' status."""
 
-  @classmethod
-  def new(cls, operation, original_response):
-    """Factory method.
+    @classmethod
+    def new(cls, operation, original_response):
+        """Factory method.
 
-    Args:
-      operation: [AgentOperation] The operation this status is for.
-      original_response: [string] The original JSON with the status identifier.
+        Args:
+          operation: [AgentOperation] The operation this status is for.
+          original_response: [string] The original JSON with the status identifier.
 
-    Returns:
-      sk.SpinnakerStatus for handling status from a Gate request.
-    """
-    return GatePipelineStatus(operation, original_response)
+        Returns:
+          sk.SpinnakerStatus for handling status from a Gate request.
+        """
+        return GatePipelineStatus(operation, original_response)
 
-  @property
-  def timed_out(self):
-    """True if status indicates the request timed out."""
-    return (self.current_state == 'TERMINAL'
-            and str(self.detail).find(' timed out.') > 0)
+    @property
+    def timed_out(self):
+        """True if status indicates the request timed out."""
+        return (
+            self.current_state == "TERMINAL"
+            and str(self.detail).find(" timed out.") > 0
+        )
 
-  def __init__(self, operation, original_response=None):
-    """Construct a new Gate request status.
+    def __init__(self, operation, original_response=None):
+        """Construct a new Gate request status.
 
-    Args:
-      operation: [AgentOperation] The operation this status is for.
-      original_response: [string] The original JSON with the status identifier.
-    """
-    super(GatePipelineStatus, self).__init__(operation, original_response)
-    self.__saw_pipeline = False
+        Args:
+          operation: [AgentOperation] The operation this status is for.
+          original_response: [string] The original JSON with the status identifier.
+        """
+        super(GatePipelineStatus, self).__init__(operation, original_response)
+        self.__saw_pipeline = False
 
-  def _update_response_from_json(self, doc):
-    """Updates abstract sk.SpinnakerStatus attributes from a Gate response.
+    def _update_response_from_json(self, doc):
+        """Updates abstract sk.SpinnakerStatus attributes from a Gate response.
 
-    This is called by the base class.
+        This is called by the base class.
 
-    Args:
-       doc: [dict] JSON Document object read from response payload.
-    """
-    self._bind_exception_details(None)
+        Args:
+           doc: [dict] JSON Document object read from response payload.
+        """
+        self._bind_exception_details(None)
 
-    if not isinstance(doc, list):
-      self._bind_error("Invalid response='{0}'".format(doc))
-      self.current_state = 'CITEST_INTERNAL_ERROR'
+        if not isinstance(doc, list):
+            self._bind_error("Invalid response='{0}'".format(doc))
+            self.current_state = "CITEST_INTERNAL_ERROR"
 
-    # It can take a while for the running pipelines to show up.
-    if len(doc) == 0 or not isinstance(doc, list):
-      return
+        # It can take a while for the running pipelines to show up.
+        if len(doc) == 0 or not isinstance(doc, list):
+            return
 
-    if not self.__saw_pipeline:
-      logger = logging.getLogger(__name__)
-      logger.info('Pipeline is now visible.')
-      self.__saw_pipeline = True
+        if not self.__saw_pipeline:
+            logger = logging.getLogger(__name__)
+            logger.info("Pipeline is now visible.")
+            self.__saw_pipeline = True
 
-    # TODO(lwander): We need a way to ensure we are monitoring the correct
-    #                pipeline.
-    doc = doc[0]
-    if self.current_state != doc['status']:
-      self.current_state = doc['status']
-      logger = logging.getLogger(__name__)
-      logger.info('Pipeline state is now %s', self.current_state)
+        # TODO(lwander): We need a way to ensure we are monitoring the correct
+        #                pipeline.
+        doc = doc[0]
+        if self.current_state != doc["status"]:
+            self.current_state = doc["status"]
+            logger = logging.getLogger(__name__)
+            logger.info("Pipeline state is now %s", self.current_state)
 
-    # TODO(ewiseblatt): 20160308
-    # It looks like sometimes when we get an exception, the exception is
-    # burried in one of the interior stages and not propagated back up to
-    # the top level status. It's context is empty. So this might not
-    # be working at all, or at least is incomplete.
-    context = doc.get('context', {})
-    exception_details = context.get('exception', None)
-    self._bind_exception_details(exception_details)
+        # TODO(ewiseblatt): 20160308
+        # It looks like sometimes when we get an exception, the exception is
+        # burried in one of the interior stages and not propagated back up to
+        # the top level status. It's context is empty. So this might not
+        # be working at all, or at least is incomplete.
+        context = doc.get("context", {})
+        exception_details = context.get("exception", None)
+        self._bind_exception_details(exception_details)
 
 
 class GateAgent(sk.SpinnakerAgent):
-  """Specialization of SpinnakerAgent for Gate subsystem.
+    """Specialization of SpinnakerAgent for Gate subsystem.
 
-  This class just adds convienence methods specific to Gate.
-  """
-
-  def make_create_app_operation(self, bindings, application, account_name,
-                                cloud_providers=None,
-                                description=None):
-    """Create a Gate operation that will create a new application.
-
-    Args:
-      bindings: [dict] key/value pairs including optional TEST_EMAIL.
-      application: [string] Name of application to create.
-      account_name: [string] Account name owning the application.
-      cloud_providers: [string] Comma-separated list of cloud providers.
-      description: [string] Text description field for the operation payload.
-
-    Returns:
-      AgentOperation.
+    This class just adds convienence methods specific to Gate.
     """
-    email = bindings.get('TEST_EMAIL', 'testuser@testhost.org')
-    payload = self.make_json_payload_from_kwargs(
-        job=[{
-            'type': 'createApplication',
-            'account': account_name,
-            'application': {
-                'name': application,
-                'description': description or 'Gate Testing Application',
-                'email': email,
-                'platformHealthOnly': True,
-                'cloudProviders': cloud_providers or "",
-            },
-            'user': '[anonymous]'
-        }],
-        description='Create Application: ' + application,
-        application=application)
 
-    return self.new_post_operation(
-        title='create_app', data=payload, path='tasks')
+    def make_create_app_operation(
+        self,
+        bindings,
+        application,
+        account_name,
+        cloud_providers=None,
+        description=None,
+    ):
+        """Create a Gate operation that will create a new application.
 
-  def make_delete_app_operation(self, application, account_name):
-    """Create a Gate operation that will delete an existing application.
+        Args:
+          bindings: [dict] key/value pairs including optional TEST_EMAIL.
+          application: [string] Name of application to create.
+          account_name: [string] Account name owning the application.
+          cloud_providers: [string] Comma-separated list of cloud providers.
+          description: [string] Text description field for the operation payload.
 
-    Args:
-      application: [string] Name of application to create.
-      account_name: [string] Spinnaker account deleting the application.
+        Returns:
+          AgentOperation.
+        """
+        email = bindings.get("TEST_EMAIL", "testuser@testhost.org")
+        payload = self.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "type": "createApplication",
+                    "account": account_name,
+                    "application": {
+                        "name": application,
+                        "description": description or "Gate Testing Application",
+                        "email": email,
+                        "platformHealthOnly": True,
+                        "cloudProviders": cloud_providers or "",
+                    },
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Create Application: " + application,
+            application=application,
+        )
 
-    Returns:
-      AgentOperation.
-    """
-    payload = self.make_json_payload_from_kwargs(
-        job=[{
-            'type': 'deleteApplication',
-            'account': account_name,
-            'application': {'name': application},
-            'user': '[anonymous]'
-        }],
-        description='Delete Application: ' + application,
-        application=application)
+        return self.new_post_operation(title="create_app", data=payload, path="tasks")
 
-    return self.new_post_operation(
-        title='delete_app', data=payload, path='tasks')
+    def make_delete_app_operation(self, application, account_name):
+        """Create a Gate operation that will delete an existing application.
+
+        Args:
+          application: [string] Name of application to create.
+          account_name: [string] Spinnaker account deleting the application.
+
+        Returns:
+          AgentOperation.
+        """
+        payload = self.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "type": "deleteApplication",
+                    "account": account_name,
+                    "application": {"name": application},
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Delete Application: " + application,
+            application=application,
+        )
+
+        return self.new_post_operation(title="delete_app", data=payload, path="tasks")
 
 
 def new_agent(bindings, port=8084):
-  """Create an agent to interact with a Spinnaker Gate server.
+    """Create an agent to interact with a Spinnaker Gate server.
 
-  Args:
-    bindings: [dict] Bindings that specify how to connect to the server.
-       The actual parameters used depend on the hosting platform.
-       The hosting platform is specified with 'host_platform'.
-    port: [int] The port the server is listening on.
+    Args:
+      bindings: [dict] Bindings that specify how to connect to the server.
+         The actual parameters used depend on the hosting platform.
+         The hosting platform is specified with 'host_platform'.
+      port: [int] The port the server is listening on.
 
-  Returns:
-    sk.SpinnakerAgent connected to the specified gate server, or None.
-    The agent will have an additional attributes:
-       managed_project: The name of the project Spinnaker is managing.
-       account_name: The account name that Spinnaker is configured to use.
-  """
-  spinnaker = GateAgent.new_instance_from_bindings(
-      'gate', GateTaskStatus.new, bindings, port)
-  return spinnaker
+    Returns:
+      sk.SpinnakerAgent connected to the specified gate server, or None.
+      The agent will have an additional attributes:
+         managed_project: The name of the project Spinnaker is managing.
+         account_name: The account name that Spinnaker is configured to use.
+    """
+    spinnaker = GateAgent.new_instance_from_bindings(
+        "gate", GateTaskStatus.new, bindings, port
+    )
+    return spinnaker

--- a/testing/citest/spinnaker_testing/gcs_pubsub_trigger_agent.py
+++ b/testing/citest/spinnaker_testing/gcs_pubsub_trigger_agent.py
@@ -24,175 +24,209 @@ from spinnaker_testing.gate import GateAgent
 
 
 class GcsFileUploadAgent(base_agent.BaseAgent):
-  """Specialization to upload files to GCS.
-  """
-  def __init__(self, credentials_path=None, logger=None):
-    super(GcsFileUploadAgent, self).__init__(logger=logger)
-    if credentials_path:
-      self.__client = storage.Client.from_service_account_json(
-          credentials_path)
-    else:
-      self.__client = storage.Client()
+    """Specialization to upload files to GCS."""
 
-    # Allow up to 13 minutes to wait on operations.
-    # 13 minutes is arbitrary. The current test takes around 6-7 minutes
-    # end-to-end. Other use cases might make it more clear what this should be.
-    self.default_max_wait_secs = 780
+    def __init__(self, credentials_path=None, logger=None):
+        super(GcsFileUploadAgent, self).__init__(logger=logger)
+        if credentials_path:
+            self.__client = storage.Client.from_service_account_json(credentials_path)
+        else:
+            self.__client = storage.Client()
 
-  def upload_string(self, bucket_name, upload_path, contents):
-    """Uploads a local file to a bucket at a relative upload path.
-    """
-    logging.info('Uploading string to bucket %s at path %s',
-                 bucket_name, upload_path)
-    bucket = self.__client.get_bucket(bucket_name)
-    upload_blob = bucket.blob(upload_path)
-    upload_blob.upload_from_string(contents)
+        # Allow up to 13 minutes to wait on operations.
+        # 13 minutes is arbitrary. The current test takes around 6-7 minutes
+        # end-to-end. Other use cases might make it more clear what this should be.
+        self.default_max_wait_secs = 780
 
-  def upload_file(self, bucket_name, upload_path, local_filename):
-    """Uploads a local file to a bucket at a relative upload path.
-    """
-    logging.info('Uploading local file %s to bucket %s at path %s',
-                 local_filename, bucket_name, upload_path)
-    bucket = self.__client.get_bucket(bucket_name)
-    upload_blob = bucket.blob(upload_path)
-    upload_blob.upload_from_filename(filename=local_filename)
+    def upload_string(self, bucket_name, upload_path, contents):
+        """Uploads a local file to a bucket at a relative upload path."""
+        logging.info(
+            "Uploading string to bucket %s at path %s", bucket_name, upload_path
+        )
+        bucket = self.__client.get_bucket(bucket_name)
+        upload_blob = bucket.blob(upload_path)
+        upload_blob.upload_from_string(contents)
 
-  def export_to_json_snapshot(self, snapshot, entity):
-    super(GcsFileUploadAgent, self).export_to_json_snapshot(snapshot, entity)
+    def upload_file(self, bucket_name, upload_path, local_filename):
+        """Uploads a local file to a bucket at a relative upload path."""
+        logging.info(
+            "Uploading local file %s to bucket %s at path %s",
+            local_filename,
+            bucket_name,
+            upload_path,
+        )
+        bucket = self.__client.get_bucket(bucket_name)
+        upload_blob = bucket.blob(upload_path)
+        upload_blob.upload_from_filename(filename=local_filename)
 
-  def new_gcs_pubsub_trigger_operation(
-      self, gate_agent, title, bucket_name, upload_path,
-      local_filename, status_class, status_path):
-    return GcsPubsubUploadTriggerOperation(
-        title, self, gate_agent, bucket_name, upload_path,
-        local_filename, status_class, status_path)
+    def export_to_json_snapshot(self, snapshot, entity):
+        super(GcsFileUploadAgent, self).export_to_json_snapshot(snapshot, entity)
+
+    def new_gcs_pubsub_trigger_operation(
+        self,
+        gate_agent,
+        title,
+        bucket_name,
+        upload_path,
+        local_filename,
+        status_class,
+        status_path,
+    ):
+        return GcsPubsubUploadTriggerOperation(
+            title,
+            self,
+            gate_agent,
+            bucket_name,
+            upload_path,
+            local_filename,
+            status_class,
+            status_path,
+        )
 
 
 class BaseGcsPubsubTriggerOperation(base_agent.AgentOperation):
-  """Specialization for base gcs pubsub trigger operations.
-  """
-  def __init__(self, title, gcs_pubsub_agent, gate_agent, **kwargs):
-    """Construct operation
+    """Specialization for base gcs pubsub trigger operations."""
 
-    Args:
-      gcs_pubsub_agent: [GcsFileUploadAgent] agent to perform operation
-      gate_agent: [GateAgent] agent used for monitoring status
-    """
-    if (not gcs_pubsub_agent
-        or not isinstance(gcs_pubsub_agent, GcsFileUploadAgent)):
-      raise TypeError('gcs_pubsub_agent is not a GcsFileUploadAgent: '
-                      + gcs_pubsub_agent.__class__.__name__)
-    if (not gate_agent or not isinstance(gate_agent, GateAgent)):
-      raise TypeError('gate_agent is not a GateAgent: '
-                      + gate_agent.__class__.__name__)
-    super(BaseGcsPubsubTriggerOperation, self).__init__(
-        title, gate_agent, **kwargs)
-    self.__pubsub_agent = gcs_pubsub_agent
+    def __init__(self, title, gcs_pubsub_agent, gate_agent, **kwargs):
+        """Construct operation
 
-  def export_to_json_snapshot(self, snapshot, entity):
-    snapshot.edge_builder.make_mechanism(
-        entity, 'Gcs Pubsub Agent', self.__pubsub_agent)
-    super(BaseGcsPubsubTriggerOperation, self).export_to_json_snapshot(
-        snapshot, entity)
+        Args:
+          gcs_pubsub_agent: [GcsFileUploadAgent] agent to perform operation
+          gate_agent: [GateAgent] agent used for monitoring status
+        """
+        if not gcs_pubsub_agent or not isinstance(gcs_pubsub_agent, GcsFileUploadAgent):
+            raise TypeError(
+                "gcs_pubsub_agent is not a GcsFileUploadAgent: "
+                + gcs_pubsub_agent.__class__.__name__
+            )
+        if not gate_agent or not isinstance(gate_agent, GateAgent):
+            raise TypeError(
+                "gate_agent is not a GateAgent: " + gate_agent.__class__.__name__
+            )
+        super(BaseGcsPubsubTriggerOperation, self).__init__(title, gate_agent, **kwargs)
+        self.__pubsub_agent = gcs_pubsub_agent
 
-  def execute(self, agent=None):
-    status = self._do_execute(self.__pubsub_agent)
-    self.__pubsub_agent.logger.debug('Returning status %s', status)
-    return status
+    def export_to_json_snapshot(self, snapshot, entity):
+        snapshot.edge_builder.make_mechanism(
+            entity, "Gcs Pubsub Agent", self.__pubsub_agent
+        )
+        super(BaseGcsPubsubTriggerOperation, self).export_to_json_snapshot(
+            snapshot, entity
+        )
 
-  def _do_execute(self, agent):
-    raise NotImplementedError('{0}._do_execute'.format(type(self)))
+    def execute(self, agent=None):
+        status = self._do_execute(self.__pubsub_agent)
+        self.__pubsub_agent.logger.debug("Returning status %s", status)
+        return status
+
+    def _do_execute(self, agent):
+        raise NotImplementedError("{0}._do_execute".format(type(self)))
 
 
 class GcsPubsubUploadTriggerOperation(BaseGcsPubsubTriggerOperation):
-  """Specialization for main logic of gcs pubsub trigger operations.
-  """
-  def __init__(
-      self, title, gcs_pubsub_agent, gate_agent, bucket_name, upload_path,
-      local_filename, status_class, status_path):
-    super(GcsPubsubUploadTriggerOperation, self).__init__(
-        title, gcs_pubsub_agent, gate_agent)
-    self.__bucket_name = bucket_name
-    self.__upload_path = upload_path
-    self.__local_filename = local_filename
-    self.__status_class = status_class
-    self.__status_path = status_path
+    """Specialization for main logic of gcs pubsub trigger operations."""
 
-  def _do_execute(self, agent):
-    agent.upload_file(
-        self.__bucket_name, self.__upload_path, self.__local_filename)
+    def __init__(
+        self,
+        title,
+        gcs_pubsub_agent,
+        gate_agent,
+        bucket_name,
+        upload_path,
+        local_filename,
+        status_class,
+        status_path,
+    ):
+        super(GcsPubsubUploadTriggerOperation, self).__init__(
+            title, gcs_pubsub_agent, gate_agent
+        )
+        self.__bucket_name = bucket_name
+        self.__upload_path = upload_path
+        self.__local_filename = local_filename
+        self.__status_class = status_class
+        self.__status_path = status_path
 
-    return GcsPubsubTriggerOperationStatus(
-        self, self.__status_class, self.__status_path)
+    def _do_execute(self, agent):
+        agent.upload_file(self.__bucket_name, self.__upload_path, self.__local_filename)
+
+        return GcsPubsubTriggerOperationStatus(
+            self, self.__status_class, self.__status_path
+        )
 
 
 class GcsPubsubTriggerOperationStatus(base_agent.AgentOperationStatus):
-  """Status of pipeline executions triggered via gcs -> pub/sub events
-  """
-  @property
-  def finished(self):
-    return self.__trigger_status.finished or self.__is_timed_out
+    """Status of pipeline executions triggered via gcs -> pub/sub events"""
 
-  @property
-  def finished_ok(self):
-    return self.__trigger_status.finished_ok
+    @property
+    def finished(self):
+        return self.__trigger_status.finished or self.__is_timed_out
 
-  @property
-  def id(self):
-    return self.__trigger_status.id
+    @property
+    def finished_ok(self):
+        return self.__trigger_status.finished_ok
 
-  @property
-  def detail(self):
-    return 'trigger response: {response}'.format(
-        response=self.__trigger_response)
+    @property
+    def id(self):
+        return self.__trigger_status.id
 
-  @property
-  def timed_out(self):
-    return self.__trigger_status.timed_out or self.__is_timed_out
+    @property
+    def detail(self):
+        return "trigger response: {response}".format(response=self.__trigger_response)
 
-  def refresh(self):
-    if self.finished:
-      return
+    @property
+    def timed_out(self):
+        return self.__trigger_status.timed_out or self.__is_timed_out
 
-    self.__trigger_status.refresh()
-    detail_path = self.__trigger_status.detail_path
+    def refresh(self):
+        if self.finished:
+            return
 
-    self.__trigger_response = self.operation.agent.get(detail_path)
-    if not self.__trigger_status.finished:
-      self.__is_timed_out = time.time() >= self.__timeout_time
+        self.__trigger_status.refresh()
+        detail_path = self.__trigger_status.detail_path
 
-  def __init__(self, operation, status_class, status_path,
-               **kwargs):
-    """Constructs a GcsPubsubTriggerOperationStatus object.
+        self.__trigger_response = self.operation.agent.get(detail_path)
+        if not self.__trigger_status.finished:
+            self.__is_timed_out = time.time() >= self.__timeout_time
 
-    Args:
-    operation [BaseGcsPubsubTriggerOperation]: The GCS operation this is for.
-    """
-    super(GcsPubsubTriggerOperationStatus, self).__init__(operation)
-    max_wait_secs = kwargs.pop('max_wait_secs', 300)
-    self.__timeout_time = time.time() + max_wait_secs
-    self.__trigger_response = operation.agent.get(status_path)
-    self.__trigger_status = status_class(operation, original_response=self.__trigger_response)
-    self.__trigger_status._bind_id("n/a")
-    self.__trigger_status._bind_detail_path(status_path)
-    self.__is_timed_out = False
+    def __init__(self, operation, status_class, status_path, **kwargs):
+        """Constructs a GcsPubsubTriggerOperationStatus object.
 
-  def export_summary_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotableEntity interface."""
-    (super(GcsPubsubTriggerOperationStatus, self)
-     .export_summary_to_json_snapshot(snapshot, entity))
+        Args:
+        operation [BaseGcsPubsubTriggerOperation]: The GCS operation this is for.
+        """
+        super(GcsPubsubTriggerOperationStatus, self).__init__(operation)
+        max_wait_secs = kwargs.pop("max_wait_secs", 300)
+        self.__timeout_time = time.time() + max_wait_secs
+        self.__trigger_response = operation.agent.get(status_path)
+        self.__trigger_status = status_class(
+            operation, original_response=self.__trigger_response
+        )
+        self.__trigger_status._bind_id("n/a")
+        self.__trigger_status._bind_detail_path(status_path)
+        self.__is_timed_out = False
 
-    if self.__trigger_response:
-      summary = snapshot.make_entity_for_object_summary(self.__trigger_response)
-      relation = 'VALID' if self.__trigger_response.ok() else 'INVALID'
-    else:
-      summary = 'No Trigger Response Yet'
-      relation = None
-    snapshot.edge_builder.make(
-      entity, 'Trigger Response', summary, relation=relation)
+    def export_summary_to_json_snapshot(self, snapshot, entity):
+        """Implements JsonSnapshotableEntity interface."""
+        (
+            super(
+                GcsPubsubTriggerOperationStatus, self
+            ).export_summary_to_json_snapshot(snapshot, entity)
+        )
 
-  def export_to_json_snapshot(self, snapshot, entity):
-    snapshot.edge_builder.make_output(
-        entity, 'Trigger Response', self.__trigger_response)
-    super(GcsPubsubTriggerOperationStatus, self).export_to_json_snapshot(
-        snapshot, entity)
+        if self.__trigger_response:
+            summary = snapshot.make_entity_for_object_summary(self.__trigger_response)
+            relation = "VALID" if self.__trigger_response.ok() else "INVALID"
+        else:
+            summary = "No Trigger Response Yet"
+            relation = None
+        snapshot.edge_builder.make(
+            entity, "Trigger Response", summary, relation=relation
+        )
+
+    def export_to_json_snapshot(self, snapshot, entity):
+        snapshot.edge_builder.make_output(
+            entity, "Trigger Response", self.__trigger_response
+        )
+        super(GcsPubsubTriggerOperationStatus, self).export_to_json_snapshot(
+            snapshot, entity
+        )

--- a/testing/citest/spinnaker_testing/google_scenario_support.py
+++ b/testing/citest/spinnaker_testing/google_scenario_support.py
@@ -35,347 +35,388 @@ from spinnaker_testing.base_scenario_support import BaseScenarioPlatformSupport
 
 
 class GoogleScenarioSupport(BaseScenarioPlatformSupport):
-  """Provides SpinnakerScenarioSupport for Google Compute Engine."""
+    """Provides SpinnakerScenarioSupport for Google Compute Engine."""
 
-  @classmethod
-  def add_commandline_parameters(cls, scenario_class, builder, defaults):
-    """Implements BaseScenarioPlatformSupport interface.
+    @classmethod
+    def add_commandline_parameters(cls, scenario_class, builder, defaults):
+        """Implements BaseScenarioPlatformSupport interface.
 
-    Args:
-      scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
-      builder: [citest.base.ConfigBindingsBuilder]
-      defaults: [dict] Default binding value overrides.
-         This is used to initialize the default commandline parameters.
-    """
-    # TODO(ewiseblatt): 20160923
-    # This is probably obsoleted. It is only used by the gcloud agent,
-    # which is only used to establish a tunnel. I dont think the credentials
-    # are needed there, but your ssh passphrase is (which is unrelated).
-    builder.add_argument(
-        '--gce_service_account',
-        default=defaults.get('GCE_SERVICE_ACCOUNT', None),
-        help='The GCE service account to use when interacting with the'
-             ' gce_instance. The default will be the default configured'
-             ' account on the local machine. To change the default account,'
-             ' use "gcloud config set account". To active service accounts,'
-             ' use "gcloud auth activate-service-account".'
-             ' This parameter is only used if the spinnaker host platform'
-             ' is GCE.')
+        Args:
+          scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
+          builder: [citest.base.ConfigBindingsBuilder]
+          defaults: [dict] Default binding value overrides.
+             This is used to initialize the default commandline parameters.
+        """
+        # TODO(ewiseblatt): 20160923
+        # This is probably obsoleted. It is only used by the gcloud agent,
+        # which is only used to establish a tunnel. I dont think the credentials
+        # are needed there, but your ssh passphrase is (which is unrelated).
+        builder.add_argument(
+            "--gce_service_account",
+            default=defaults.get("GCE_SERVICE_ACCOUNT", None),
+            help="The GCE service account to use when interacting with the"
+            " gce_instance. The default will be the default configured"
+            " account on the local machine. To change the default account,"
+            ' use "gcloud config set account". To active service accounts,'
+            ' use "gcloud auth activate-service-account".'
+            " This parameter is only used if the spinnaker host platform"
+            " is GCE.",
+        )
 
-    builder.add_argument(
-        '--gce_credentials',
-        dest='spinnaker_google_account',
-        help='DEPRECATED. Replaced by --spinnaker_google_account')
+        builder.add_argument(
+            "--gce_credentials",
+            dest="spinnaker_google_account",
+            help="DEPRECATED. Replaced by --spinnaker_google_account",
+        )
 
-    #
-    # Location Parameters
-    #
-    builder.add_argument(
-        '--gce_instance', default=defaults.get('GCE_INSTANCE', None),
-        help='The GCE instance name that {system} is running on.'
-             ' This parameter is only used if the spinnaker host platform'
-             ' is GCE.'.format(system=scenario_class.ENDPOINT_SUBSYSTEM))
+        #
+        # Location Parameters
+        #
+        builder.add_argument(
+            "--gce_instance",
+            default=defaults.get("GCE_INSTANCE", None),
+            help="The GCE instance name that {system} is running on."
+            " This parameter is only used if the spinnaker host platform"
+            " is GCE.".format(system=scenario_class.ENDPOINT_SUBSYSTEM),
+        )
 
-    builder.add_argument(
-        '--gce_project', default=defaults.get('GCE_PROJECT', None),
-        help='The GCE project that {system} is running within.'
-             ' This parameter is only used if the spinnaker host platform'
-             ' is GCE.'.format(system=scenario_class.ENDPOINT_SUBSYSTEM))
+        builder.add_argument(
+            "--gce_project",
+            default=defaults.get("GCE_PROJECT", None),
+            help="The GCE project that {system} is running within."
+            " This parameter is only used if the spinnaker host platform"
+            " is GCE.".format(system=scenario_class.ENDPOINT_SUBSYSTEM),
+        )
 
-    builder.add_argument(
-        '--gce_zone', default=defaults.get('GCE_ZONE', None),
-        help='The GCE zone that {system} is running within.'
-             ' This parameter is only used if the spinnaker host platform'
-             ' is GCE.'.format(system=scenario_class.ENDPOINT_SUBSYSTEM))
+        builder.add_argument(
+            "--gce_zone",
+            default=defaults.get("GCE_ZONE", None),
+            help="The GCE zone that {system} is running within."
+            " This parameter is only used if the spinnaker host platform"
+            " is GCE.".format(system=scenario_class.ENDPOINT_SUBSYSTEM),
+        )
 
-    builder.add_argument(
-        '--gce_ssh_passphrase_file',
-        default=defaults.get('GCE_SSH_PASSPHRASE_FILE', None),
-        help='Specifying a file containing the SSH passphrase'
-             ' will permit tunneling or the execution of remote'
-             ' commands into the --gce_instance if needed.')
+        builder.add_argument(
+            "--gce_ssh_passphrase_file",
+            default=defaults.get("GCE_SSH_PASSPHRASE_FILE", None),
+            help="Specifying a file containing the SSH passphrase"
+            " will permit tunneling or the execution of remote"
+            " commands into the --gce_instance if needed.",
+        )
 
-    #
-    # Operation Parameters
-    #
-    builder.add_argument(
-        '--spinnaker_google_account',
-        default=defaults.get('SPINNAKER_GOOGLE_ACCOUNT', None),
-        help='Spinnaker account name to use for test operations against GCE.'
-             ' Only used when managing resources on GCE.'
-             ' If left empty then use the configured primary account.')
+        #
+        # Operation Parameters
+        #
+        builder.add_argument(
+            "--spinnaker_google_account",
+            default=defaults.get("SPINNAKER_GOOGLE_ACCOUNT", None),
+            help="Spinnaker account name to use for test operations against GCE."
+            " Only used when managing resources on GCE."
+            " If left empty then use the configured primary account.",
+        )
 
-    builder.add_argument(
-        '--test_gce_image_name',
-        default=defaults.get('TEST_GCE_IMAGE_NAME',
-                             'apache-base-image'),
-        help='Default Google Compute Engine image name to use when'
-             ' creating test instances.')
+        builder.add_argument(
+            "--test_gce_image_name",
+            default=defaults.get("TEST_GCE_IMAGE_NAME", "apache-base-image"),
+            help="Default Google Compute Engine image name to use when"
+            " creating test instances.",
+        )
 
-    builder.add_argument(
-        '--test_gce_region',
-        default=defaults.get('TEST_GCE_REGION', ''),
-        help='The GCE region to test generated instances in (when managing'
-             ' GCE). If not specified, then derive it from --test_gce_zone.')
+        builder.add_argument(
+            "--test_gce_region",
+            default=defaults.get("TEST_GCE_REGION", ""),
+            help="The GCE region to test generated instances in (when managing"
+            " GCE). If not specified, then derive it from --test_gce_zone.",
+        )
 
-    builder.add_argument(
-        '--test_gce_zone',
-        default=defaults.get('TEST_GCE_ZONE', 'us-central1-f'),
-        help='The GCE zone to test generated instances in (when managing GCE).'
-             ' This implies the GCE region as well.')
+        builder.add_argument(
+            "--test_gce_zone",
+            default=defaults.get("TEST_GCE_ZONE", "us-central1-f"),
+            help="The GCE zone to test generated instances in (when managing GCE)."
+            " This implies the GCE region as well.",
+        )
 
-    #
-    # Observer Parameters
-    #
-    builder.add_argument(
-        '--managed_gce_project', dest='google_primary_managed_project_id',
-        help='GCE project to test instances in (when managing GCE).')
+        #
+        # Observer Parameters
+        #
+        builder.add_argument(
+            "--managed_gce_project",
+            dest="google_primary_managed_project_id",
+            help="GCE project to test instances in (when managing GCE).",
+        )
 
-    builder.add_argument(
-        '--gce_credentials_path',
-        default=defaults.get('GCE_CREDENTIALS_PATH', None),
-        help='A path to the JSON file with credentials to use for observing'
-             ' tests run against Google Cloud Platform.')
+        builder.add_argument(
+            "--gce_credentials_path",
+            default=defaults.get("GCE_CREDENTIALS_PATH", None),
+            help="A path to the JSON file with credentials to use for observing"
+            " tests run against Google Cloud Platform.",
+        )
 
-    #
-    # Debugging Parameters
-    #
-    builder.add_argument(
-        '--record_gcp_resource_usage',
-        default=defaults.get(
-            'RECORD_GCP_RESOURCE_USAGE',
-            os.environ.get('RECORD_GCP_RESOURCE_USAGE', '').lower() == 'true'),
-        help='Record difference in GCP resources observed before and after'
-        ' test. Tests should be run in isolation to interpret literally.')
-    builder.add_argument(
-        '--gcp_resource_usage_log_path',
-        default=defaults.get(
-            'GCP_RESOURCE_USAGE_LOG_PATH',
-            os.environ.get('GCP_RESOURCE_USAGE_LOG_PATH', '') or None),
-        help='Append resource usage summaries into the file at path.')
+        #
+        # Debugging Parameters
+        #
+        builder.add_argument(
+            "--record_gcp_resource_usage",
+            default=defaults.get(
+                "RECORD_GCP_RESOURCE_USAGE",
+                os.environ.get("RECORD_GCP_RESOURCE_USAGE", "").lower() == "true",
+            ),
+            help="Record difference in GCP resources observed before and after"
+            " test. Tests should be run in isolation to interpret literally.",
+        )
+        builder.add_argument(
+            "--gcp_resource_usage_log_path",
+            default=defaults.get(
+                "GCP_RESOURCE_USAGE_LOG_PATH",
+                os.environ.get("GCP_RESOURCE_USAGE_LOG_PATH", "") or None,
+            ),
+            help="Append resource usage summaries into the file at path.",
+        )
 
-  def _make_observer(self):
-    """Implements BaseScenarioPlatformSupport interface."""
-    bindings = self.scenario.bindings
-    if not bindings.get('GOOGLE_PRIMARY_MANAGED_PROJECT_ID'):
-      raise ValueError('There is no "google_primary_managed_project_id"')
+    def _make_observer(self):
+        """Implements BaseScenarioPlatformSupport interface."""
+        bindings = self.scenario.bindings
+        if not bindings.get("GOOGLE_PRIMARY_MANAGED_PROJECT_ID"):
+            raise ValueError('There is no "google_primary_managed_project_id"')
 
-    return gcp.GcpComputeAgent.make_agent(
-        scopes=gcp.COMPUTE_READ_WRITE_SCOPE,
-        credentials_path=bindings['GCE_CREDENTIALS_PATH'],
-        default_variables={
-            'project': bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID'],
-            'region': bindings['TEST_GCE_REGION'],
-            'zone': bindings['TEST_GCE_ZONE']
-            })
+        return gcp.GcpComputeAgent.make_agent(
+            scopes=gcp.COMPUTE_READ_WRITE_SCOPE,
+            credentials_path=bindings["GCE_CREDENTIALS_PATH"],
+            default_variables={
+                "project": bindings["GOOGLE_PRIMARY_MANAGED_PROJECT_ID"],
+                "region": bindings["TEST_GCE_REGION"],
+                "zone": bindings["TEST_GCE_ZONE"],
+            },
+        )
 
-  def __init__(self, scenario):
-    """Constructor.
+    def __init__(self, scenario):
+        """Constructor.
 
-    Args:
-      scenario: [SpinnakerTestScenario] The scenario being supported.
-    """
-    super(GoogleScenarioSupport, self).__init__("google", scenario)
-    bindings = scenario.bindings
+        Args:
+          scenario: [SpinnakerTestScenario] The scenario being supported.
+        """
+        super(GoogleScenarioSupport, self).__init__("google", scenario)
+        bindings = scenario.bindings
 
-    if not bindings['TEST_GCE_ZONE']:
-      bindings['TEST_GCE_ZONE'] = bindings['GCE_ZONE']
+        if not bindings["TEST_GCE_ZONE"]:
+            bindings["TEST_GCE_ZONE"] = bindings["GCE_ZONE"]
 
-    if not bindings.get('TEST_GCE_REGION', ''):
-      bindings['TEST_GCE_REGION'] = bindings['TEST_GCE_ZONE'][:-2]
+        if not bindings.get("TEST_GCE_REGION", ""):
+            bindings["TEST_GCE_REGION"] = bindings["TEST_GCE_ZONE"][:-2]
 
-    if not bindings.get('GOOGLE_PRIMARY_MANAGED_PROJECT_ID'):
-      # Default to the project we are managing.
-      bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID'] = (
-          scenario.agent.deployed_config.get(
-              'providers.google.primaryCredentials.project', None))
-      if not bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID']:
-        # But if that wasnt defined then default to the subsystem's project.
-        bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID'] = bindings['GCE_PROJECT']
-
+        if not bindings.get("GOOGLE_PRIMARY_MANAGED_PROJECT_ID"):
+            # Default to the project we are managing.
+            bindings[
+                "GOOGLE_PRIMARY_MANAGED_PROJECT_ID"
+            ] = scenario.agent.deployed_config.get(
+                "providers.google.primaryCredentials.project", None
+            )
+            if not bindings["GOOGLE_PRIMARY_MANAGED_PROJECT_ID"]:
+                # But if that wasnt defined then default to the subsystem's project.
+                bindings["GOOGLE_PRIMARY_MANAGED_PROJECT_ID"] = bindings["GCE_PROJECT"]
 
 
 GcpApiResourceList = collections.namedtuple(
-    'GcpApiResourceList', ['resource_list', 'errors'])
+    "GcpApiResourceList", ["resource_list", "errors"]
+)
 
 GcpResourceUsage = collections.namedtuple(
-    'GcpResourceUsage',
-    ['project_quota', 'region_quota', 'api_resource_list_map'])
+    "GcpResourceUsage", ["project_quota", "region_quota", "api_resource_list_map"]
+)
 
 
 class GcpResourceUsageAnalyzer(object):
-  """A nonstandard class for inspecting Google Quota and Resources.
+    """A nonstandard class for inspecting Google Quota and Resources.
 
-     This isnt for testing, rather is for analyzing the tests to help
-     deterimine the quota requirements needed to run them so that we
-     can orchestrate their execution consistent with the quota available.
-  """
+    This isnt for testing, rather is for analyzing the tests to help
+    deterimine the quota requirements needed to run them so that we
+    can orchestrate their execution consistent with the quota available.
+    """
 
-  @property
-  def running_quota(self):
-    """Return map of cumulative sum of diffed quota values seen so far."""
-    return self.__running_quota
+    @property
+    def running_quota(self):
+        """Return map of cumulative sum of diffed quota values seen so far."""
+        return self.__running_quota
 
-  @property
-  def max_quota(self):
-    """Return map of max running quota values seen for each region."""
-    return self.__max_quota
+    @property
+    def max_quota(self):
+        """Return map of max running quota values seen for each region."""
+        return self.__max_quota
 
-  def __init__(self, scenario):
-    self.__running_quota = {}
-    self.__max_quota = {}
-    self.__scenario = scenario
-    self.__log_path = None
-    if scenario.bindings.get('RECORD_GCP_RESOURCE_USAGE'):
-      self.__log_path = scenario.bindings.get('GCP_RESOURCE_USAGE_LOG_PATH')
-    self.__to_log_path('\n{now}\n{decorator}  {scenario} in {main}  {decorator}'.format(
-        now=datetime.datetime.now(),
-        decorator='*' * 5,
-        scenario=scenario.__class__.__name__,
-        main=os.path.splitext(os.path.basename(__main__.__file__))[0]))
-    atexit.register(self.__log_quota_summary)
+    def __init__(self, scenario):
+        self.__running_quota = {}
+        self.__max_quota = {}
+        self.__scenario = scenario
+        self.__log_path = None
+        if scenario.bindings.get("RECORD_GCP_RESOURCE_USAGE"):
+            self.__log_path = scenario.bindings.get("GCP_RESOURCE_USAGE_LOG_PATH")
+        self.__to_log_path(
+            "\n{now}\n{decorator}  {scenario} in {main}  {decorator}".format(
+                now=datetime.datetime.now(),
+                decorator="*" * 5,
+                scenario=scenario.__class__.__name__,
+                main=os.path.splitext(os.path.basename(__main__.__file__))[0],
+            )
+        )
+        atexit.register(self.__log_quota_summary)
 
-  def __log_quota_summary(self):
-    self.__to_log_path(
-        '--- FINAL RUNNING QUOTA --',
-        detail=json.JSONEncoder(
-            indent=2, separators=(',', ': ')).encode(self.__running_quota),
-        indent=2)
-    self.__to_log_path(
-        '--- MAX FIXTURE QUOTA --',
-        detail=json.JSONEncoder(
-            indent=2, separators=(',', ': ')).encode(self.__max_quota),
-        indent=2)
+    def __log_quota_summary(self):
+        self.__to_log_path(
+            "--- FINAL RUNNING QUOTA --",
+            detail=json.JSONEncoder(indent=2, separators=(",", ": ")).encode(
+                self.__running_quota
+            ),
+            indent=2,
+        )
+        self.__to_log_path(
+            "--- MAX FIXTURE QUOTA --",
+            detail=json.JSONEncoder(indent=2, separators=(",", ": ")).encode(
+                self.__max_quota
+            ),
+            indent=2,
+        )
 
-  def __to_log_path(self, heading, detail=None, indent=0):
-    if self.__log_path:
-      padding = '  ' * indent
-      with open(self.__log_path, 'a') as fd:
-        fd.write('%s%s\n' % (padding, heading))
-        if detail:
-          padding += '  '
-          fd.write('%s%s\n' % (padding, detail.replace('\n', '\n' + padding)))
+    def __to_log_path(self, heading, detail=None, indent=0):
+        if self.__log_path:
+            padding = "  " * indent
+            with open(self.__log_path, "a") as fd:
+                fd.write("%s%s\n" % (padding, heading))
+                if detail:
+                    padding += "  "
+                    fd.write("%s%s\n" % (padding, detail.replace("\n", "\n" + padding)))
 
-  def make_gcp_api_scanner(self, project, credentials_path,
-                           include_apis=None, exclude_apis=None):
-    """Create a GcpApiScanner for the given project and credentials."""
-    builder = ApiInvestigatorBuilder()
-    builder.include_apis = include_apis or ['compute']
-    builder.exclude_apis = exclude_apis or ['compute.*Operations']
-    investigator = builder.build()
+    def make_gcp_api_scanner(
+        self, project, credentials_path, include_apis=None, exclude_apis=None
+    ):
+        """Create a GcpApiScanner for the given project and credentials."""
+        builder = ApiInvestigatorBuilder()
+        builder.include_apis = include_apis or ["compute"]
+        builder.exclude_apis = exclude_apis or ["compute.*Operations"]
+        investigator = builder.build()
 
-    default_variables = {'project': project}
-    return ApiResourceScanner(investigator, credentials_path,
-                              default_variables=default_variables)
+        default_variables = {"project": project}
+        return ApiResourceScanner(
+            investigator, credentials_path, default_variables=default_variables
+        )
 
-  def collect_resource_usage(self, gcp_agent, scanner, apis=None):
-    """Returns current GcpResourceUsage"""
+    def collect_resource_usage(self, gcp_agent, scanner, apis=None):
+        """Returns current GcpResourceUsage"""
 
-    def extract_quota(region_info):
-      return {info['metric']: info['usage'] for info in region_info['quotas']}
+        def extract_quota(region_info):
+            return {info["metric"]: info["usage"] for info in region_info["quotas"]}
 
-    apis = apis or ['compute']
-    item_filter = lambda item: True
-    context = ExecutionContext()
+        apis = apis or ["compute"]
+        item_filter = lambda item: True
+        context = ExecutionContext()
 
-    project_quota = extract_quota(gcp_agent.invoke_resource(
-        context, 'get', 'projects'))
+        project_quota = extract_quota(
+            gcp_agent.invoke_resource(context, "get", "projects")
+        )
 
-    region_info = gcp_agent.invoke_resource(context, 'list', 'regions')
-    region_quota = {elem['name']: extract_quota(elem)
-                    for elem in region_info['items']}
+        region_info = gcp_agent.invoke_resource(context, "list", "regions")
+        region_quota = {
+            elem["name"]: extract_quota(elem) for elem in region_info["items"]
+        }
 
-    api_resource_list_map = {}
-    for api in apis:
-      resources, errs = scanner.list_api(api, item_filter=item_filter)
-      api_resource_list_map[api] = GcpApiResourceList(resources, errs)
+        api_resource_list_map = {}
+        for api in apis:
+            resources, errs = scanner.list_api(api, item_filter=item_filter)
+            api_resource_list_map[api] = GcpApiResourceList(resources, errs)
 
-    return GcpResourceUsage(project_quota, region_quota, api_resource_list_map)
+        return GcpResourceUsage(project_quota, region_quota, api_resource_list_map)
 
-  def log_delta_resource_usage(self, test_case, scanner, before, after):
-    """Log quota usage and instances affected."""
-    before_region = dict(before.region_quota)
-    before_region['global'] = before.project_quota
+    def log_delta_resource_usage(self, test_case, scanner, before, after):
+        """Log quota usage and instances affected."""
+        before_region = dict(before.region_quota)
+        before_region["global"] = before.project_quota
 
-    after_region = dict(after.region_quota)
-    after_region['global'] = after.project_quota
+        after_region = dict(after.region_quota)
+        after_region["global"] = after.project_quota
 
-    before_resources = {}
-    after_resources = {}
-    for api in before.api_resource_list_map.keys():
-      before_resources[api] = before.api_resource_list_map[api].resource_list
-      after_resources[api] = after.api_resource_list_map[api].resource_list
+        before_resources = {}
+        after_resources = {}
+        for api in before.api_resource_list_map.keys():
+            before_resources[api] = before.api_resource_list_map[api].resource_list
+            after_resources[api] = after.api_resource_list_map[api].resource_list
 
-    api_diff = ApiDiff.make_api_resources_diff_map(
-        scanner, before_resources, after_resources)
+        api_diff = ApiDiff.make_api_resources_diff_map(
+            scanner, before_resources, after_resources
+        )
 
-    self.__to_log_path('\nTEST: %s' % test_case.title, indent=1)
-    self.__log_delta_quota(before_region, after_region)
-    self.__log_api_diff(api_diff)
+        self.__to_log_path("\nTEST: %s" % test_case.title, indent=1)
+        self.__log_delta_quota(before_region, after_region)
+        self.__log_api_diff(api_diff)
 
-  def __update_running_quota(self, diff):
-    for region, delta in diff.items():
-      max_region = self.__max_quota.get(region, {})
-      running_region = self.__running_quota.get(region, {})
-      for name, value in delta.items():
-        before = running_region.get(name, 0)
-        after = before + value
-        running_region[name] = after
-        max_region[name] = max(after, max_region.get(name, 0))
-      self.__running_quota[region] = running_region
-      self.__max_quota[region] = max_region
+    def __update_running_quota(self, diff):
+        for region, delta in diff.items():
+            max_region = self.__max_quota.get(region, {})
+            running_region = self.__running_quota.get(region, {})
+            for name, value in delta.items():
+                before = running_region.get(name, 0)
+                after = before + value
+                running_region[name] = after
+                max_region[name] = max(after, max_region.get(name, 0))
+            self.__running_quota[region] = running_region
+            self.__max_quota[region] = max_region
 
-  def __log_delta_quota(self, before, after):
-    if before == after:
-      logging.info('No GCP quota impact.')
-      return
+    def __log_delta_quota(self, before, after):
+        if before == after:
+            logging.info("No GCP quota impact.")
+            return
 
-    diff = {}
-    for region in after.keys():
-      before_quota = before.get(region, {})
-      after_quota = after.get(region, {})
-      if before_quota == after_quota:
-        continue
-      delta = {metric: after_quota[metric] - before_quota[metric]
-               for metric in after_quota.keys()
-               if after_quota.get(metric) != before_quota.get(metric)}
-      if delta:
-        diff[region] = delta
+        diff = {}
+        for region in after.keys():
+            before_quota = before.get(region, {})
+            after_quota = after.get(region, {})
+            if before_quota == after_quota:
+                continue
+            delta = {
+                metric: after_quota[metric] - before_quota[metric]
+                for metric in after_quota.keys()
+                if after_quota.get(metric) != before_quota.get(metric)
+            }
+            if delta:
+                diff[region] = delta
 
-    self.__update_running_quota(diff)
-    self.__to_log_path(
-        '--- QUOTA ---',
-        detail=json.JSONEncoder(indent=2, separators=(',', ': ')).encode(diff),
-        indent=2)
-    JournalLogger.journal_or_log_detail('GCP Quota Impact',
-                                        str(diff), format='json')
+        self.__update_running_quota(diff)
+        self.__to_log_path(
+            "--- QUOTA ---",
+            detail=json.JSONEncoder(indent=2, separators=(",", ": ")).encode(diff),
+            indent=2,
+        )
+        JournalLogger.journal_or_log_detail(
+            "GCP Quota Impact", str(diff), format="json"
+        )
 
-  def __log_api_diff(self, api_diff):
-    text_list = []
-    for api, diff in api_diff.items():
-      added = diff.to_instances_added()
-      removed = diff.to_instances_removed()
-      if not (added or removed):
-        continue
-      text_list.append(api + ' Changes:')
-      if added:
-        text_list.append('+ ADDED:')
-        for resource, instances in added.items():
-          text_list.append('  %s' % resource)
-          text_list.extend(['  - {!r}'.format(name) for name in instances])
+    def __log_api_diff(self, api_diff):
+        text_list = []
+        for api, diff in api_diff.items():
+            added = diff.to_instances_added()
+            removed = diff.to_instances_removed()
+            if not (added or removed):
+                continue
+            text_list.append(api + " Changes:")
+            if added:
+                text_list.append("+ ADDED:")
+                for resource, instances in added.items():
+                    text_list.append("  %s" % resource)
+                    text_list.extend(["  - {!r}".format(name) for name in instances])
 
-      if removed:
-        text_list.append('- REMOVED:')
-        for resource, instances in removed.items():
-          text_list.append('  %s' % resource)
-          text_list.extend(['  - {!r}'.format(name) for name in instances])
+            if removed:
+                text_list.append("- REMOVED:")
+                for resource, instances in removed.items():
+                    text_list.append("  %s" % resource)
+                    text_list.extend(["  - {!r}".format(name) for name in instances])
 
-    self.__to_log_path('--- RESOURCES ---',
-                       detail='\n'.join(text_list) if text_list else 'None',
-                       indent=2)
+        self.__to_log_path(
+            "--- RESOURCES ---",
+            detail="\n".join(text_list) if text_list else "None",
+            indent=2,
+        )
 
-    if text_list:
-      JournalLogger.journal_or_log_detail(
-          'GCP Resource Impact', '\n'.join(text_list), format='pre')
-    else:
-      logging.info('No GCP resource impact')
+        if text_list:
+            JournalLogger.journal_or_log_detail(
+                "GCP Resource Impact", "\n".join(text_list), format="pre"
+            )
+        else:
+            logging.info("No GCP resource impact")

--- a/testing/citest/spinnaker_testing/jenkins_agent.py
+++ b/testing/citest/spinnaker_testing/jenkins_agent.py
@@ -222,9 +222,8 @@ class BaseJenkinsOperation(base_agent.AgentOperation):
     status = self._do_execute(agent)
     agent.logger.debug('Returning status %s', status)
     return status
-
   def _do_execute(self, agent):
-    raise UnimplementedError('{0}._do_execute'.format(type(self)))
+    raise NotImplementedError("{0}._do_execute".format(type(self)))
 
 
 class JenkinsTriggerOperation(BaseJenkinsOperation):

--- a/testing/citest/spinnaker_testing/jenkins_agent.py
+++ b/testing/citest/spinnaker_testing/jenkins_agent.py
@@ -15,251 +15,281 @@
 
 import os
 
-from citest.service_testing import (base_agent, http_agent)
+from citest.service_testing import base_agent, http_agent
 
 
 class JenkinsOperationStatus(base_agent.AgentOperationStatus):
-  """Specialization of AgentOperationStatus for Jenkins operations.
+    """Specialization of AgentOperationStatus for Jenkins operations.
 
-  Jenkins operations are interesting to the effect that we use them to
-  trigger steps in other services, meaning the status of Jenkins operation
-  depends often on the status of another endpoint. To achieve this,
-  this status class is effectively a wrapper around a second agent/status
-  pair which collect information on the action resulting from the Jenkins
-  trigger.
-  """
-  @property
-  def id(self):
-    return self.__trigger_status.id
-
-  @property
-  def finished(self):
-    return self.__trigger_status.finished
-
-  @property
-  def finished_ok(self):
-    return self.__trigger_status.finished_ok
-
-  @property
-  def detail(self):
-    return self.__trigger_status.detail
-
-  @property
-  def error(self):
-    return self.__trigger_status.error
-
-  @property
-  def trigger_status(self):
+    Jenkins operations are interesting to the effect that we use them to
+    trigger steps in other services, meaning the status of Jenkins operation
+    depends often on the status of another endpoint. To achieve this,
+    this status class is effectively a wrapper around a second agent/status
+    pair which collect information on the action resulting from the Jenkins
+    trigger.
     """
-    The endpoint where the status of the Jenkins operation can be found.
-    """
-    return self.__trigger_status
 
-  @property
-  def timed_out(self):
-    return self.__trigger_status.timed_out
+    @property
+    def id(self):
+        return self.__trigger_status.id
 
-  def refresh(self):
-    return self.__trigger_status.refresh()
+    @property
+    def finished(self):
+        return self.__trigger_status.finished
 
-  def __init__(self, operation, status_class, path, http_response):
-    """Constructs a JenkinsOperationStatus object.
+    @property
+    def finished_ok(self):
+        return self.__trigger_status.finished_ok
 
-    Args:
-      operation [BaseJenkinsOperation]: The Jenkins operation that this is for.
-      status_class [AgentOperationClass]: The status class used to monitor the
-          action that the jenkins trigger kicked off.
-      path [string]: The path the trigger_status should poll on.
-      http_response [HttpResponseType]: Response given by Jenkins to the
-        trigger.
-    """
-    super(JenkinsOperationStatus, self).__init__(operation)
-    self.__trigger_status = status_class(operation, http_response)
-    self.__trigger_status._bind_id("n/a for synchronous request")
-    self.__trigger_status._bind_detail_path(path)
+    @property
+    def detail(self):
+        return self.__trigger_status.detail
 
-  def __cmp__(self, response):
-    return self.__trigger_status.__cmp__(response.__trigger_status)
+    @property
+    def error(self):
+        return self.__trigger_status.error
 
-  def __str__(self):
-    return 'jenkins_trigger_status={0}'.format(self.__trigger_status)
+    @property
+    def trigger_status(self):
+        """
+        The endpoint where the status of the Jenkins operation can be found.
+        """
+        return self.__trigger_status
 
-  def export_summary_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotableEntity interface."""
-    super(JenkinsOperationStatus, self).export_summary_to_json_snapshot(
-        snapshot, entity)
-    trigger_status = self.__trigger_status
-    trigger_status_summary = snapshot.make_entity_for_object_summary(
-        self.__trigger_status)
-    detail_doc = trigger_status.detail_doc
-    status_status = detail_doc[0].get('status') if detail_doc else None
-    relation = ('VALID' if status_status == 'SUCCEEDED'
-                else 'INVALID' if status_status == 'TERMINAL'
-                else None)
-    snapshot.edge_builder.make(
-        entity, 'Trigger Status', trigger_status_summary, relation=relation)
+    @property
+    def timed_out(self):
+        return self.__trigger_status.timed_out
 
-  def export_to_json_snapshot(self, snapshot, entity):
-    snapshot.edge_builder.make_output(
-        entity, 'Trigger Status', self.__trigger_status)
-    super(JenkinsOperationStatus, self).export_to_json_snapshot(
-        snapshot, entity)
+    def refresh(self):
+        return self.__trigger_status.refresh()
+
+    def __init__(self, operation, status_class, path, http_response):
+        """Constructs a JenkinsOperationStatus object.
+
+        Args:
+          operation [BaseJenkinsOperation]: The Jenkins operation that this is for.
+          status_class [AgentOperationClass]: The status class used to monitor the
+              action that the jenkins trigger kicked off.
+          path [string]: The path the trigger_status should poll on.
+          http_response [HttpResponseType]: Response given by Jenkins to the
+            trigger.
+        """
+        super(JenkinsOperationStatus, self).__init__(operation)
+        self.__trigger_status = status_class(operation, http_response)
+        self.__trigger_status._bind_id("n/a for synchronous request")
+        self.__trigger_status._bind_detail_path(path)
+
+    def __cmp__(self, response):
+        return self.__trigger_status.__cmp__(response.__trigger_status)
+
+    def __str__(self):
+        return "jenkins_trigger_status={0}".format(self.__trigger_status)
+
+    def export_summary_to_json_snapshot(self, snapshot, entity):
+        """Implements JsonSnapshotableEntity interface."""
+        super(JenkinsOperationStatus, self).export_summary_to_json_snapshot(
+            snapshot, entity
+        )
+        trigger_status = self.__trigger_status
+        trigger_status_summary = snapshot.make_entity_for_object_summary(
+            self.__trigger_status
+        )
+        detail_doc = trigger_status.detail_doc
+        status_status = detail_doc[0].get("status") if detail_doc else None
+        relation = (
+            "VALID"
+            if status_status == "SUCCEEDED"
+            else "INVALID"
+            if status_status == "TERMINAL"
+            else None
+        )
+        snapshot.edge_builder.make(
+            entity, "Trigger Status", trigger_status_summary, relation=relation
+        )
+
+    def export_to_json_snapshot(self, snapshot, entity):
+        snapshot.edge_builder.make_output(
+            entity, "Trigger Status", self.__trigger_status
+        )
+        super(JenkinsOperationStatus, self).export_to_json_snapshot(snapshot, entity)
 
 
 class JenkinsAgent(base_agent.BaseAgent):
-  """A specialization of BaseAgent for interacting with Jenkins."""
-  def __init__(self, baseUrl, auth_path, owner_agent, logger=None, max_wait_secs=780):
-    super(JenkinsAgent, self).__init__(logger=logger)
-    self.__http_agent = http_agent.HttpAgent(baseUrl)
-    self.__owner_agent = owner_agent
+    """A specialization of BaseAgent for interacting with Jenkins."""
 
-    # Set the timeout for waiting on operations.  The default of 13 minutes
-    # (set in the parameter list above) is arbitrary; the current test takes
-    # around 6-7 minutes end-to-end. Other use cases might make it more clear
-    # what this should be.
-    self.default_max_wait_secs = max_wait_secs
+    def __init__(self, baseUrl, auth_path, owner_agent, logger=None, max_wait_secs=780):
+        super(JenkinsAgent, self).__init__(logger=logger)
+        self.__http_agent = http_agent.HttpAgent(baseUrl)
+        self.__owner_agent = owner_agent
 
-    # pylint: disable=bad-indentation
-    if auth_path is None:
-        auth_info = [os.environ.get('JENKINS_USER', None),
-                     os.environ.get('JENKINS_PASSWORD', None)]
-        if auth_info[0] is None or auth_info[1] is None:
-          raise ValueError(
-              'You must either supply --jenkins_auth_path'
-              ' or JENKINS_USER and JENKINS_PASSWORD environment variables.')
-    else:
-        with open(auth_path, 'r') as f:
-          auth_info = bytes.decode(f.read()).split()
+        # Set the timeout for waiting on operations.  The default of 13 minutes
+        # (set in the parameter list above) is arbitrary; the current test takes
+        # around 6-7 minutes end-to-end. Other use cases might make it more clear
+        # what this should be.
+        self.default_max_wait_secs = max_wait_secs
 
-          if len(auth_info) != 2:
-            raise ValueError(
-                '--jenkins_auth_path={path} is not in the correct '
-                'format. You must supply a file with the contents '
-                '<username> <password'
-                .format(path=auth_path))
+        # pylint: disable=bad-indentation
+        if auth_path is None:
+            auth_info = [
+                os.environ.get("JENKINS_USER", None),
+                os.environ.get("JENKINS_PASSWORD", None),
+            ]
+            if auth_info[0] is None or auth_info[1] is None:
+                raise ValueError(
+                    "You must either supply --jenkins_auth_path"
+                    " or JENKINS_USER and JENKINS_PASSWORD environment variables."
+                )
+        else:
+            with open(auth_path, "r") as f:
+                auth_info = bytes.decode(f.read()).split()
 
-    self.__http_agent.add_basic_auth_header(auth_info[0], auth_info[1])
+                if len(auth_info) != 2:
+                    raise ValueError(
+                        "--jenkins_auth_path={path} is not in the correct "
+                        "format. You must supply a file with the contents "
+                        "<username> <password".format(path=auth_path)
+                    )
 
-  def get(self, path):
-    return self.__owner_agent.get(path)
+        self.__http_agent.add_basic_auth_header(auth_info[0], auth_info[1])
 
-  def _trigger_jenkins_build(self, job, token):
-    jenkins_path = 'job/{job}/build/?token={token}'.format(job=job,
-                                                           token=token)
-    self.logger.info('Triggering Jenkins %s', jenkins_path)
-    result = self.__http_agent.get(jenkins_path)
-    result.check_ok()
-    return result
+    def get(self, path):
+        return self.__owner_agent.get(path)
 
-  def export_to_json_snapshot(self, snapshot, entity):
-    snapshot.edge_builder.make_control(
-        entity, 'baseUrl', self.__http_agent.base_url)
-    super(JenkinsAgent, self).export_to_json_snapshot(snapshot, entity)
+    def _trigger_jenkins_build(self, job, token):
+        jenkins_path = "job/{job}/build/?token={token}".format(job=job, token=token)
+        self.logger.info("Triggering Jenkins %s", jenkins_path)
+        result = self.__http_agent.get(jenkins_path)
+        result.check_ok()
+        return result
 
-  def new_jenkins_trigger_operation(self, title, job, token, status_class,
-                                    status_path, **kwargs):
-    """Returns a new JenkinsTriggerOperation
+    def export_to_json_snapshot(self, snapshot, entity):
+        snapshot.edge_builder.make_control(
+            entity, "baseUrl", self.__http_agent.base_url
+        )
+        super(JenkinsAgent, self).export_to_json_snapshot(snapshot, entity)
 
-    Args:
-      title [string]: Name of the operation.
-      job [string]: Name of the Jenkins job to trigger.
-      token [string]: Token required for triggering the job.
-      status_class [AgentOperationStatus]: The status object in charge of
-        recording the success of the action resulting from the trigger.
-      status_path [string]: The path the status_class must poll on for
-        success of the trigger.
-      kwargs [kwargs]:  Additional AgentOperation kwargs.
-    """
-    return JenkinsTriggerOperation(
-        title=title, jenkins_agent=self,
-        status_class=status_class, job=job, token=token,
-        status_path=status_path, **kwargs)
+    def new_jenkins_trigger_operation(
+        self, title, job, token, status_class, status_path, **kwargs
+    ):
+        """Returns a new JenkinsTriggerOperation
+
+        Args:
+          title [string]: Name of the operation.
+          job [string]: Name of the Jenkins job to trigger.
+          token [string]: Token required for triggering the job.
+          status_class [AgentOperationStatus]: The status object in charge of
+            recording the success of the action resulting from the trigger.
+          status_path [string]: The path the status_class must poll on for
+            success of the trigger.
+          kwargs [kwargs]:  Additional AgentOperation kwargs.
+        """
+        return JenkinsTriggerOperation(
+            title=title,
+            jenkins_agent=self,
+            status_class=status_class,
+            job=job,
+            token=token,
+            status_path=status_path,
+            **kwargs
+        )
 
 
 class BaseJenkinsOperation(base_agent.AgentOperation):
-  @property
-  def status_class(self):
-    return self.__status_class
+    @property
+    def status_class(self):
+        return self.__status_class
 
-  @property
-  def data(self):
-    return self.__data
+    @property
+    def data(self):
+        return self.__data
 
-  def __init__(self, title, jenkins_agent,
-               status_class=JenkinsOperationStatus, **kwargs):
-    """Construct a BaseJenkinsOperation
+    def __init__(
+        self, title, jenkins_agent, status_class=JenkinsOperationStatus, **kwargs
+    ):
+        """Construct a BaseJenkinsOperation
 
-    Args:
-      title [string]: Name of operation.
-      jenkins_agent [JenkinsAgent]: JenkinsAgent class that has the Jenkins
-        configuration stored.
-      status_class [AgentOperationStatus]: The status class that will
-       confirm success of the action resulting from the Jenkins trigger.
-      kwargs [kwargs]:  Additional AgentOperation constructor kwargs.
-    """
-    super(BaseJenkinsOperation, self).__init__(title, jenkins_agent, **kwargs)
-    if not jenkins_agent or not isinstance(jenkins_agent, JenkinsAgent):
-      raise TypeError('agent not a  JenkinsAgent: '
-                      + jenkins_agent.__class__.__name__)
+        Args:
+          title [string]: Name of operation.
+          jenkins_agent [JenkinsAgent]: JenkinsAgent class that has the Jenkins
+            configuration stored.
+          status_class [AgentOperationStatus]: The status class that will
+           confirm success of the action resulting from the Jenkins trigger.
+          kwargs [kwargs]:  Additional AgentOperation constructor kwargs.
+        """
+        super(BaseJenkinsOperation, self).__init__(title, jenkins_agent, **kwargs)
+        if not jenkins_agent or not isinstance(jenkins_agent, JenkinsAgent):
+            raise TypeError(
+                "agent not a  JenkinsAgent: " + jenkins_agent.__class__.__name__
+            )
 
-    self.__status_class = status_class
-    self.__data = {}
+        self.__status_class = status_class
+        self.__data = {}
 
-  def export_to_json_snapshot(self, snapshot, entity):
-    snapshot.edge_builder.make_mechanism(entity, 'Jenkins Agent', self.agent)
-    # TODO(ewiseblatt): Not sure if this is input or output.
-    snapshot.edge_builder.make_data(
-        entity, 'Payload Data', self.__data, format='json')
-    super(BaseJenkinsOperation, self).export_to_json_snapshot(snapshot, entity)
+    def export_to_json_snapshot(self, snapshot, entity):
+        snapshot.edge_builder.make_mechanism(entity, "Jenkins Agent", self.agent)
+        # TODO(ewiseblatt): Not sure if this is input or output.
+        snapshot.edge_builder.make_data(
+            entity, "Payload Data", self.__data, format="json"
+        )
+        super(BaseJenkinsOperation, self).export_to_json_snapshot(snapshot, entity)
 
-  def execute(self, agent=None):
-    if not self.agent:
-      if not isinstance(agent, JenkinsAgent):
-        raise TypeError('agent not a JenkinsAgent: '
-                        + agent.__class__.__name__)
-      self.bind_agent(agent)
+    def execute(self, agent=None):
+        if not self.agent:
+            if not isinstance(agent, JenkinsAgent):
+                raise TypeError("agent not a JenkinsAgent: " + agent.__class__.__name__)
+            self.bind_agent(agent)
 
-    status = self._do_execute(agent)
-    agent.logger.debug('Returning status %s', status)
-    return status
-  def _do_execute(self, agent):
-    raise NotImplementedError("{0}._do_execute".format(type(self)))
+        status = self._do_execute(agent)
+        agent.logger.debug("Returning status %s", status)
+        return status
+
+    def _do_execute(self, agent):
+        raise NotImplementedError("{0}._do_execute".format(type(self)))
 
 
 class JenkinsTriggerOperation(BaseJenkinsOperation):
-  """Specialization of AgentOperation that triggers a build at the specified
-  project.
-  """
-  def __init__(self, title, jenkins_agent, token, job, status_class,
-               status_path, **kwargs):
-    """Construct a JenkinsTriggerOperation.
-
-    Args:
-      title [string]: Name of the operation.
-      jenkins_agent [JenkinsAgent]: The JenkensAgent class that has the Jenkins
-        configuration stored.
-      job [string]: Name of the Jenkins job to be triggered.
-      token [string]: The token required to trigger the Jenkins job.
-      status_class [AgentOperationClass]: The status class used to monitor the
-          action that the jenkins trigger kicked off.
-      status_path [string]: The path the status should poll for success on.
-      kwargs [kwargs]:  Additional Operation constructor kwargs.
+    """Specialization of AgentOperation that triggers a build at the specified
+    project.
     """
-    super(JenkinsTriggerOperation, self).__init__(
-        jenkins_agent=jenkins_agent, status_class=status_class, title=title,
-        **kwargs)
 
-    self.__token = token
-    self.__job = job
-    self.__status_class = status_class
-    self.__status_path = status_path
+    def __init__(
+        self, title, jenkins_agent, token, job, status_class, status_path, **kwargs
+    ):
+        """Construct a JenkinsTriggerOperation.
 
-  def _do_execute(self, agent):
-    http_response = self.agent._trigger_jenkins_build(job=self.__job,
-                                                      token=self.__token)
-    agent.logger.debug(
-        'Checking for effect of jenkins trigger at url={url}'.format(
-            url=self.__status_path))
+        Args:
+          title [string]: Name of the operation.
+          jenkins_agent [JenkinsAgent]: The JenkensAgent class that has the Jenkins
+            configuration stored.
+          job [string]: Name of the Jenkins job to be triggered.
+          token [string]: The token required to trigger the Jenkins job.
+          status_class [AgentOperationClass]: The status class used to monitor the
+              action that the jenkins trigger kicked off.
+          status_path [string]: The path the status should poll for success on.
+          kwargs [kwargs]:  Additional Operation constructor kwargs.
+        """
+        super(JenkinsTriggerOperation, self).__init__(
+            jenkins_agent=jenkins_agent,
+            status_class=status_class,
+            title=title,
+            **kwargs
+        )
 
-    return JenkinsOperationStatus(
-        self, self.__status_class, self.__status_path, http_response)
+        self.__token = token
+        self.__job = job
+        self.__status_class = status_class
+        self.__status_path = status_path
+
+    def _do_execute(self, agent):
+        http_response = self.agent._trigger_jenkins_build(
+            job=self.__job, token=self.__token
+        )
+        agent.logger.debug(
+            "Checking for effect of jenkins trigger at url={url}".format(
+                url=self.__status_path
+            )
+        )
+
+        return JenkinsOperationStatus(
+            self, self.__status_class, self.__status_path, http_response
+        )

--- a/testing/citest/spinnaker_testing/kato.py
+++ b/testing/citest/spinnaker_testing/kato.py
@@ -23,116 +23,115 @@ import spinnaker_testing.spinnaker as sk
 
 
 class _KatoStatus(sk.SpinnakerStatus):
-  """Specialization of sk.SpinnakerStatus for accessing Kato status."""
+    """Specialization of sk.SpinnakerStatus for accessing Kato status."""
 
-  @classmethod
-  def new(cls, operation, original_response):
-    """Factory method.
+    @classmethod
+    def new(cls, operation, original_response):
+        """Factory method.
 
-    Args:
-      operation: The operation this status is for.
-      original_response: The original JSON string with the status identifier.
+        Args:
+          operation: The operation this status is for.
+          original_response: The original JSON string with the status identifier.
 
-    Returns:
-      sk.SpinnakerStatus for handling status from a Kato request.
-    """
-    return _KatoStatus(operation, original_response)
+        Returns:
+          sk.SpinnakerStatus for handling status from a Kato request.
+        """
+        return _KatoStatus(operation, original_response)
 
-  @property
-  def finished(self):
-    return self.__finished
+    @property
+    def finished(self):
+        return self.__finished
 
-  @property
-  def finished_ok(self):
-    return self.__finished and not self.__failed
+    @property
+    def finished_ok(self):
+        return self.__finished and not self.__failed
 
-  @property
-  def timed_out(self):
-    return False
+    @property
+    def timed_out(self):
+        return False
 
-  def __init__(self, operation, original_response=None):
-    """Construct a new Kato request status.
+    def __init__(self, operation, original_response=None):
+        """Construct a new Kato request status.
 
-    Args:
-      operation: The operation this status is for.
-      original_response: The original JSON string with the status identifier.
-    """
-    super(_KatoStatus, self).__init__(operation, original_response)
+        Args:
+          operation: The operation this status is for.
+          original_response: The original JSON string with the status identifier.
+        """
+        super(_KatoStatus, self).__init__(operation, original_response)
 
-    if not original_response.ok():
-      self.__finished = True
-      self.__failed = True
-      return
+        if not original_response.ok():
+            self.__finished = True
+            self.__failed = True
+            return
 
-    self.__finished = False
-    self.__failed = False
+        self.__finished = False
+        self.__failed = False
 
-    doc = None
-    try:
-      doc = json.JSONDecoder().decode(original_response.output)
-    except ValueError:
-      pass
-    except TypeError:
-      pass
+        doc = None
+        try:
+            doc = json.JSONDecoder().decode(original_response.output)
+        except ValueError:
+            pass
+        except TypeError:
+            pass
 
-    if isinstance(doc, dict):
-      self._bind_detail_path(doc['resourceUri'])
-      self._bind_id(doc['id'])
-    else:
-      self._bind_error('Invalid response="{0}"'.format(original_response))
-      self.__finished = True
-      self.__failed = True
-      self.current_state = 'CITEST_INTERNAL_ERROR'
+        if isinstance(doc, dict):
+            self._bind_detail_path(doc["resourceUri"])
+            self._bind_id(doc["id"])
+        else:
+            self._bind_error('Invalid response="{0}"'.format(original_response))
+            self.__finished = True
+            self.__failed = True
+            self.current_state = "CITEST_INTERNAL_ERROR"
 
-  def _update_response_from_json(self, doc):
-    """Updates abstract SpinnakerStatus attributes from a Kato response.
+    def _update_response_from_json(self, doc):
+        """Updates abstract SpinnakerStatus attributes from a Kato response.
 
-    This is called by the base class.
-    """
-    status = doc['status']
-    failed = status['failed']
-    self.current_state = status['phase']
-    self._bind_exception_details(None)
-    if status['completed']:
-      self.__finished = True
-      self.__failed = failed
-    if failed:
-      self._bind_exception_details(status['status'])
+        This is called by the base class.
+        """
+        status = doc["status"]
+        failed = status["failed"]
+        self.current_state = status["phase"]
+        self._bind_exception_details(None)
+        if status["completed"]:
+            self.__finished = True
+            self.__failed = failed
+        if failed:
+            self._bind_exception_details(status["status"])
 
 
 class KatoAgent(sk.SpinnakerAgent):
-  """Specialization of SpinnakerAgent for Kato subsystem.
+    """Specialization of SpinnakerAgent for Kato subsystem.
 
-  This class just adds convienence methods specific to Kato.
-  """
-
-  @staticmethod
-  def type_to_payload(name, payload_dict):
-    """Make a kato operation JSON payload string.
-
-    Args:
-       name: The kato type name of the payload is used to
-         build a payload dictionary in the form {[name: payload_dict]}.
-       payload_dict: The value of the payload content.
-
-    Returns:
-       JSON encoded payload string for Kato request.
+    This class just adds convienence methods specific to Kato.
     """
-    return KatoAgent.make_json_payload_from_object([{name: payload_dict}])
+
+    @staticmethod
+    def type_to_payload(name, payload_dict):
+        """Make a kato operation JSON payload string.
+
+        Args:
+           name: The kato type name of the payload is used to
+             build a payload dictionary in the form {[name: payload_dict]}.
+           payload_dict: The value of the payload content.
+
+        Returns:
+           JSON encoded payload string for Kato request.
+        """
+        return KatoAgent.make_json_payload_from_object([{name: payload_dict}])
 
 
 def new_agent(bindings, port=7002):
-  """Create agent to interact with a Spinnaker Kato server.
+    """Create agent to interact with a Spinnaker Kato server.
 
-  Args:
-    bindings: Bindings that specify how to connect to the server.
-       The actual parameters used depend on the hosting platform.
-       The hosting platform is specified with 'host_platform'.
-    port: The port the server is listening on.
+    Args:
+      bindings: Bindings that specify how to connect to the server.
+         The actual parameters used depend on the hosting platform.
+         The hosting platform is specified with 'host_platform'.
+      port: The port the server is listening on.
 
-  Returns:
-    sk.SpinnakerAgent connected to the specified kato server, or None.
-  """
-  kato = KatoAgent.new_instance_from_bindings(
-      'kato', _KatoStatus.new, bindings, port)
-  return kato
+    Returns:
+      sk.SpinnakerAgent connected to the specified kato server, or None.
+    """
+    kato = KatoAgent.new_instance_from_bindings("kato", _KatoStatus.new, bindings, port)
+    return kato

--- a/testing/citest/spinnaker_testing/kubernetes_manifests.py
+++ b/testing/citest/spinnaker_testing/kubernetes_manifests.py
@@ -21,146 +21,179 @@ ov_factory = jc.ObservationPredicateFactory()
 """Utilities for producing and manipulating Kubernetes Manifests stored as
 dictionaries"""
 
+
 class KubernetesManifestFactory(object):
-  """Utilities for building Kubernetes Manifests"""
+    """Utilities for building Kubernetes Manifests"""
 
-  def __init__(self, scenario):
-    self.scenario = scenario
+    def __init__(self, scenario):
+        self.scenario = scenario
 
-  def service(self, name):
-    return {
-        'apiVersion': 'v1',
-        'kind': 'Service',
-        'metadata': {
-            'name': name,
-            'namespace': self.scenario.TEST_NAMESPACE,
-            'labels': {
-                'app': self.scenario.TEST_APP,
-                'owner': 'citest',
-            }
-        },
-        'spec': {
-            'selector': {
-                'app': self.scenario.TEST_APP,
+    def service(self, name):
+        return {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": name,
+                "namespace": self.scenario.TEST_NAMESPACE,
+                "labels": {
+                    "app": self.scenario.TEST_APP,
+                    "owner": "citest",
+                },
             },
-            'ports': [{
-                'protocol': 'TCP',
-                'port': 80
-            }]
+            "spec": {
+                "selector": {
+                    "app": self.scenario.TEST_APP,
+                },
+                "ports": [{"protocol": "TCP", "port": 80}],
+            },
         }
-    }
 
-  def deployment(self, name, image):
-    return {
-        'apiVersion': 'apps/v1',
-        'kind': 'Deployment',
-        'metadata': {
-            'name': name,
-            'namespace': self.scenario.TEST_NAMESPACE,
-            'labels': {
-                'app': self.scenario.TEST_APP,
-                'owner': 'citest',
-            }
-        },
-        'spec': {
-            'replicas': 1,
-            'selector': {
-                'matchLabels': {
-                    'app': self.scenario.TEST_APP,
-                }
+    def deployment(self, name, image):
+        return {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "name": name,
+                "namespace": self.scenario.TEST_NAMESPACE,
+                "labels": {
+                    "app": self.scenario.TEST_APP,
+                    "owner": "citest",
+                },
             },
-            'template': {
-                'metadata': {
-                    'labels': {
-                        'app': self.scenario.TEST_APP,
-                        'owner': 'citest',
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "matchLabels": {
+                        "app": self.scenario.TEST_APP,
                     }
                 },
-                'spec': {
-                    'containers': [{
-                        'name': 'primary',
-                        'image': image,
-                    }]
-                }
-            }
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "app": self.scenario.TEST_APP,
+                            "owner": "citest",
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "primary",
+                                "image": image,
+                            }
+                        ]
+                    },
+                },
+            },
         }
-    }
 
-  def add_configmap_volume(self, deployment, configmap_name):
-    deployment['spec']['template']['spec']['volumes'] = [{
-      'name': 'test-volume',
-      'configMap': {
-        'name': configmap_name,
-      },
-    }]
-
-  def config_map(self, name, data):
-    return {
-        'apiVersion': 'v1',
-        'kind': 'ConfigMap',
-        'metadata': {
-            'name': name,
-            'namespace': self.scenario.TEST_NAMESPACE,
-            'labels': {
-                'app': self.scenario.TEST_APP,
-                'owner': 'citest',
+    def add_configmap_volume(self, deployment, configmap_name):
+        deployment["spec"]["template"]["spec"]["volumes"] = [
+            {
+                "name": "test-volume",
+                "configMap": {
+                    "name": configmap_name,
+                },
             }
-        },
-        'data': data
-    }
+        ]
+
+    def config_map(self, name, data):
+        return {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": name,
+                "namespace": self.scenario.TEST_NAMESPACE,
+                "labels": {
+                    "app": self.scenario.TEST_APP,
+                    "owner": "citest",
+                },
+            },
+            "data": data,
+        }
+
 
 class KubernetesManifestPredicateFactory(object):
-  def config_map_key_value_predicate(self, key, value):
-    return ov_factory.value_list_contains(jp.DICT_MATCHES({
-         'data': jp.DICT_MATCHES({
-             key: jp.STR_EQ(value)
-         })
-     }))
+    def config_map_key_value_predicate(self, key, value):
+        return ov_factory.value_list_contains(
+            jp.DICT_MATCHES({"data": jp.DICT_MATCHES({key: jp.STR_EQ(value)})})
+        )
 
-  def deployment_configmap_mounted_predicate(self, configmap_name):
-    return ov_factory.value_list_contains(jp.DICT_MATCHES({
-         'spec': jp.DICT_MATCHES({
-           'template': jp.DICT_MATCHES({
-             'spec': jp.DICT_MATCHES({
-               'volumes': jp.LIST_MATCHES([jp.DICT_MATCHES({
-                  'configMap': jp.DICT_MATCHES({
-                    'name': jp.STR_SUBSTR(configmap_name)
-                   })
-                 })
-               ])
-             })
-           })
-         }),
-         'status': jp.DICT_MATCHES({
-           'availableReplicas': jp.NUM_GE(1)
-         })
-     }))
+    def deployment_configmap_mounted_predicate(self, configmap_name):
+        return ov_factory.value_list_contains(
+            jp.DICT_MATCHES(
+                {
+                    "spec": jp.DICT_MATCHES(
+                        {
+                            "template": jp.DICT_MATCHES(
+                                {
+                                    "spec": jp.DICT_MATCHES(
+                                        {
+                                            "volumes": jp.LIST_MATCHES(
+                                                [
+                                                    jp.DICT_MATCHES(
+                                                        {
+                                                            "configMap": jp.DICT_MATCHES(
+                                                                {
+                                                                    "name": jp.STR_SUBSTR(
+                                                                        configmap_name
+                                                                    )
+                                                                }
+                                                            )
+                                                        }
+                                                    )
+                                                ]
+                                            )
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    ),
+                    "status": jp.DICT_MATCHES({"availableReplicas": jp.NUM_GE(1)}),
+                }
+            )
+        )
 
-  def service_selector_predicate(self, key, value):
-    return ov_factory.value_list_contains(jp.DICT_MATCHES({
-         'spec': jp.DICT_MATCHES({
-           'selector': jp.DICT_MATCHES({
-             key: jp.STR_EQ(value)
-           })
-         }),
-     }))
+    def service_selector_predicate(self, key, value):
+        return ov_factory.value_list_contains(
+            jp.DICT_MATCHES(
+                {
+                    "spec": jp.DICT_MATCHES(
+                        {"selector": jp.DICT_MATCHES({key: jp.STR_EQ(value)})}
+                    ),
+                }
+            )
+        )
 
-  def deployment_image_predicate(self, image):
-    return ov_factory.value_list_contains(jp.DICT_MATCHES({
-         'spec': jp.DICT_MATCHES({
-           'template': jp.DICT_MATCHES({
-             'spec': jp.DICT_MATCHES({
-               'containers': jp.LIST_MATCHES([
-                 jp.DICT_MATCHES({ 'image': jp.STR_EQ(image) })
-               ])
-             })
-           })
-         }),
-         'status': jp.DICT_MATCHES({
-           'availableReplicas': jp.NUM_GE(1)
-         })
-     }))
+    def deployment_image_predicate(self, image):
+        return ov_factory.value_list_contains(
+            jp.DICT_MATCHES(
+                {
+                    "spec": jp.DICT_MATCHES(
+                        {
+                            "template": jp.DICT_MATCHES(
+                                {
+                                    "spec": jp.DICT_MATCHES(
+                                        {
+                                            "containers": jp.LIST_MATCHES(
+                                                [
+                                                    jp.DICT_MATCHES(
+                                                        {"image": jp.STR_EQ(image)}
+                                                    )
+                                                ]
+                                            )
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    ),
+                    "status": jp.DICT_MATCHES({"availableReplicas": jp.NUM_GE(1)}),
+                }
+            )
+        )
 
-  def not_found_observation_predicate(self, title='Not Found Permitted'):
-    return ov_factory.error_list_contains(st.CliAgentRunErrorPredicate(
-      title=title, error_regex='.* not found'))
+    def not_found_observation_predicate(self, title="Not Found Permitted"):
+        return ov_factory.error_list_contains(
+            st.CliAgentRunErrorPredicate(title=title, error_regex=".* not found")
+        )

--- a/testing/citest/spinnaker_testing/kubernetes_scenario_support.py
+++ b/testing/citest/spinnaker_testing/kubernetes_scenario_support.py
@@ -19,45 +19,47 @@ from spinnaker_testing.base_scenario_support import BaseScenarioPlatformSupport
 
 
 class KubernetesScenarioSupport(BaseScenarioPlatformSupport):
-  """Provides SpinnakerScenarioSupport for Kubernetes."""
+    """Provides SpinnakerScenarioSupport for Kubernetes."""
 
-  @classmethod
-  def add_commandline_parameters(cls, scenario_class, builder, defaults):
-    """Implements BaseScenarioPlatformSupport interface.
+    @classmethod
+    def add_commandline_parameters(cls, scenario_class, builder, defaults):
+        """Implements BaseScenarioPlatformSupport interface.
 
-    Args:
-      scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
-      builder: [citest.base.ConfigBindingsBuilder]
-      defaults: [dict] Default binding value overrides.
-         This is used to initialize the default commandline parameters.
-    """
-    builder.add_argument(
-        '--kube_credentials',
-        dest='spinnaker_kubernetes_account',
-        help='DEPRECATED. Replaced by --spinnaker_kubernetes_account')
+        Args:
+          scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
+          builder: [citest.base.ConfigBindingsBuilder]
+          defaults: [dict] Default binding value overrides.
+             This is used to initialize the default commandline parameters.
+        """
+        builder.add_argument(
+            "--kube_credentials",
+            dest="spinnaker_kubernetes_account",
+            help="DEPRECATED. Replaced by --spinnaker_kubernetes_account",
+        )
 
-    #
-    # Operation Parameters
-    #
-    builder.add_argument(
-        '--spinnaker_kubernetes_account',
-        default=defaults.get('SPINNAKER_KUBERNETES_ACCOUNT', None),
-        help='Spinnaker account name to use for test operations against'
-             ' Kubernetes. Only used when managing jobs running on'
-             ' Kubernetes.')
+        #
+        # Operation Parameters
+        #
+        builder.add_argument(
+            "--spinnaker_kubernetes_account",
+            default=defaults.get("SPINNAKER_KUBERNETES_ACCOUNT", None),
+            help="Spinnaker account name to use for test operations against"
+            " Kubernetes. Only used when managing jobs running on"
+            " Kubernetes.",
+        )
 
-  def _make_observer(self):
-    """Implements BaseScenarioPlatformSupport interface."""
-    bindings = self.scenario.bindings
-    if not bindings.get('SPINNAKER_KUBERNETES_ACCOUNT'):
-      raise ValueError('There is no "spinnaker_kubernetes_account"')
+    def _make_observer(self):
+        """Implements BaseScenarioPlatformSupport interface."""
+        bindings = self.scenario.bindings
+        if not bindings.get("SPINNAKER_KUBERNETES_ACCOUNT"):
+            raise ValueError('There is no "spinnaker_kubernetes_account"')
 
-    return kube.KubeCtlAgent()
+        return kube.KubeCtlAgent()
 
-  def __init__(self, scenario):
-    """Constructor.
+    def __init__(self, scenario):
+        """Constructor.
 
-    Args:
-      scenario: [SpinnakerTestScenario] The scenario being supported.
-    """
-    super(KubernetesScenarioSupport, self).__init__("kubernetes", scenario)
+        Args:
+          scenario: [SpinnakerTestScenario] The scenario being supported.
+        """
+        super(KubernetesScenarioSupport, self).__init__("kubernetes", scenario)

--- a/testing/citest/spinnaker_testing/kubernetes_v2_scenario_support.py
+++ b/testing/citest/spinnaker_testing/kubernetes_v2_scenario_support.py
@@ -19,41 +19,42 @@ from spinnaker_testing.base_scenario_support import BaseScenarioPlatformSupport
 
 
 class KubernetesV2ScenarioSupport(BaseScenarioPlatformSupport):
-  """Provides SpinnakerScenarioSupport for Kubernetes V2."""
+    """Provides SpinnakerScenarioSupport for Kubernetes V2."""
 
-  @classmethod
-  def add_commandline_parameters(cls, scenario_class, builder, defaults):
-    """Implements BaseScenarioPlatformSupport interface.
+    @classmethod
+    def add_commandline_parameters(cls, scenario_class, builder, defaults):
+        """Implements BaseScenarioPlatformSupport interface.
 
-    Args:
-      scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
-      builder: [citest.base.ConfigBindingsBuilder]
-      defaults: [dict] Default binding value overrides.
-         This is used to initialize the default commandline parameters.
-    """
+        Args:
+          scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
+          builder: [citest.base.ConfigBindingsBuilder]
+          defaults: [dict] Default binding value overrides.
+             This is used to initialize the default commandline parameters.
+        """
 
-    #
-    # Operation Parameters
-    #
-    builder.add_argument(
-        '--spinnaker_kubernetes_v2_account',
-        default=defaults.get('SPINNAKER_KUBERNETES_V2_ACCOUNT', None),
-        help='Spinnaker account name to use for test operations against'
-             ' Kubernetes V2. Only used when managing jobs running on'
-             ' Kubernetes.')
+        #
+        # Operation Parameters
+        #
+        builder.add_argument(
+            "--spinnaker_kubernetes_v2_account",
+            default=defaults.get("SPINNAKER_KUBERNETES_V2_ACCOUNT", None),
+            help="Spinnaker account name to use for test operations against"
+            " Kubernetes V2. Only used when managing jobs running on"
+            " Kubernetes.",
+        )
 
-  def _make_observer(self):
-    """Implements BaseScenarioPlatformSupport interface."""
-    bindings = self.scenario.bindings
-    if not bindings.get('SPINNAKER_KUBERNETES_V2_ACCOUNT'):
-      raise ValueError('There is no "spinnaker_kubernetes_v2_account"')
+    def _make_observer(self):
+        """Implements BaseScenarioPlatformSupport interface."""
+        bindings = self.scenario.bindings
+        if not bindings.get("SPINNAKER_KUBERNETES_V2_ACCOUNT"):
+            raise ValueError('There is no "spinnaker_kubernetes_v2_account"')
 
-    return kube.KubeCtlAgent()
+        return kube.KubeCtlAgent()
 
-  def __init__(self, scenario):
-    """Constructor.
+    def __init__(self, scenario):
+        """Constructor.
 
-    Args:
-      scenario: [SpinnakerTestScenario] The scenario being supported.
-    """
-    super(KubernetesV2ScenarioSupport, self).__init__("kubernetes_v2", scenario)
+        Args:
+          scenario: [SpinnakerTestScenario] The scenario being supported.
+        """
+        super(KubernetesV2ScenarioSupport, self).__init__("kubernetes_v2", scenario)

--- a/testing/citest/spinnaker_testing/pipeline_support.py
+++ b/testing/citest/spinnaker_testing/pipeline_support.py
@@ -20,37 +20,48 @@ ov_factory = jc.ObservationPredicateFactory()
 
 """Utilities for producing and running pipelines in test cases"""
 
+
 class PipelineSupport(object):
-  def __init__(self, scenario):
-    self.scenario = scenario
+    def __init__(self, scenario):
+        self.scenario = scenario
 
-  def submit_pipeline_contract(self, name, stages, expectedArtifacts=[], user='anonymous'):
-    s = self.scenario
-    job = {
-        'keepWaitingPipelines': 'false',
-        'application': s.TEST_APP,
-        'name': name,
-        'lastModifiedBy': user,
-        'limitConcurrent': 'true',
-        'parallel': 'true',
-        'stages': stages,
-        'expectedArtifacts': expectedArtifacts,
-    }
-    payload = s.agent.make_json_payload_from_kwargs(**job)
-    expect_match = {key: jp.EQUIVALENT(value)
-                    for key, value in job.items()}
-    expect_match['stages'] = jp.LIST_MATCHES(
-        [jp.DICT_MATCHES({key: jp.EQUIVALENT(value)
-                         for key, value in stage.items()}) for stage in stages])
+    def submit_pipeline_contract(
+        self, name, stages, expectedArtifacts=[], user="anonymous"
+    ):
+        s = self.scenario
+        job = {
+            "keepWaitingPipelines": "false",
+            "application": s.TEST_APP,
+            "name": name,
+            "lastModifiedBy": user,
+            "limitConcurrent": "true",
+            "parallel": "true",
+            "stages": stages,
+            "expectedArtifacts": expectedArtifacts,
+        }
+        payload = s.agent.make_json_payload_from_kwargs(**job)
+        expect_match = {key: jp.EQUIVALENT(value) for key, value in job.items()}
+        expect_match["stages"] = jp.LIST_MATCHES(
+            [
+                jp.DICT_MATCHES(
+                    {key: jp.EQUIVALENT(value) for key, value in stage.items()}
+                )
+                for stage in stages
+            ]
+        )
 
-    builder = st.HttpContractBuilder(s.agent)
-    (builder.new_clause_builder('Has Pipeline',
-                                retryable_for_secs=15)
-     .get_url_path(
-        'applications/{app}/pipelineConfigs'.format(app=s.TEST_APP))
-     .contains_match(expect_match))
-    return st.OperationContract(
-        s.new_post_operation(title='save_pipeline_operation',
-                                data=payload, path='pipelines',
-                                status_class=st.SynchronousHttpOperationStatus),
-        contract=builder.build())
+        builder = st.HttpContractBuilder(s.agent)
+        (
+            builder.new_clause_builder("Has Pipeline", retryable_for_secs=15)
+            .get_url_path("applications/{app}/pipelineConfigs".format(app=s.TEST_APP))
+            .contains_match(expect_match)
+        )
+        return st.OperationContract(
+            s.new_post_operation(
+                title="save_pipeline_operation",
+                data=payload,
+                path="pipelines",
+                status_class=st.SynchronousHttpOperationStatus,
+            ),
+            contract=builder.build(),
+        )

--- a/testing/citest/spinnaker_testing/scrape_spring_config.py
+++ b/testing/citest/spinnaker_testing/scrape_spring_config.py
@@ -22,125 +22,140 @@ import socket
 from json import JSONDecoder
 
 try:
-  from urllib2 import urlopen, Request, HTTPError, URLError
+    from urllib2 import urlopen, Request, HTTPError, URLError
 except ImportError:
-  from urllib.request import urlopen, Request
-  from urllib.error import HTTPError, URLError
+    from urllib.request import urlopen, Request
+    from urllib.error import HTTPError, URLError
 
 from .expression_dict import ExpressionDict
 
 
 def infer(json):
-  """Infer the configuration from the json document.
+    """Infer the configuration from the json document.
 
-  This ordering is to mimick
-  https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html
+    This ordering is to mimick
+    https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html
 
-  Args:
-    json: [dict] A JSON document specifying the configuration.
-        This is assumed to be the result of spinnaker system '/env' URLs
-        that return the configuration information that spring uses.
-  """
-  # Build a dictionary keyed by the different config sources so
-  # that we can look them up later.
-  application_config = {}
-  for name, value in json.items():
-    match = re.match(r'applicationConfig: \[(.+)\](.*)', name)
-    if not match:
-      continue
-    key = match.group(1)
-    decorator = match.group(2) or ''
-    application_config[key + decorator] = value
+    Args:
+      json: [dict] A JSON document specifying the configuration.
+          This is assumed to be the result of spinnaker system '/env' URLs
+          that return the configuration information that spring uses.
+    """
+    # Build a dictionary keyed by the different config sources so
+    # that we can look them up later.
+    application_config = {}
+    for name, value in json.items():
+        match = re.match(r"applicationConfig: \[(.+)\](.*)", name)
+        if not match:
+            continue
+        key = match.group(1)
+        decorator = match.group(2) or ""
+        application_config[key + decorator] = value
 
-  # Load global properties into the dictionary.
-  # The ordering here is lower to higher precedence.
-  expr_dict = ExpressionDict()
-  expr_dict.update(json.get('defaultProperties', {}))
-  expr_dict.update(json.get('systemProperties', {}))
-  expr_dict.update(json.get('systemEnvironment', {}))
+    # Load global properties into the dictionary.
+    # The ordering here is lower to higher precedence.
+    expr_dict = ExpressionDict()
+    expr_dict.update(json.get("defaultProperties", {}))
+    expr_dict.update(json.get("systemProperties", {}))
+    expr_dict.update(json.get("systemEnvironment", {}))
 
-  names = expr_dict['spring.config.name'].split(',')
-  profiles = expr_dict['spring.profiles.active'].split(',')
-  locations = expr_dict['spring.config.location'].split(',')
+    names = expr_dict["spring.config.name"].split(",")
+    profiles = expr_dict["spring.profiles.active"].split(",")
+    locations = expr_dict["spring.config.location"].split(",")
 
-  # Mix in the different profile locations.
-  #
-  # TODO(ewiseblatt):
-  # Actually, this is wrong. We only want one profile.
-  for location in locations:
-    location_names = names if location.endswith('/') else ['']
-    for name in location_names:
-        # pylint: disable=bad-indentation
-        root_filename = 'file:{location}{name}'.format(
-            location=location, name=name)
-        expr_dict.update(
-            application_config.get(root_filename + '.yml', {}))
-        for profile in profiles:
-            key = root_filename + '-' + profile + '.yml'
-            expr_dict.update(application_config.get(key, {}))
+    # Mix in the different profile locations.
+    #
+    # TODO(ewiseblatt):
+    # Actually, this is wrong. We only want one profile.
+    for location in locations:
+        location_names = names if location.endswith("/") else [""]
+        for name in location_names:
+            # pylint: disable=bad-indentation
+            root_filename = "file:{location}{name}".format(location=location, name=name)
+            expr_dict.update(application_config.get(root_filename + ".yml", {}))
+            for profile in profiles:
+                key = root_filename + "-" + profile + ".yml"
+                expr_dict.update(application_config.get(key, {}))
 
-  return expr_dict
+    return expr_dict
 
 
-def scrape_spring_config(url, timeout=60, empty_if_404=True, headers={}, ignore_ssl_cert_verification=False):
-  """Construct a config binding dictionary from a running instance's baseUrl.
+def scrape_spring_config(
+    url, timeout=60, empty_if_404=True, headers={}, ignore_ssl_cert_verification=False
+):
+    """Construct a config binding dictionary from a running instance's baseUrl.
 
-  Args:
-    url: The url to construct from.
-    empty_if_404: With spring boot 1.5.4 resolvedEnv is not visible by default.
-                  If True then tolerate this treating a 404 as being empty.
-    headers: Key value pair of headers to add to the request.
-    ignore_ssl_cert_verification: If True, ignore verifying SSL certification.
+    Args:
+      url: The url to construct from.
+      empty_if_404: With spring boot 1.5.4 resolvedEnv is not visible by default.
+                    If True then tolerate this treating a 404 as being empty.
+      headers: Key value pair of headers to add to the request.
+      ignore_ssl_cert_verification: If True, ignore verifying SSL certification.
 
-  Raises:
-    urlib2.URLError if url is bad.
-  """
-  request = Request(url=url)
+    Raises:
+      urlib2.URLError if url is bad.
+    """
+    request = Request(url=url)
 
-  for key, val in headers.items():
-    request.add_header(key, val)
+    for key, val in headers.items():
+        request.add_header(key, val)
 
-  context = None
-  if ignore_ssl_cert_verification:
-    context = ssl._create_unverified_context()
+    context = None
+    if ignore_ssl_cert_verification:
+        context = ssl._create_unverified_context()
 
-  final_time = time.time() + timeout
-  while True:
-    # Sometimes this is not yet ready, so allow retries
-    try:
-      response = urlopen(request, timeout=min(10, timeout), context=context)
-      break
-    except socket.timeout as ex:
-      logging.info('Failed to scrape %s -- try again in 1s: %s', url, ex)
-      time.sleep(1)
-    except HTTPError as ex:
-      if (ex.code == 401 or ex.code == 404) and empty_if_404:
-        logging.warning('Could not scrape config from url=%s: %s'
-                        '\n  Suppressing this error and returning empty results.',
-                        url, ex)
-        return {}
-      else:
-        logging.exception('Could not scrape config from url=%s: %s'
-                          '\n  Consider reconfiguring the server with: '
-                          ' management.security.enabled: false',
-                          url, ex)
-        raise
-    except URLError as ex:
-      if empty_if_404:
-        logging.warning('Could not scrape config from url=%s: %s'
-                        '\n  Suppressing this error and returning empty results.',
-                        url, ex)
-        return {}
-      else:
-        logging.exception('Could not scrape config from url=%s: %s'
-                          '\n  Consider reconfiguring the server with: '
-                          ' management.security.enabled: false',
-                          url, ex)
-        raise
+    final_time = time.time() + timeout
+    while True:
+        # Sometimes this is not yet ready, so allow retries
+        try:
+            response = urlopen(request, timeout=min(10, timeout), context=context)
+            break
+        except socket.timeout as ex:
+            logging.info("Failed to scrape %s -- try again in 1s: %s", url, ex)
+            time.sleep(1)
+        except HTTPError as ex:
+            if (ex.code == 401 or ex.code == 404) and empty_if_404:
+                logging.warning(
+                    "Could not scrape config from url=%s: %s"
+                    "\n  Suppressing this error and returning empty results.",
+                    url,
+                    ex,
+                )
+                return {}
+            else:
+                logging.exception(
+                    "Could not scrape config from url=%s: %s"
+                    "\n  Consider reconfiguring the server with: "
+                    " management.security.enabled: false",
+                    url,
+                    ex,
+                )
+                raise
+        except URLError as ex:
+            if empty_if_404:
+                logging.warning(
+                    "Could not scrape config from url=%s: %s"
+                    "\n  Suppressing this error and returning empty results.",
+                    url,
+                    ex,
+                )
+                return {}
+            else:
+                logging.exception(
+                    "Could not scrape config from url=%s: %s"
+                    "\n  Consider reconfiguring the server with: "
+                    " management.security.enabled: false",
+                    url,
+                    ex,
+                )
+                raise
 
-  http_code = response.getcode()
-  content = response.read()
-  if http_code < 200 or http_code >= 300:
-    raise ValueError('Invalid HTTP={code} from {url}:\n{msg}'.format(
-        code=http_code, url=url, msg=content))
-  return JSONDecoder().decode(bytes.decode(content))
+    http_code = response.getcode()
+    content = response.read()
+    if http_code < 200 or http_code >= 300:
+        raise ValueError(
+            "Invalid HTTP={code} from {url}:\n{msg}".format(
+                code=http_code, url=url, msg=content
+            )
+        )
+    return JSONDecoder().decode(bytes.decode(content))

--- a/testing/citest/spinnaker_testing/spinnaker.py
+++ b/testing/citest/spinnaker_testing/spinnaker.py
@@ -76,583 +76,616 @@ from .scrape_spring_config import scrape_spring_config
 
 
 def name_value_to_dict(content):
-  """Converts a list of name=value pairs to a dictionary.
+    """Converts a list of name=value pairs to a dictionary.
 
-  Args:
-    content: [string] A list of name=value pairs with one per line.
-             This is blank lines ignored, as is anything to right of '#'.
-  """
-  result = {}
-  for match in re.finditer('^([A-Za-z_][A-Za-z0-9_]*) *= *([^#]*)',
-                           content, re.MULTILINE):
-    result[match.group(1)] = match.group(2).strip()
-  return result
+    Args:
+      content: [string] A list of name=value pairs with one per line.
+               This is blank lines ignored, as is anything to right of '#'.
+    """
+    result = {}
+    for match in re.finditer(
+        "^([A-Za-z_][A-Za-z0-9_]*) *= *([^#]*)", content, re.MULTILINE
+    ):
+        result[match.group(1)] = match.group(2).strip()
+    return result
 
 
 class SpinnakerStatus(service_testing.HttpOperationStatus):
-  """Provides access to Spinnaker's asynchronous task status.
+    """Provides access to Spinnaker's asynchronous task status.
 
-  This class can be used to track an asynchronous task status.
-  It can wait until the task completes, and provide current status state
-  from its bound reference.
-  This instance must explicitly refresh() in order to update its value.
-  It will only poll the server within refresh().
-  """
-  @property
-  def current_state(self):
-    """The value of the JSON "state" field, or None if not known."""
-    return self.__current_state
-
-  @current_state.setter
-  def current_state(self, state):
-    """Updates the current state."""
-    self.__current_state = state
-
-  @property
-  def error(self):
-    """Returns the error, if any."""
-    return self.__error
-
-  def _bind_error(self, error):
-    """Sets the error, if any."""
-    self.__error = error
-
-  @property
-  def exception_details(self):
-    """The exceptions clause from the detail if the task status is an error."""
-    return self.__exception_details
-
-  def _bind_exception_details(self, details):
-    """Sets the exception details."""
-    self.__exception_details = details
-
-  @property
-  def id(self):
-    """The underlying request ID."""
-    return self.__request_id
-
-  def _bind_id(self, request_id):
-    """Bind the request id.
-
-    Args:
-      request_id: [string] The request ID is obtained in the subsystem
-          response.
+    This class can be used to track an asynchronous task status.
+    It can wait until the task completes, and provide current status state
+    from its bound reference.
+    This instance must explicitly refresh() in order to update its value.
+    It will only poll the server within refresh().
     """
-    self.__request_id = request_id
 
-  @property
-  def detail_path(self):
-    return self.__detail_path
+    @property
+    def current_state(self):
+        """The value of the JSON "state" field, or None if not known."""
+        return self.__current_state
 
-  @property
-  def detail_doc(self):
-    return self.__json_doc
+    @current_state.setter
+    def current_state(self, state):
+        """Updates the current state."""
+        self.__current_state = state
 
-  def _bind_detail_path(self, path):
-    """Bind the detail path."""
-    self.__detail_path = path
+    @property
+    def error(self):
+        """Returns the error, if any."""
+        return self.__error
 
-  def export_to_json_snapshot(self, snapshot, entity):
-    super(SpinnakerStatus, self).export_to_json_snapshot(snapshot, entity)
-    snapshot.edge_builder.make_output(entity, 'Status Detail', self.__json_doc,
-                                      format='json')
+    def _bind_error(self, error):
+        """Sets the error, if any."""
+        self.__error = error
 
-  def __init__(self, operation, original_response=None):
-    """Initialize status tracker.
+    @property
+    def exception_details(self):
+        """The exceptions clause from the detail if the task status is an error."""
+        return self.__exception_details
 
-    Args:
-      operation: [AgentOperation]  The operation returning the status.
-      original_response: [HttpResponseType] Contains JSON identifier object
-          returned from the Spinnaker request to track. This can be none to
-          indicate an error making the original request.
-    """
-    super(SpinnakerStatus, self).__init__(operation, original_response)
-    if original_response is not None:
-      # The request ID is typically the response payload.
-      self.__request_id = original_response.output
-    self.__current_state = None  # Last known state (after last refresh()).
-    self.__detail_path = None    # The URL path on spinnaker for this status.
-    self.__exception_details = None
-    self.__error = None
-    self.__json_doc = None
+    def _bind_exception_details(self, details):
+        """Sets the exception details."""
+        self.__exception_details = details
 
-    if not original_response or original_response.http_code is None:
-      self.__current_state = 'REQUEST_FAILED'
-      return
+    @property
+    def id(self):
+        """The underlying request ID."""
+        return self.__request_id
 
-  def __str__(self):
-    """Convert status to string"""
-    return ('id={id} current_state={current}'
-            ' error=[{error}] detail=[{detail}]').format(
-                id=self.id, current=self.__current_state,
-                error=self.error, detail=self.detail)
+    def _bind_id(self, request_id):
+        """Bind the request id.
 
-  def refresh(self):
-    """Refresh the status with the current data from spinnaker."""
-    if self.finished:
-      return
+        Args:
+          request_id: [string] The request ID is obtained in the subsystem
+              response.
+        """
+        self.__request_id = request_id
 
-    http_response = self.agent.get(self.detail_path)
-    try:
-      self.set_http_response(http_response)
-    except BaseException as bex:
-      # TODO(ewiseblatt): 20160122
-      # This is temporary to help track down a transient error.
-      # Normally we dont want to do this because we want to scrub the output.
-      sys.stderr.write('Bad response from agent={0}\n'
-                       'CAUGHT {1}\nRESPONSE: {2}\n'
-                       .format(self.agent, bex, http_response))
-      raise
+    @property
+    def detail_path(self):
+        return self.__detail_path
 
-  def set_http_response(self, http_response):
-    """Updates specialized fields from http_response.
+    @property
+    def detail_doc(self):
+        return self.__json_doc
 
-    Args:
-      http_response: [HttpResponseType] From the last status update.
-    """
-    # super(SpinnakerStatus, self).set_http_response(http_response)
-    if http_response.http_code is None:
-      self.__current_state = 'Unknown'
-      return
+    def _bind_detail_path(self, path):
+        """Bind the detail path."""
+        self.__detail_path = path
 
-    decoder = JSONDecoder()
-    self.__json_doc = decoder.decode(http_response.output)
-    self._update_response_from_json(self.__json_doc)
+    def export_to_json_snapshot(self, snapshot, entity):
+        super(SpinnakerStatus, self).export_to_json_snapshot(snapshot, entity)
+        snapshot.edge_builder.make_output(
+            entity, "Status Detail", self.__json_doc, format="json"
+        )
 
-  def _update_response_from_json(self, doc):
-    """Updates abstract SpinnakerStatus attributes.
+    def __init__(self, operation, original_response=None):
+        """Initialize status tracker.
 
-    This is called by the base class.
+        Args:
+          operation: [AgentOperation]  The operation returning the status.
+          original_response: [HttpResponseType] Contains JSON identifier object
+              returned from the Spinnaker request to track. This can be none to
+              indicate an error making the original request.
+        """
+        super(SpinnakerStatus, self).__init__(operation, original_response)
+        if original_response is not None:
+            # The request ID is typically the response payload.
+            self.__request_id = original_response.output
+        self.__current_state = None  # Last known state (after last refresh()).
+        self.__detail_path = None  # The URL path on spinnaker for this status.
+        self.__exception_details = None
+        self.__error = None
+        self.__json_doc = None
 
-    Args:
-      doc: [dict] JSON document object from response payload.
-    """
-    # pylint: disable=unused-argument
-    raise Exception("_update_response_from_json is not specialized.")
+        if not original_response or original_response.http_code is None:
+            self.__current_state = "REQUEST_FAILED"
+            return
 
+    def __str__(self):
+        """Convert status to string"""
+        return (
+            "id={id} current_state={current}" " error=[{error}] detail=[{detail}]"
+        ).format(
+            id=self.id,
+            current=self.__current_state,
+            error=self.error,
+            detail=self.detail,
+        )
 
-  # helper for producing snapshot json
-  # maps relation to priority when determining outermost from list
-  # We treat None (not started) higher than valid.
-  _RELATION_SCORE = {
-      'VALID': 1,
-      None: 2,
-      'INVALID': 3,
-      'ERROR': 4,
-  }
-  # Inversion of _RELATION_SCORE
-  _SCORE_TO_RELATION = {value: key for key, value in _RELATION_SCORE.items()}
+    def refresh(self):
+        """Refresh the status with the current data from spinnaker."""
+        if self.finished:
+            return
 
-  # Convert standard spinnaker status to citest journal relation qualifier
-  # names.
-  _STATUS_TO_RELATION = {
-      'SUCCEEDED': 'VALID',
-      'TERMINAL': 'INVALID',
-      'NOT_STARTED': None,
-  }
+        http_response = self.agent.get(self.detail_path)
+        try:
+            self.set_http_response(http_response)
+        except BaseException as bex:
+            # TODO(ewiseblatt): 20160122
+            # This is temporary to help track down a transient error.
+            # Normally we dont want to do this because we want to scrub the output.
+            sys.stderr.write(
+                "Bad response from agent={0}\n"
+                "CAUGHT {1}\nRESPONSE: {2}\n".format(self.agent, bex, http_response)
+            )
+            raise
 
-  def _export_status(self, info, builder, entity):
-    """Helper function for writing spinnaker status into SnapshotableEntity.
+    def set_http_response(self, http_response):
+        """Updates specialized fields from http_response.
 
-    Args:
-      info [dict]: The spinnaker Status schema with a 'status' attribute.
-        Has no effect if there is no "status" attribute.
+        Args:
+          http_response: [HttpResponseType] From the last status update.
+        """
+        # super(SpinnakerStatus, self).set_http_response(http_response)
+        if http_response.http_code is None:
+            self.__current_state = "Unknown"
+            return
 
-    Returns:
-      The spinnaker status attribute value.
-    """
-    status = info.get('status')
-    if not status:
-      return None
-    builder.make(entity, 'Status', status,
-                 relation=self._STATUS_TO_RELATION.get(status))
-    return status
+        decoder = JSONDecoder()
+        self.__json_doc = decoder.decode(http_response.output)
+        self._update_response_from_json(self.__json_doc)
 
-  def _export_time_info(self, info, base_time, builder, entity):
-    """Helper function to write Status entry timing info to SnapshotableEntity.
+    def _update_response_from_json(self, doc):
+        """Updates abstract SpinnakerStatus attributes.
 
-    This writes a timestamp offset and delta where the offset is relative to
-    an absolute base_time. The delta are the being/end time in the info.
+        This is called by the base class.
 
-    Args:
-      info [dict]: The spinnaker Status schema with start/endTime attributes.
-        There start/endTime attributes are optional.
-      base_time [int]: The base timestamp (in ms) for timestamp offset.
-    """
-    start_time = info.get('startTime')
-    if start_time is None:
-      return
-    offset = (start_time - base_time) / 1000.0
-    end_time = info.get('endTime')
-    if not end_time:
-      builder.make_data(entity, 'Time', 'Running since {0}'.format(offset))
-    else:
-      builder.make_data(
-          entity, 'Time',
-          '{0} secs + {1}'.format(offset, (end_time - start_time) / 1000.0))
+        Args:
+          doc: [dict] JSON document object from response payload.
+        """
+        # pylint: disable=unused-argument
+        raise Exception("_update_response_from_json is not specialized.")
 
-  def _export_error_info(self, container, builder, entity):
-    """Helper function to write Status entry error info to SnapshotableEntity.
+    # helper for producing snapshot json
+    # maps relation to priority when determining outermost from list
+    # We treat None (not started) higher than valid.
+    _RELATION_SCORE = {
+        "VALID": 1,
+        None: 2,
+        "INVALID": 3,
+        "ERROR": 4,
+    }
+    # Inversion of _RELATION_SCORE
+    _SCORE_TO_RELATION = {value: key for key, value in _RELATION_SCORE.items()}
 
-    Has no effect if errors could not be found in the container.
+    # Convert standard spinnaker status to citest journal relation qualifier
+    # names.
+    _STATUS_TO_RELATION = {
+        "SUCCEEDED": "VALID",
+        "TERMINAL": "INVALID",
+        "NOT_STARTED": None,
+    }
 
-    Args:
-      container [dict]: Excerpt from Status response to look for errors.
-    """
-    message = []
-    if 'error' in container:
-      message.append(container['error'])
+    def _export_status(self, info, builder, entity):
+        """Helper function for writing spinnaker status into SnapshotableEntity.
 
-    details = container.get('details', {})
-    error_list = details.get('errors', [])
-    if error_list:
-      message.extend(['*  ' + str(err) for err in error_list])
-    if not message:
-      return
-    builder.make(entity, 'Error(s)',
-                 '\n'.join(message), relation='ERROR', format='pre')
+        Args:
+          info [dict]: The spinnaker Status schema with a 'status' attribute.
+            Has no effect if there is no "status" attribute.
+
+        Returns:
+          The spinnaker status attribute value.
+        """
+        status = info.get("status")
+        if not status:
+            return None
+        builder.make(
+            entity, "Status", status, relation=self._STATUS_TO_RELATION.get(status)
+        )
+        return status
+
+    def _export_time_info(self, info, base_time, builder, entity):
+        """Helper function to write Status entry timing info to SnapshotableEntity.
+
+        This writes a timestamp offset and delta where the offset is relative to
+        an absolute base_time. The delta are the being/end time in the info.
+
+        Args:
+          info [dict]: The spinnaker Status schema with start/endTime attributes.
+            There start/endTime attributes are optional.
+          base_time [int]: The base timestamp (in ms) for timestamp offset.
+        """
+        start_time = info.get("startTime")
+        if start_time is None:
+            return
+        offset = (start_time - base_time) / 1000.0
+        end_time = info.get("endTime")
+        if not end_time:
+            builder.make_data(entity, "Time", "Running since {0}".format(offset))
+        else:
+            builder.make_data(
+                entity,
+                "Time",
+                "{0} secs + {1}".format(offset, (end_time - start_time) / 1000.0),
+            )
+
+    def _export_error_info(self, container, builder, entity):
+        """Helper function to write Status entry error info to SnapshotableEntity.
+
+        Has no effect if errors could not be found in the container.
+
+        Args:
+          container [dict]: Excerpt from Status response to look for errors.
+        """
+        message = []
+        if "error" in container:
+            message.append(container["error"])
+
+        details = container.get("details", {})
+        error_list = details.get("errors", [])
+        if error_list:
+            message.extend(["*  " + str(err) for err in error_list])
+        if not message:
+            return
+        builder.make(
+            entity, "Error(s)", "\n".join(message), relation="ERROR", format="pre"
+        )
 
 
 class SpinnakerAgent(service_testing.HttpAgent):
-  """A BaseAgent  to a spinnaker subsystem.
+    """A BaseAgent  to a spinnaker subsystem.
 
-  The agent supports POST using the standard spinnaker subsystem protocol
-  of returning status references and obtaining details through followup GETs.
+    The agent supports POST using the standard spinnaker subsystem protocol
+    of returning status references and obtaining details through followup GETs.
 
-  Class instances should be created using one of the new* factory methods.
-  """
-
-  @classmethod
-  def __determine_host_platform(cls, bindings):
-    """Helper function to determine the platform spinnaker is hosted on.
-
-    This is used while figuring out how to connect to the instance.
+    Class instances should be created using one of the new* factory methods.
     """
-    host_platform = bindings.get('HOST_PLATFORM', None)
-    if not host_platform:
-      if bindings['GCE_PROJECT']:
-        host_platform = 'gce'
-      elif bindings['NATIVE_HOSTNAME']:
-        host_platform = 'native'
-      else:
-        bindings['NATIVE_HOSTNAME'] = 'localhost'
-        logging.getLogger(__name__).info('Assuming --native_hostname=localhost')
-        host_platform = 'native'
 
-    return host_platform
+    @classmethod
+    def __determine_host_platform(cls, bindings):
+        """Helper function to determine the platform spinnaker is hosted on.
 
-  @classmethod
-  def __determine_native_base_url(cls, bindings, default_port):
-    """Helper function to determine a native host platform's base URL.
+        This is used while figuring out how to connect to the instance.
+        """
+        host_platform = bindings.get("HOST_PLATFORM", None)
+        if not host_platform:
+            if bindings["GCE_PROJECT"]:
+                host_platform = "gce"
+            elif bindings["NATIVE_HOSTNAME"]:
+                host_platform = "native"
+            else:
+                bindings["NATIVE_HOSTNAME"] = "localhost"
+                logging.getLogger(__name__).info("Assuming --native_hostname=localhost")
+                host_platform = "native"
 
-    The returned base URL may be None if bindings['NATIVE_BASE_URL'] and
-    bindings['NATIVE_HOSTNAME'] are both missing.
+        return host_platform
 
-    Args:
-      bindings: [dict] List of bindings to configure the endpoint
-          NATIVE_BASE_URL: The base URL to use, if given. If NATIVE_BASE_URL
-              is not provided, the URL will be constructed using NATIVE_HOSTNAME
-              and NATIVE_PORT using http.
-          NATIVE_HOSTNAME: The host of the base URL to use, if NATIVE_BASE_URL
-              is not given.
-          NATIVE_PORT: The port of the base URL to use, if NATIVE_BASE_URL
-              is not given.
-      default_port: The port to use if bindings['NATIVE_BASE_URL'] is not given
-          and bindings['NATIVE_PORT'] is not given.
-    """
-    base_url = None
-    if bindings['NATIVE_BASE_URL']:
-      base_url = bindings['NATIVE_BASE_URL']
-    elif bindings['NATIVE_HOSTNAME']:
-      base_url = 'http://{host}:{port}'.format(
-                 host=bindings['NATIVE_HOSTNAME'],
-                 port=bindings['NATIVE_PORT'] or default_port)
-    return base_url
+    @classmethod
+    def __determine_native_base_url(cls, bindings, default_port):
+        """Helper function to determine a native host platform's base URL.
 
-  @classmethod
-  def new_instance_from_bindings(cls, name, status_factory, bindings, port):
-    """Create a new Spinnaker HttpAgent talking to the specified server port.
-    Args:
-      name:[string] The name of agent we are creating for reporting only.
-      status_factory: [SpinnakerStatus (SpinnakerAgent, HttpResponseType)]
-         Factory method for creating specialized SpinnakerStatus instances.
-      bindings: [dict] Specify how to connect to the server.
-         The actual parameters used depend on the hosting platform.
-         The hosting platform is specified with 'host_platform'
-      port: [int] The port of the endpoint we want to connect to.
+        The returned base URL may be None if bindings['NATIVE_BASE_URL'] and
+        bindings['NATIVE_HOSTNAME'] are both missing.
 
-    Returns:
-      A SpinnakerAgent connected to the specified instance port.
-    """
-    host_platform = cls.__determine_host_platform(bindings)
-    if host_platform == 'native':
-      base_url = cls.__determine_native_base_url(bindings, port)
-      return cls.new_native_instance(
-          name, status_factory=status_factory, base_url=base_url, bindings=bindings)
+        Args:
+          bindings: [dict] List of bindings to configure the endpoint
+              NATIVE_BASE_URL: The base URL to use, if given. If NATIVE_BASE_URL
+                  is not provided, the URL will be constructed using NATIVE_HOSTNAME
+                  and NATIVE_PORT using http.
+              NATIVE_HOSTNAME: The host of the base URL to use, if NATIVE_BASE_URL
+                  is not given.
+              NATIVE_PORT: The port of the base URL to use, if NATIVE_BASE_URL
+                  is not given.
+          default_port: The port to use if bindings['NATIVE_BASE_URL'] is not given
+              and bindings['NATIVE_PORT'] is not given.
+        """
+        base_url = None
+        if bindings["NATIVE_BASE_URL"]:
+            base_url = bindings["NATIVE_BASE_URL"]
+        elif bindings["NATIVE_HOSTNAME"]:
+            base_url = "http://{host}:{port}".format(
+                host=bindings["NATIVE_HOSTNAME"],
+                port=bindings["NATIVE_PORT"] or default_port,
+            )
+        return base_url
 
-    if host_platform == 'gce':
-      return cls.new_gce_instance_from_bindings(
-          name, status_factory, bindings, port)
+    @classmethod
+    def new_instance_from_bindings(cls, name, status_factory, bindings, port):
+        """Create a new Spinnaker HttpAgent talking to the specified server port.
+        Args:
+          name:[string] The name of agent we are creating for reporting only.
+          status_factory: [SpinnakerStatus (SpinnakerAgent, HttpResponseType)]
+             Factory method for creating specialized SpinnakerStatus instances.
+          bindings: [dict] Specify how to connect to the server.
+             The actual parameters used depend on the hosting platform.
+             The hosting platform is specified with 'host_platform'
+          port: [int] The port of the endpoint we want to connect to.
 
-    raise ValueError('Unknown host_platform={0}'.format(host_platform))
+        Returns:
+          A SpinnakerAgent connected to the specified instance port.
+        """
+        host_platform = cls.__determine_host_platform(bindings)
+        if host_platform == "native":
+            base_url = cls.__determine_native_base_url(bindings, port)
+            return cls.new_native_instance(
+                name,
+                status_factory=status_factory,
+                base_url=base_url,
+                bindings=bindings,
+            )
 
-  @classmethod
-  def new_gce_instance_from_bindings(
-      cls, name, status_factory, bindings, port):
-    """Create a new Spinnaker HttpAgent talking to the specified server port.
+        if host_platform == "gce":
+            return cls.new_gce_instance_from_bindings(
+                name, status_factory, bindings, port
+            )
 
-    Args:
-      name: [string] The name of agent we are creating for reporting only.
-      status_factory: [SpinnakerStatus (SpinnakerAgent, HttpResponseType)]
-         Factory method for creating specialized SpinnakerStatus instances.
-      bindings: [dict] List of bindings to configure the endpoint
-          GCE_PROJECT: The GCE project ID that the endpoint is in.
-          GCE_ZONE: The GCE zone that the endpoint is in.
-          GCE_INSTANCE: The GCE instance that the endpoint is in.
-          GCE_SSH_PASSPHRASE_FILE: If not empty, the SSH passphrase key
-              for tunneling if needed to connect through a GCE firewall.
-          GCE_SERVICE_ACCOUNT: If not empty, the GCE service account to use
-              when interacting with the GCE instance.
-          IGNORE_SSL_CERT_VERIFICATION: If True, ignores SSL certificate
-              verification when scraping spring config.
-      port: [int] The port of the endpoint we want to connect to.
-    Returns:
-      A SpinnakerAgent connected to the specified instance port.
-    """
-    project = bindings['GCE_PROJECT']
-    zone = bindings['GCE_ZONE']
-    instance = bindings['GCE_INSTANCE']
-    ssh_passphrase_file = bindings.get('GCE_SSH_PASSPHRASE_FILE', None)
-    service_account = bindings.get('GCE_SERVICE_ACCOUNT', None)
-    ignore_ssl_cert_verification = bindings['IGNORE_SSL_CERT_VERIFICATION']
+        raise ValueError("Unknown host_platform={0}".format(host_platform))
 
-    logger = logging.getLogger(__name__)
-    JournalLogger.begin_context('Locating {0}...'.format(name))
-    context_relation = 'ERROR'
-    try:
-      gcloud = gcp.GCloudAgent(
-          project=project, zone=zone, service_account=service_account,
-          ssh_passphrase_file=ssh_passphrase_file)
-      netloc = gce_util.establish_network_connectivity(
-          gcloud=gcloud, instance=instance, target_port=port)
-      if not netloc:
-        error = 'Could not locate {0}.'.format(name)
-        logger.error(error)
-        context_relation = 'INVALID'
-        raise RuntimeError(error)
+    @classmethod
+    def new_gce_instance_from_bindings(cls, name, status_factory, bindings, port):
+        """Create a new Spinnaker HttpAgent talking to the specified server port.
 
-      protocol = bindings['NETWORK_PROTOCOL']
-      base_url = '{protocol}://{netloc}'.format(protocol=protocol,
-                                                netloc=netloc)
-      logger.info('%s is available at %s. Using %s', name, netloc, base_url)
-      deployed_config = scrape_spring_config(
-          os.path.join(base_url, 'resolvedEnv'),
-          ignore_ssl_cert_verification=ignore_ssl_cert_verification)
-      JournalLogger.journal_or_log_detail(
-          '{0} configuration'.format(name), deployed_config)
-      spinnaker_agent = cls(base_url, status_factory)
-      spinnaker_agent.__deployed_config = deployed_config
-      context_relation = 'VALID'
-    except:
-      logger.exception('Failed to create spinnaker agent.')
-      raise
-    finally:
-      JournalLogger.end_context(relation=context_relation)
+        Args:
+          name: [string] The name of agent we are creating for reporting only.
+          status_factory: [SpinnakerStatus (SpinnakerAgent, HttpResponseType)]
+             Factory method for creating specialized SpinnakerStatus instances.
+          bindings: [dict] List of bindings to configure the endpoint
+              GCE_PROJECT: The GCE project ID that the endpoint is in.
+              GCE_ZONE: The GCE zone that the endpoint is in.
+              GCE_INSTANCE: The GCE instance that the endpoint is in.
+              GCE_SSH_PASSPHRASE_FILE: If not empty, the SSH passphrase key
+                  for tunneling if needed to connect through a GCE firewall.
+              GCE_SERVICE_ACCOUNT: If not empty, the GCE service account to use
+                  when interacting with the GCE instance.
+              IGNORE_SSL_CERT_VERIFICATION: If True, ignores SSL certificate
+                  verification when scraping spring config.
+          port: [int] The port of the endpoint we want to connect to.
+        Returns:
+          A SpinnakerAgent connected to the specified instance port.
+        """
+        project = bindings["GCE_PROJECT"]
+        zone = bindings["GCE_ZONE"]
+        instance = bindings["GCE_INSTANCE"]
+        ssh_passphrase_file = bindings.get("GCE_SSH_PASSPHRASE_FILE", None)
+        service_account = bindings.get("GCE_SERVICE_ACCOUNT", None)
+        ignore_ssl_cert_verification = bindings["IGNORE_SSL_CERT_VERIFICATION"]
 
-    return spinnaker_agent
+        logger = logging.getLogger(__name__)
+        JournalLogger.begin_context("Locating {0}...".format(name))
+        context_relation = "ERROR"
+        try:
+            gcloud = gcp.GCloudAgent(
+                project=project,
+                zone=zone,
+                service_account=service_account,
+                ssh_passphrase_file=ssh_passphrase_file,
+            )
+            netloc = gce_util.establish_network_connectivity(
+                gcloud=gcloud, instance=instance, target_port=port
+            )
+            if not netloc:
+                error = "Could not locate {0}.".format(name)
+                logger.error(error)
+                context_relation = "INVALID"
+                raise RuntimeError(error)
 
-  @classmethod
-  def new_native_instance(cls, name, status_factory, base_url, bindings):
-    """Create a new Spinnaker HttpAgent talking to the specified server port.
+            protocol = bindings["NETWORK_PROTOCOL"]
+            base_url = "{protocol}://{netloc}".format(protocol=protocol, netloc=netloc)
+            logger.info("%s is available at %s. Using %s", name, netloc, base_url)
+            deployed_config = scrape_spring_config(
+                os.path.join(base_url, "resolvedEnv"),
+                ignore_ssl_cert_verification=ignore_ssl_cert_verification,
+            )
+            JournalLogger.journal_or_log_detail(
+                "{0} configuration".format(name), deployed_config
+            )
+            spinnaker_agent = cls(base_url, status_factory)
+            spinnaker_agent.__deployed_config = deployed_config
+            context_relation = "VALID"
+        except:
+            logger.exception("Failed to create spinnaker agent.")
+            raise
+        finally:
+            JournalLogger.end_context(relation=context_relation)
 
-    Args:
-      name: [string] The name of agent we are creating for reporting only.
-      status_factory: [SpinnakerStatus (SpinnakerAgent, HttpResponseType)]
-         Factory method for creating specialized SpinnakerStatus instances.
-      base_url: [string] The service base URL to send messages to.
-      bindings: [dict] List of bindings to configure the endpoint
-          BEARER_AUTH_TOKEN: The token used to authenticate request to a
-              protected host.
-          IGNORE_SSL_CERT_VERIFICATION: If True, ignores SSL certificate
-              verification when making requests.
-    Returns:
-      A SpinnakerAgent connected to the specified instance port.
-    """
-    bearer_auth_token = bindings.get('BEARER_AUTH_TOKEN', None)
-    ignore_ssl_cert_verification = bindings['IGNORE_SSL_CERT_VERIFICATION']
+        return spinnaker_agent
 
-    logger = logging.getLogger(__name__)
-    logger.info('Locating %s...', name)
-    if not base_url:
-      logger.error('Could not locate %s.', name)
-      return None
+    @classmethod
+    def new_native_instance(cls, name, status_factory, base_url, bindings):
+        """Create a new Spinnaker HttpAgent talking to the specified server port.
 
-    logger.info('%s is available at %s', name, base_url)
-    env_url = os.path.join(base_url, 'resolvedEnv')
-    headers = {}
-    if bearer_auth_token:
-      headers['Authorization'] = 'Bearer {}'.format(bearer_auth_token)
-    deployed_config = scrape_spring_config(env_url, headers=headers, ignore_ssl_cert_verification=ignore_ssl_cert_verification)
-    JournalLogger.journal_or_log_detail(
-        '{0} configuration'.format(name), deployed_config)
+        Args:
+          name: [string] The name of agent we are creating for reporting only.
+          status_factory: [SpinnakerStatus (SpinnakerAgent, HttpResponseType)]
+             Factory method for creating specialized SpinnakerStatus instances.
+          base_url: [string] The service base URL to send messages to.
+          bindings: [dict] List of bindings to configure the endpoint
+              BEARER_AUTH_TOKEN: The token used to authenticate request to a
+                  protected host.
+              IGNORE_SSL_CERT_VERIFICATION: If True, ignores SSL certificate
+                  verification when making requests.
+        Returns:
+          A SpinnakerAgent connected to the specified instance port.
+        """
+        bearer_auth_token = bindings.get("BEARER_AUTH_TOKEN", None)
+        ignore_ssl_cert_verification = bindings["IGNORE_SSL_CERT_VERIFICATION"]
 
-    spinnaker_agent = cls(base_url, status_factory)
-    spinnaker_agent.ignore_ssl_cert_verification = ignore_ssl_cert_verification
-    spinnaker_agent.__deployed_config = deployed_config
+        logger = logging.getLogger(__name__)
+        logger.info("Locating %s...", name)
+        if not base_url:
+            logger.error("Could not locate %s.", name)
+            return None
 
-    if bearer_auth_token:
-      spinnaker_agent.add_header('Authorization', 'Bearer {}'.format(bearer_auth_token))
+        logger.info("%s is available at %s", name, base_url)
+        env_url = os.path.join(base_url, "resolvedEnv")
+        headers = {}
+        if bearer_auth_token:
+            headers["Authorization"] = "Bearer {}".format(bearer_auth_token)
+        deployed_config = scrape_spring_config(
+            env_url,
+            headers=headers,
+            ignore_ssl_cert_verification=ignore_ssl_cert_verification,
+        )
+        JournalLogger.journal_or_log_detail(
+            "{0} configuration".format(name), deployed_config
+        )
 
-    return spinnaker_agent
+        spinnaker_agent = cls(base_url, status_factory)
+        spinnaker_agent.ignore_ssl_cert_verification = ignore_ssl_cert_verification
+        spinnaker_agent.__deployed_config = deployed_config
 
-  @property
-  def deployed_config(self):
-    """The configuration dictionary gleaned from the deployed service."""
-    return self.__deployed_config
+        if bearer_auth_token:
+            spinnaker_agent.add_header(
+                "Authorization", "Bearer {}".format(bearer_auth_token)
+            )
 
-  @property
-  def runtime_config(self):
-    """Confguration dictionary approxmation from static config files.
+        return spinnaker_agent
 
-    This might not be available at all, depending on how we can access the
-    service. This does not consider how the service was actually invoked
-    so may be incomplete or wrong. However it is probably close enough for
-    our needs, and certainly close enough to locate the service to obtain
-    the actual |deploy_config| data.
-    """
-    return self.config_dict
+    @property
+    def deployed_config(self):
+        """The configuration dictionary gleaned from the deployed service."""
+        return self.__deployed_config
 
-  def __init__(self, base_url, status_factory):
-    """Construct a an agent for talking to spinnaker.
+    @property
+    def runtime_config(self):
+        """Confguration dictionary approxmation from static config files.
 
-    This could really be any spinnaker subsystem, not just the master process.
-    The important consideration is that the protocol for this server is that
-    posting requests returns a reference url for status updates, and accepts
-    GET requests on those urls to return status details.
+        This might not be available at all, depending on how we can access the
+        service. This does not consider how the service was actually invoked
+        so may be incomplete or wrong. However it is probably close enough for
+        our needs, and certainly close enough to locate the service to obtain
+        the actual |deploy_config| data.
+        """
+        return self.config_dict
 
-    Args:
-      base_url: [string] The base URL string spinnaker is running on.
-      status_factory: [SpinnakerStatus (SpinnakerAgent, HttpResponseType)]
-         Factory method for creating specialized SpinnakerStatus instances.
-    """
-    super(SpinnakerAgent, self).__init__(base_url)
-    self.__deployed_config = {}
-    self.__default_status_factory = status_factory
+    def __init__(self, base_url, status_factory):
+        """Construct a an agent for talking to spinnaker.
 
-    # 6 minutes is a long time, but starting VMs can take 2-3 mins
-    # especially with internal polling, so platform sluggishness combined
-    # with a missed poll can go higher. We still dont expect to come
-    # near this, but care more about eventual correctness than timeliness
-    # here. We can capture timing information and look at it after the fact
-    # to make performance related conclusions.
-    self.default_max_wait_secs = 600
+        This could really be any spinnaker subsystem, not just the master process.
+        The important consideration is that the protocol for this server is that
+        posting requests returns a reference url for status updates, and accepts
+        GET requests on those urls to return status details.
 
-  def _new_messaging_status(self, operation, http_response):
-    """Implements HttpAgent interface."""
-    return (operation.status_class(operation, http_response)
+        Args:
+          base_url: [string] The base URL string spinnaker is running on.
+          status_factory: [SpinnakerStatus (SpinnakerAgent, HttpResponseType)]
+             Factory method for creating specialized SpinnakerStatus instances.
+        """
+        super(SpinnakerAgent, self).__init__(base_url)
+        self.__deployed_config = {}
+        self.__default_status_factory = status_factory
+
+        # 6 minutes is a long time, but starting VMs can take 2-3 mins
+        # especially with internal polling, so platform sluggishness combined
+        # with a missed poll can go higher. We still dont expect to come
+        # near this, but care more about eventual correctness than timeliness
+        # here. We can capture timing information and look at it after the fact
+        # to make performance related conclusions.
+        self.default_max_wait_secs = 600
+
+    def _new_messaging_status(self, operation, http_response):
+        """Implements HttpAgent interface."""
+        return (
+            operation.status_class(operation, http_response)
             if operation.status_class
-            else self.__default_status_factory(operation, http_response))
+            else self.__default_status_factory(operation, http_response)
+        )
 
-  @staticmethod
-  def __get_deployed_local_yaml_bindings(gcloud, instance):
-    """Return the contents of the spinnaker-local.yml configuration file.
+    @staticmethod
+    def __get_deployed_local_yaml_bindings(gcloud, instance):
+        """Return the contents of the spinnaker-local.yml configuration file.
 
-    Args:
-      gcloud: [GCloudAgent] Specifies project and zone.
-          Capable of remote fetching if needed.
-      instance: [string] The GCE instance name containing the deployment.
+        Args:
+          gcloud: [GCloudAgent] Specifies project and zone.
+              Capable of remote fetching if needed.
+          instance: [string] The GCE instance name containing the deployment.
 
-    Returns:
-      None or the configuration file contents.
-    """
-    config_dict = ExpressionDict()
-    logger = logging.getLogger(__name__)
+        Returns:
+          None or the configuration file contents.
+        """
+        config_dict = ExpressionDict()
+        logger = logging.getLogger(__name__)
 
-    if gce_util.am_i(gcloud.project, gcloud.zone, instance):
-      yaml_file = os.path.expanduser('~/.spinnaker/spinnaker-local.yml')
-      logger.debug('We are the instance. Config from %s', yaml_file)
+        if gce_util.am_i(gcloud.project, gcloud.zone, instance):
+            yaml_file = os.path.expanduser("~/.spinnaker/spinnaker-local.yml")
+            logger.debug("We are the instance. Config from %s", yaml_file)
 
-      if not os.path.exists(yaml_file):
-        logger.debug('%s does not exist', yaml_file)
-        return None
+            if not os.path.exists(yaml_file):
+                logger.debug("%s does not exist", yaml_file)
+                return None
 
-      try:
-        yaml_accumulator.load_path(yaml_file, config_dict)
-        return config_dict
-      except IOError as ex:
-        logger.error('Failed to load from %s: %s', yaml_file, ex)
-        return None
+            try:
+                yaml_accumulator.load_path(yaml_file, config_dict)
+                return config_dict
+            except IOError as ex:
+                logger.error("Failed to load from %s: %s", yaml_file, ex)
+                return None
 
-      logger.debug('Load spinnaker-local.yml from instance %s', instance)
+            logger.debug("Load spinnaker-local.yml from instance %s", instance)
 
-    # If this is a production installation, look in:
-    #    /home/spinnaker/.spinnaker
-    # or /opt/spinnaker/config
-    # or /etc/default/spinnaker (name/value)
-    # Otherwise look in ~/.spinnaker for a development installation.
-    # pylint: disable=bad-continuation
-    response = gcloud.remote_command(
-        instance,
-        'LIST=""'
-        '; for i in /etc/default/spinnaker'
-           ' /home/spinnaker/.spinnaker/spinnaker-local.yml'
-           ' /opt/spinnaker/config/spinnaker-local.yml'
-           ' $HOME/.spinnaker/spinnaker-local.yml'
-        '; do'
-            ' if sudo stat $i >& /dev/null; then'
+        # If this is a production installation, look in:
+        #    /home/spinnaker/.spinnaker
+        # or /opt/spinnaker/config
+        # or /etc/default/spinnaker (name/value)
+        # Otherwise look in ~/.spinnaker for a development installation.
+        # pylint: disable=bad-continuation
+        response = gcloud.remote_command(
+            instance,
+            'LIST=""'
+            "; for i in /etc/default/spinnaker"
+            " /home/spinnaker/.spinnaker/spinnaker-local.yml"
+            " /opt/spinnaker/config/spinnaker-local.yml"
+            " $HOME/.spinnaker/spinnaker-local.yml"
+            "; do"
+            " if sudo stat $i >& /dev/null; then"
             '   LIST="$LIST $i"'
-            '; fi'
-        '; done'
-        # tar emits warnings about the absolute paths, so we'll filter them out
-        # We need to base64 the binary results so we return text.
-        '; (sudo tar czf - $LIST 2> /dev/null | base64)')
+            "; fi"
+            "; done"
+            # tar emits warnings about the absolute paths, so we'll filter them out
+            # We need to base64 the binary results so we return text.
+            "; (sudo tar czf - $LIST 2> /dev/null | base64)",
+        )
 
-    if not response.ok():
-      logger.error(
-          'Could not determine configuration:\n%s', response.error)
-      return None
+        if not response.ok():
+            logger.error("Could not determine configuration:\n%s", response.error)
+            return None
 
-    # gcloud prints an info message about upgrades to the output stream.
-    # There seems to be no way to suppress this!
-    # Look for it and truncate the stream there if we see it.
-    got = response.output
-    update_msg_offset = got.find('Updates are available')
-    if update_msg_offset > 0:
-      got = got[0:update_msg_offset]
+        # gcloud prints an info message about upgrades to the output stream.
+        # There seems to be no way to suppress this!
+        # Look for it and truncate the stream there if we see it.
+        got = response.output
+        update_msg_offset = got.find("Updates are available")
+        if update_msg_offset > 0:
+            got = got[0:update_msg_offset]
 
-    # When we ssh in, there may be a message written warning us that the host
-    # was added to known hosts. If so, this will be the first line. Remove it.
-    eoln = got.find('\n')
-    if eoln > 0 and re.match('^Warning: .+$', got[0:eoln]):
-      got = got[eoln + 1:]
+        # When we ssh in, there may be a message written warning us that the host
+        # was added to known hosts. If so, this will be the first line. Remove it.
+        eoln = got.find("\n")
+        if eoln > 0 and re.match("^Warning: .+$", got[0:eoln]):
+            got = got[eoln + 1 :]
 
-    if not got:
-      return None
+        if not got:
+            return None
 
-    tar = tarfile.open(mode='r', fileobj=BytesIO(base64.b64decode(got)))
+        tar = tarfile.open(mode="r", fileobj=BytesIO(base64.b64decode(got)))
 
-    try:
-      entry = tar.extractfile('etc/default/spinnaker')
-    except KeyError:
-      pass
-    else:
-      logger.info('Importing configuration from /etc/default/spinnaker')
-      config_dict.update(name_value_to_dict(entry.read()))
+        try:
+            entry = tar.extractfile("etc/default/spinnaker")
+        except KeyError:
+            pass
+        else:
+            logger.info("Importing configuration from /etc/default/spinnaker")
+            config_dict.update(name_value_to_dict(entry.read()))
 
-    file_list = ['home/spinnaker/.spinnaker/spinnaker-local.yml',
-                 'opt/spinnaker/config/spinnaker-local.yml']
-    log_name = os.environ.get('LOGNAME')
-    if log_name is not None:
-      file_list.append(os.path.join('home', log_name,
-                                    '.spinnaker/spinnaker-local.yml'))
+        file_list = [
+            "home/spinnaker/.spinnaker/spinnaker-local.yml",
+            "opt/spinnaker/config/spinnaker-local.yml",
+        ]
+        log_name = os.environ.get("LOGNAME")
+        if log_name is not None:
+            file_list.append(
+                os.path.join("home", log_name, ".spinnaker/spinnaker-local.yml")
+            )
 
-    for member in file_list:
-      try:
-        entry = tar.extractfile(member)
-      except KeyError:
-        continue
+        for member in file_list:
+            try:
+                entry = tar.extractfile(member)
+            except KeyError:
+                continue
 
-      logger.info('Importing configuration from %s', member)
-      yaml_accumulator.load_string(entry.read(), config_dict)
+            logger.info("Importing configuration from %s", member)
+            yaml_accumulator.load_string(entry.read(), config_dict)
 
-    return config_dict
+        return config_dict

--- a/testing/citest/spinnaker_testing/spinnaker_test_scenario.py
+++ b/testing/citest/spinnaker_testing/spinnaker_test_scenario.py
@@ -45,311 +45,337 @@ PLATFORM_SUPPORT_CLASSES = [
     kubernetes_scenario_support.KubernetesScenarioSupport,
     kubernetes_v2_scenario_support.KubernetesV2ScenarioSupport,
     azure_scenario_support.AzureScenarioSupport,
-    dcos_scenario_support.DcosScenarioSupport
+    dcos_scenario_support.DcosScenarioSupport,
 ]
 
 
 class SpinnakerTestScenario(sk.AgentTestScenario):
-  """Specialization of AgentTestScenario to facilitate testing Spinnaker.
+    """Specialization of AgentTestScenario to facilitate testing Spinnaker.
 
-  Adds standard command line arguments for locating the deployed system, and
-  setting up observers.
-  """
-  ENDPOINT_SUBSYSTEM = 'the server to test'
-
-  @classmethod
-  def new_post_operation(cls, title, data, path, **kwargs):
-    """Creates an operation that posts data to the given path when executed.
-
-    The base_url will come from the agent that the operation is eventually
-    executed on.
-
-    Args:
-      title: [string] The name of the operation for reporting purposes.
-      data: [string] The payload to send in the HTTP POST.
-      path: [string] The path relative to the base url provided later.
-      kwargs: [kwargs] Additional kwargs for HttpPostOperation
+    Adds standard command line arguments for locating the deployed system, and
+    setting up observers.
     """
-    return http_agent.HttpPostOperation(title=title, data=data, path=path,
-                                        **kwargs)
 
-  @classmethod
-  def new_put_operation(cls, title, data, path, **kwargs):
-    """Creates an operation that puts data to the given path when executed.
+    ENDPOINT_SUBSYSTEM = "the server to test"
 
-    The base_url will come from the agent that the operation is eventually
-    executed on.
+    @classmethod
+    def new_post_operation(cls, title, data, path, **kwargs):
+        """Creates an operation that posts data to the given path when executed.
 
-    Args:
-      title: [string] The name of the operation for reporting purposes.
-      data: [string] The payload to send in the HTTP PUT.
-      path: [string] The path relative to the base url provided later.
-      kwargs: [kwargs] Additional kwargs for HttpPutOperation
-    """
-    return http_agent.HttpPutOperation(title=title, data=data, path=path,
-                                       **kwargs)
+        The base_url will come from the agent that the operation is eventually
+        executed on.
 
-  @classmethod
-  def new_patch_operation(cls, title, data, path, **kwargs):
-    """Creates an operation that patches data to the given path when executed.
+        Args:
+          title: [string] The name of the operation for reporting purposes.
+          data: [string] The payload to send in the HTTP POST.
+          path: [string] The path relative to the base url provided later.
+          kwargs: [kwargs] Additional kwargs for HttpPostOperation
+        """
+        return http_agent.HttpPostOperation(title=title, data=data, path=path, **kwargs)
 
-    The base_url will come from the agent that the operation is eventually
-    executed on.
+    @classmethod
+    def new_put_operation(cls, title, data, path, **kwargs):
+        """Creates an operation that puts data to the given path when executed.
 
-    Args:
-      title: [string] The name of the operation for reporting purposes.
-      data: [string] The payload to send in the HTTP PATCH.
-      path: [string] The path relative to the base url provided later.
-      kwargs: [kwargs] Additional kwargs for HttpPatchOperation
-    """
-    return http_agent.HttpPatchOperation(title=title, data=data, path=path,
-                                         **kwargs)
+        The base_url will come from the agent that the operation is eventually
+        executed on.
 
-  @classmethod
-  def new_delete_operation(cls, title, data, path, **kwargs):
-    """Creates an operation that deletes from the given path when executed.
+        Args:
+          title: [string] The name of the operation for reporting purposes.
+          data: [string] The payload to send in the HTTP PUT.
+          path: [string] The path relative to the base url provided later.
+          kwargs: [kwargs] Additional kwargs for HttpPutOperation
+        """
+        return http_agent.HttpPutOperation(title=title, data=data, path=path, **kwargs)
 
-    The base_url will come from the agent that the operation is eventually
-    executed on.
+    @classmethod
+    def new_patch_operation(cls, title, data, path, **kwargs):
+        """Creates an operation that patches data to the given path when executed.
 
-    Args:
-      title: [string] The name of the operation for reporting purposes.
-      data: [string] The payload to send in the HTTP DELETE.
-      path: [string] The path relative to the base url provided later.
-      kwargs: [kwargs] Additional kwargs for HttpDeleteOperation
-    """
-    return http_agent.HttpDeleteOperation(title=title, data=data, path=path,
-                                          **kwargs)
+        The base_url will come from the agent that the operation is eventually
+        executed on.
 
-  @classmethod
-  def _init_spinnaker_bindings_builder(cls, builder, defaults):
-    """Initialize bindings for spinnaker itself.
+        Args:
+          title: [string] The name of the operation for reporting purposes.
+          data: [string] The payload to send in the HTTP PATCH.
+          path: [string] The path relative to the base url provided later.
+          kwargs: [kwargs] Additional kwargs for HttpPatchOperation
+        """
+        return http_agent.HttpPatchOperation(
+            title=title, data=data, path=path, **kwargs
+        )
 
-    Args:
-      builder: [citest.base.ConfigBindingsBuilder]
-      defaults: [dict] Default binding value overrides.
-         This is used to initialize the default commandline parameters.
-    """
-    # This could probably be removed fairly easily.
-    # It probably isnt useful anymore.
-    builder.add_argument(
-        '--host_platform', default=defaults.get('HOST_PLATFORM', None),
-        help='Platform running spinnaker (gce, native).'
-             ' If this is not explicitly set, then try to'
-             ' guess based on other parameters set.')
+    @classmethod
+    def new_delete_operation(cls, title, data, path, **kwargs):
+        """Creates an operation that deletes from the given path when executed.
 
-    builder.add_argument(
-        '--native_hostname', default=defaults.get('NATIVE_HOSTNAME', None),
-        help='Host name that {system} is running on.'
-             ' This parameter is only used if the spinnaker host platform'
-             ' is "native".'.format(system=cls.ENDPOINT_SUBSYSTEM))
+        The base_url will come from the agent that the operation is eventually
+        executed on.
 
-    builder.add_argument(
-        '--network_protocol', default='http',
-        help='The network protocol to use talking to the native port.'
-        ' The default is "http", but this could be changed to "https".')
+        Args:
+          title: [string] The name of the operation for reporting purposes.
+          data: [string] The payload to send in the HTTP DELETE.
+          path: [string] The path relative to the base url provided later.
+          kwargs: [kwargs] Additional kwargs for HttpDeleteOperation
+        """
+        return http_agent.HttpDeleteOperation(
+            title=title, data=data, path=path, **kwargs
+        )
 
-    builder.add_argument(
-        '--native_port', default=defaults.get('NATIVE_PORT', None),
-        help='Port number that {system} is running on.'
-             ' This parameter is only used if the spinnaker host platform'
-             ' is "native". It is not needed if the system is using its'
-             ' standard port.'.format(system=cls.ENDPOINT_SUBSYSTEM))
+    @classmethod
+    def _init_spinnaker_bindings_builder(cls, builder, defaults):
+        """Initialize bindings for spinnaker itself.
 
-    builder.add_argument(
-        '--native_base_url', default=defaults.get('NATIVE_BASE_URL', None),
-        help='Base URL that {system} is running on. If provided, this field'
-             ' will override --native_hostname and --native_port.'
-             ' This parameter is only used if the spinnaker host platform'
-             ' is "native".'.format(system=cls.ENDPOINT_SUBSYSTEM))
+        Args:
+          builder: [citest.base.ConfigBindingsBuilder]
+          defaults: [dict] Default binding value overrides.
+             This is used to initialize the default commandline parameters.
+        """
+        # This could probably be removed fairly easily.
+        # It probably isnt useful anymore.
+        builder.add_argument(
+            "--host_platform",
+            default=defaults.get("HOST_PLATFORM", None),
+            help="Platform running spinnaker (gce, native)."
+            " If this is not explicitly set, then try to"
+            " guess based on other parameters set.",
+        )
 
-    builder.add_argument(
-        '--test_stack', default=defaults.get('TEST_STACK', 'test'),
-        help='Default Spinnaker stack decorator.')
+        builder.add_argument(
+            "--native_hostname",
+            default=defaults.get("NATIVE_HOSTNAME", None),
+            help="Host name that {system} is running on."
+            " This parameter is only used if the spinnaker host platform"
+            ' is "native".'.format(system=cls.ENDPOINT_SUBSYSTEM),
+        )
 
-    builder.add_argument(
-        '--test_app', default=defaults.get('TEST_APP', cls.__name__.lower()),
-        help='Default Spinnaker application name to use with test.')
+        builder.add_argument(
+            "--network_protocol",
+            default="http",
+            help="The network protocol to use talking to the native port."
+            ' The default is "http", but this could be changed to "https".',
+        )
 
-    builder.add_argument(
-        '--test_user', default=defaults.get('TEST_USER', 'anonymous'),
-        help='User used to make API calls to a Spinnaker application.')
+        builder.add_argument(
+            "--native_port",
+            default=defaults.get("NATIVE_PORT", None),
+            help="Port number that {system} is running on."
+            " This parameter is only used if the spinnaker host platform"
+            ' is "native". It is not needed if the system is using its'
+            " standard port.".format(system=cls.ENDPOINT_SUBSYSTEM),
+        )
 
-    builder.add_argument(
-        '--bearer_auth_token', default=defaults.get('BEARER_AUTH_TOKEN', None),
-        help='Bearer token used to authenticate outbound requests to {system}.'
-            ' This parameter is only used if the spinnaker host platform'
+        builder.add_argument(
+            "--native_base_url",
+            default=defaults.get("NATIVE_BASE_URL", None),
+            help="Base URL that {system} is running on. If provided, this field"
+            " will override --native_hostname and --native_port."
+            " This parameter is only used if the spinnaker host platform"
+            ' is "native".'.format(system=cls.ENDPOINT_SUBSYSTEM),
+        )
+
+        builder.add_argument(
+            "--test_stack",
+            default=defaults.get("TEST_STACK", "test"),
+            help="Default Spinnaker stack decorator.",
+        )
+
+        builder.add_argument(
+            "--test_app",
+            default=defaults.get("TEST_APP", cls.__name__.lower()),
+            help="Default Spinnaker application name to use with test.",
+        )
+
+        builder.add_argument(
+            "--test_user",
+            default=defaults.get("TEST_USER", "anonymous"),
+            help="User used to make API calls to a Spinnaker application.",
+        )
+
+        builder.add_argument(
+            "--bearer_auth_token",
+            default=defaults.get("BEARER_AUTH_TOKEN", None),
+            help="Bearer token used to authenticate outbound requests to {system}."
+            " This parameter is only used if the spinnaker host platform"
             ' is "native". It is not needed if the system is not using'
-            ' authentication.'.format(system=cls.ENDPOINT_SUBSYSTEM))
+            " authentication.".format(system=cls.ENDPOINT_SUBSYSTEM),
+        )
 
-    builder.add_argument(
-        '--ignore_ssl_cert_verification', default=defaults.get('IGNORE_SSL_CERT_VERIFICATION', False),
-        type=bool,
-        help='Ignores SSL certification verification when making requests to'
-             ' Spinnaker.')
+        builder.add_argument(
+            "--ignore_ssl_cert_verification",
+            default=defaults.get("IGNORE_SSL_CERT_VERIFICATION", False),
+            type=bool,
+            help="Ignores SSL certification verification when making requests to"
+            " Spinnaker.",
+        )
 
-  @classmethod
-  def init_bindings_builder(cls, builder, defaults=None):
-    """Initialize command line bindings.
+    @classmethod
+    def init_bindings_builder(cls, builder, defaults=None):
+        """Initialize command line bindings.
 
-    Args:
-      builder: [citest.base.ConfigBindingsBuilder]
-      defaults: [dict] Default binding value overrides.
-         This is used to initialize the default commandline parameters.
-    """
-    defaults = defaults or {}
+        Args:
+          builder: [citest.base.ConfigBindingsBuilder]
+          defaults: [dict] Default binding value overrides.
+             This is used to initialize the default commandline parameters.
+        """
+        defaults = defaults or {}
 
-    for klas in PLATFORM_SUPPORT_CLASSES:
-      klas.add_commandline_parameters(cls, builder, defaults)
+        for klas in PLATFORM_SUPPORT_CLASSES:
+            klas.add_commandline_parameters(cls, builder, defaults)
 
-    cls._init_spinnaker_bindings_builder(builder, defaults=defaults)
+        cls._init_spinnaker_bindings_builder(builder, defaults=defaults)
 
-    super(SpinnakerTestScenario, cls).init_bindings_builder(
-        builder, defaults=defaults)
+        super(SpinnakerTestScenario, cls).init_bindings_builder(
+            builder, defaults=defaults
+        )
 
-  @property
-  def gcp_observer(self):
-    """The observer for inspecting GCE platform stated.
+    @property
+    def gcp_observer(self):
+        """The observer for inspecting GCE platform stated.
 
-    Raises:
-      Exception if the observer is not available.
-    """
-    return self.__platform_support['google'].observer
+        Raises:
+          Exception if the observer is not available.
+        """
+        return self.__platform_support["google"].observer
 
-  @property
-  def kube_observer(self):
-    """The observer for inspecting Kubernetes platform state."
+    @property
+    def kube_observer(self):
+        """The observer for inspecting Kubernetes platform state."
 
-    Raises:
-      Exception if the observer is not available.
-    """
-    return self.__platform_support['kubernetes'].observer
+        Raises:
+          Exception if the observer is not available.
+        """
+        return self.__platform_support["kubernetes"].observer
 
-  @property
-  def kube_v2_observer(self):
-    """The observer for inspecting Kubernetes V2 platform state."
+    @property
+    def kube_v2_observer(self):
+        """The observer for inspecting Kubernetes V2 platform state."
 
-    Raises:
-      Exception if the observer is not available.
-    """
-    return self.__platform_support['kubernetes_v2'].observer
+        Raises:
+          Exception if the observer is not available.
+        """
+        return self.__platform_support["kubernetes_v2"].observer
 
-  @property
-  def aws_observer(self):
-    """The observer for inspecting AWS platform state.
+    @property
+    def aws_observer(self):
+        """The observer for inspecting AWS platform state.
 
-    Raises:
-      Exception if the observer is not available.
-    """
-    return self.__platform_support['aws'].observer
+        Raises:
+          Exception if the observer is not available.
+        """
+        return self.__platform_support["aws"].observer
 
-  @property
-  def appengine_observer(self):
-    """The observer for inspecting App Engine platform state.
+    @property
+    def appengine_observer(self):
+        """The observer for inspecting App Engine platform state.
 
-    Raises:
-      Exception if the observer is not available.
-    """
-    return self.__platform_support['appengine'].observer
+        Raises:
+          Exception if the observer is not available.
+        """
+        return self.__platform_support["appengine"].observer
 
-  @property
-  def az_observer(self):
-    """The observer for inspecting Azure platform state.
+    @property
+    def az_observer(self):
+        """The observer for inspecting Azure platform state.
 
-    Raises:
-      Exception if the observer is not available.
-    """
-    return self.__platform_support['azure'].observer
+        Raises:
+          Exception if the observer is not available.
+        """
+        return self.__platform_support["azure"].observer
 
-  @property
-  def dcos_observer(self):
-    """The observer for inspecting DC/OS platform state."
+    @property
+    def dcos_observer(self):
+        """The observer for inspecting DC/OS platform state."
 
-    Raises:
-      Exception if the observer is not available.
-    """
-    return self.__platform_support['dcos'].observer
+        Raises:
+          Exception if the observer is not available.
+        """
+        return self.__platform_support["dcos"].observer
 
-  def __init__(self, bindings, agent=None):
-    """Constructor
+    def __init__(self, bindings, agent=None):
+        """Constructor
 
-    Args:
-      bindings: [dict] The parameter bindings for overriding the test
-         scenario configuration.
-      agent: [SpinnakerAgent] The Spinnaker agent to bind to the scenario.
-    """
-    super(SpinnakerTestScenario, self).__init__(bindings, agent)
-    self.__google_resource_analyzer = None
-    agent = self.agent
-    bindings = self.bindings
+        Args:
+          bindings: [dict] The parameter bindings for overriding the test
+             scenario configuration.
+          agent: [SpinnakerAgent] The Spinnaker agent to bind to the scenario.
+        """
+        super(SpinnakerTestScenario, self).__init__(bindings, agent)
+        self.__google_resource_analyzer = None
+        agent = self.agent
+        bindings = self.bindings
 
-    # For read-only tests that don't make mutating calls to Spinnaker,
-    # there is nothing to update in the bindings, e.g. GCP quota test.
-    if agent is not None:
-      for key, value in agent.runtime_config.items():
+        # For read-only tests that don't make mutating calls to Spinnaker,
+        # there is nothing to update in the bindings, e.g. GCP quota test.
+        if agent is not None:
+            for key, value in agent.runtime_config.items():
+                try:
+                    if bindings[key]:
+                        continue  # keep existing value already set within citest
+                except KeyError:
+                    pass
+                bindings[key] = value  # use value from agent's configuration
+
+        JournalLogger.begin_context("Configure Scenario Bindings")
+        self.__platform_support = {}
+        for klas in PLATFORM_SUPPORT_CLASSES:
+            try:
+                support = klas(self)
+                self.__platform_support[support.platform_name] = support
+            except:
+                logger = logging.getLogger(__name__)
+
+                logger.exception(
+                    "Failed to initialize support class %s:\n%s",
+                    str(klas),
+                    traceback.format_exc(),
+                )
+
         try:
-          if bindings[key]:
-            continue  # keep existing value already set within citest
-        except KeyError:
-          pass
-        bindings[key] = value  # use value from agent's configuration
+            self._do_init_bindings()
+        except:
+            logger = logging.getLogger(__name__)
+            logger.exception("Failed to initialize spinnaker agent.")
+            raise
+        finally:
+            JournalLogger.end_context()
 
-    JournalLogger.begin_context('Configure Scenario Bindings')
-    self.__platform_support = {}
-    for klas in PLATFORM_SUPPORT_CLASSES:
-      try:
-        support = klas(self)
-        self.__platform_support[support.platform_name] = support
-      except:
-        logger = logging.getLogger(__name__)
+    def _do_init_bindings(self):
+        """Hook for specific tests to add additional bindings."""
+        pass
 
-        logger.exception('Failed to initialize support class %s:\n%s',
-                         str(klas), traceback.format_exc())
+    def pre_run_hook(self, test_case, context):
+        if not self.bindings.get("RECORD_GCP_RESOURCE_USAGE"):
+            return None
 
-    try:
-      self._do_init_bindings()
-    except:
-      logger = logging.getLogger(__name__)
-      logger.exception('Failed to initialize spinnaker agent.')
-      raise
-    finally:
-      JournalLogger.end_context()
+        if self.__google_resource_analyzer is None:
+            from google_scenario_support import GcpResourceUsageAnalyzer
 
-  def _do_init_bindings(self):
-    """Hook for specific tests to add additional bindings."""
-    pass
+            self.__google_resource_analyzer = GcpResourceUsageAnalyzer(self)
+        analyzer = self.__google_resource_analyzer
 
-  def pre_run_hook(self, test_case, context):
-    if not self.bindings.get('RECORD_GCP_RESOURCE_USAGE'):
-      return None
+        scanner = analyzer.make_gcp_api_scanner(
+            self.bindings.get("GOOGLE_ACCOUNT_PROJECT"),
+            self.bindings.get("GOOGLE_CREDENTIALS_PATH"),
+            include_apis=["compute"],
+            exclude_apis=["compute.*Operations"],
+        )
+        JournalLogger.begin_context("Capturing initial quota usage")
+        try:
+            usage = analyzer.collect_resource_usage(self.gcp_observer, scanner)
+        finally:
+            JournalLogger.end_context()
+        return (scanner, usage)
 
-    if self.__google_resource_analyzer is None:
-      from google_scenario_support import GcpResourceUsageAnalyzer
-      self.__google_resource_analyzer = GcpResourceUsageAnalyzer(self)
-    analyzer = self.__google_resource_analyzer
+    def post_run_hook(self, info, test_case, context):
+        if not info:
+            return
 
-    scanner = analyzer.make_gcp_api_scanner(
-        self.bindings.get('GOOGLE_ACCOUNT_PROJECT'),
-        self.bindings.get('GOOGLE_CREDENTIALS_PATH'),
-        include_apis=['compute'],
-        exclude_apis=['compute.*Operations'])
-    JournalLogger.begin_context('Capturing initial quota usage')
-    try:
-      usage = analyzer.collect_resource_usage(self.gcp_observer, scanner)
-    finally:
-      JournalLogger.end_context()
-    return (scanner, usage)
-
-  def post_run_hook(self, info, test_case, context):
-    if not info:
-      return
-
-    scanner, before_usage = info
-    analyzer = self.__google_resource_analyzer
-    JournalLogger.begin_context('Capturing final quota usage')
-    try:
-      after_usage = analyzer.collect_resource_usage(self.gcp_observer, scanner)
-    finally:
-      JournalLogger.end_context()
-    analyzer.log_delta_resource_usage(
-        test_case, scanner, before_usage, after_usage)
+        scanner, before_usage = info
+        analyzer = self.__google_resource_analyzer
+        JournalLogger.begin_context("Capturing final quota usage")
+        try:
+            after_usage = analyzer.collect_resource_usage(self.gcp_observer, scanner)
+        finally:
+            JournalLogger.end_context()
+        analyzer.log_delta_resource_usage(test_case, scanner, before_usage, after_usage)

--- a/testing/citest/spinnaker_testing/yaml_accumulator.py
+++ b/testing/citest/spinnaker_testing/yaml_accumulator.py
@@ -19,52 +19,51 @@ import yaml
 
 
 def __flatten_into(root, prefix, target):
-  """Helper function that flattens a dictionary into the target dictionary.
+    """Helper function that flattens a dictionary into the target dictionary.
 
-  Args:
-    root: [dict] The dictionary to flatten from.
-    prefix: [string] The key prefix to use when adding entries into the target.
-    target: [dict] The dictinoary to update into.
-  """
-  for name, value in root.items():
-    key = prefix + name
-    if isinstance(value, dict):
-      __flatten_into(value, key + '.', target)
-    else:
-      target[key] = value
+    Args:
+      root: [dict] The dictionary to flatten from.
+      prefix: [string] The key prefix to use when adding entries into the target.
+      target: [dict] The dictinoary to update into.
+    """
+    for name, value in root.items():
+        key = prefix + name
+        if isinstance(value, dict):
+            __flatten_into(value, key + ".", target)
+        else:
+            target[key] = value
 
 
 def flatten(root):
-  """Flatten a hierarchical YAML dictionary into one with composite keys.
+    """Flatten a hierarchical YAML dictionary into one with composite keys.
 
-  Args:
-    root: [dict] A hierarchical dictionary.
+    Args:
+      root: [dict] A hierarchical dictionary.
 
-  Returns:
-    Equivalent dictionary with '.'-delimited keys.
-  """
-  result = {}
-  __flatten_into(root, '', result)
-  return result
+    Returns:
+      Equivalent dictionary with '.'-delimited keys.
+    """
+    result = {}
+    __flatten_into(root, "", result)
+    return result
 
 
 def load_string(source, target):
-  """Load dictionary implied by YAML text into target dictionary.
+    """Load dictionary implied by YAML text into target dictionary.
 
-  Args:
-    source: [string] YAML document text.
-    target: [dict] To update from YAML.
-  """
-  target.update(flatten(yaml.safe_load(source, Loader=yaml.Loader)))
+    Args:
+      source: [string] YAML document text.
+      target: [dict] To update from YAML.
+    """
+    target.update(flatten(yaml.safe_load(source, Loader=yaml.Loader)))
 
 
 def load_path(path, target):
-  """Load dictionary implied by YAML file into target dictionary.
+    """Load dictionary implied by YAML file into target dictionary.
 
-  Args:
-    path: [string] Path to file containing YAML document text.
-    target: [dict] To update from YAML.
-  """
-  with open(path, 'r') as f:
-    target.update(flatten(yaml.safe_load(f, Loader=yaml.Loader)))
-
+    Args:
+      path: [string] Path to file containing YAML document text.
+      target: [dict] To update from YAML.
+    """
+    with open(path, "r") as f:
+        target.update(flatten(yaml.safe_load(f, Loader=yaml.Loader)))

--- a/testing/citest/tests/appengine_gcs_pubsub_test.py
+++ b/testing/citest/tests/appengine_gcs_pubsub_test.py
@@ -73,396 +73,466 @@ import spinnaker_testing.frigga as frigga
 
 ov_factory = jc.ObservationPredicateFactory()
 
+
 class AppengineGcsPubsubTestScenario(sk.SpinnakerTestScenario):
-  """
-  Scenario for testing GAE deploys of GCS artifacts via pub/sub triggers.
-  """
-  @classmethod
-  def new_agent(cls, bindings):
-    return gate.new_agent(bindings)
-
-  @classmethod
-  def initArgumentParser(cls, parser, defaults=None):
-    """Initialize command line argument parser.
-
-    Args:
-    parser: argparse.ArgumentParser
     """
-    super(AppengineGcsPubsubTestScenario, cls).initArgumentParser(
-      parser, defaults=defaults)
+    Scenario for testing GAE deploys of GCS artifacts via pub/sub triggers.
+    """
 
-    defaults = defaults or {}
-    parser.add_argument(
-      '--app_directory_root', default=None,
-      help='Path from the root of source code repository to the application directory.')
-    parser.add_argument(
-      '--branch', default='master',
-      help='Git branch to be used when deploying from source code repository.')
-    parser.add_argument(
-      '--git_repo_url', default=None,
-      help='URL of a git source code repository used by Spinnaker to deploy to App Engine.')
-    parser.add_argument(
-      '--test_gcs_bucket', default=None,
-      help='GCS bucket to upload GAE app source code to.')
-    parser.add_argument(
-      '--test_storage_account_name', default=None,
-      help='Storage account when testing GCS buckets.'
-      ' If not specified, use the application default credentials.')
-    parser.add_argument(
-      '--test_subscription_name', default=None,
-      help='Google pub/sub subscription name configured in Echo.')
+    @classmethod
+    def new_agent(cls, bindings):
+        return gate.new_agent(bindings)
 
-  def __init__(self, bindings, agent=None):
-    super(AppengineGcsPubsubTestScenario, self).__init__(bindings, agent)
-    self.logger = logging.getLogger(__name__)
+    @classmethod
+    def initArgumentParser(cls, parser, defaults=None):
+        """Initialize command line argument parser.
 
-    bindings = self.bindings
+        Args:
+        parser: argparse.ArgumentParser
+        """
+        super(AppengineGcsPubsubTestScenario, cls).initArgumentParser(
+            parser, defaults=defaults
+        )
 
-    if not bindings['GIT_REPO_URL']:
-      raise ValueError('Must supply value for --git_repo_url')
+        defaults = defaults or {}
+        parser.add_argument(
+            "--app_directory_root",
+            default=None,
+            help="Path from the root of source code repository to the application directory.",
+        )
+        parser.add_argument(
+            "--branch",
+            default="master",
+            help="Git branch to be used when deploying from source code repository.",
+        )
+        parser.add_argument(
+            "--git_repo_url",
+            default=None,
+            help="URL of a git source code repository used by Spinnaker to deploy to App Engine.",
+        )
+        parser.add_argument(
+            "--test_gcs_bucket",
+            default=None,
+            help="GCS bucket to upload GAE app source code to.",
+        )
+        parser.add_argument(
+            "--test_storage_account_name",
+            default=None,
+            help="Storage account when testing GCS buckets."
+            " If not specified, use the application default credentials.",
+        )
+        parser.add_argument(
+            "--test_subscription_name",
+            default=None,
+            help="Google pub/sub subscription name configured in Echo.",
+        )
 
-    if not bindings['APP_DIRECTORY_ROOT']:
-      raise ValueError('Must supply value for --app_directory_root')
+    def __init__(self, bindings, agent=None):
+        super(AppengineGcsPubsubTestScenario, self).__init__(bindings, agent)
+        self.logger = logging.getLogger(__name__)
 
-    # We'll call out the app name because it is widely used
-    # because it scopes the context of our activities.
-    self.TEST_APP = bindings['TEST_APP']
-    self.TEST_STACK = bindings['TEST_STACK']
-    self.__EXPECTED_ARTIFACT_ID = 'deployable-gae-app-artifact'
+        bindings = self.bindings
 
-    self.__gcp_project = bindings['APPENGINE_PRIMARY_MANAGED_PROJECT_ID']
-    self.__cluster_name = frigga.Naming.cluster(self.TEST_APP, self.TEST_STACK)
-    self.__server_group_name = frigga.Naming.server_group(self.TEST_APP, self.TEST_STACK)
-    self.__lb_name = self.__cluster_name
+        if not bindings["GIT_REPO_URL"]:
+            raise ValueError("Must supply value for --git_repo_url")
 
-    self.__subscription_name = bindings['TEST_SUBSCRIPTION_NAME']
-    self.__gcs_pubsub_agent = sk.GcsFileUploadAgent(bindings['APPENGINE_CREDENTIALS_PATH'])
+        if not bindings["APP_DIRECTORY_ROOT"]:
+            raise ValueError("Must supply value for --app_directory_root")
 
-    # Python is clearly hard-coded as the runtime here, but we're just asking App Engine to be a static file server.
-    self.__app_yaml = ('\n'.join(['runtime: python27',
-                                  'api_version: 1',
-                                  'threadsafe: true',
-                                  'service: {service}',
-                                  'handlers:',
-                                  ' - url: /.*',
-                                  '   static_dir: .']).format(service=self.__lb_name))
+        # We'll call out the app name because it is widely used
+        # because it scopes the context of our activities.
+        self.TEST_APP = bindings["TEST_APP"]
+        self.TEST_STACK = bindings["TEST_STACK"]
+        self.__EXPECTED_ARTIFACT_ID = "deployable-gae-app-artifact"
 
-    self.__app_directory_root = bindings['APP_DIRECTORY_ROOT']
-    self.__branch = bindings['BRANCH']
+        self.__gcp_project = bindings["APPENGINE_PRIMARY_MANAGED_PROJECT_ID"]
+        self.__cluster_name = frigga.Naming.cluster(self.TEST_APP, self.TEST_STACK)
+        self.__server_group_name = frigga.Naming.server_group(
+            self.TEST_APP, self.TEST_STACK
+        )
+        self.__lb_name = self.__cluster_name
 
-    self.pipeline_id = None
+        self.__subscription_name = bindings["TEST_SUBSCRIPTION_NAME"]
+        self.__gcs_pubsub_agent = sk.GcsFileUploadAgent(
+            bindings["APPENGINE_CREDENTIALS_PATH"]
+        )
 
-    self.bucket = bindings['TEST_GCS_BUCKET']
-    self.__test_repository_url = 'gs://' + self.bucket
-    self.__pipeline_id = None
+        # Python is clearly hard-coded as the runtime here, but we're just asking App Engine to be a static file server.
+        self.__app_yaml = "\n".join(
+            [
+                "runtime: python27",
+                "api_version: 1",
+                "threadsafe: true",
+                "service: {service}",
+                "handlers:",
+                " - url: /.*",
+                "   static_dir: .",
+            ]
+        ).format(service=self.__lb_name)
 
+        self.__app_directory_root = bindings["APP_DIRECTORY_ROOT"]
+        self.__branch = bindings["BRANCH"]
 
-  def create_app(self):
-    # Not testing create_app, since the operation is well tested elsewhere.
-    # Retryable to handle platform flakiness.
-    contract = jc.Contract()
-    return st.OperationContract(
-      self.agent.make_create_app_operation(
-        bindings=self.bindings,
-        application=self.TEST_APP,
-        account_name=self.bindings['SPINNAKER_APPENGINE_ACCOUNT'],
-        cloud_providers="appengine"),
-      contract=contract)
+        self.pipeline_id = None
 
-  def delete_app(self):
-    # Not testing delete_app, since the operation is well tested elsewhere.
-    # Retryable to handle platform flakiness.
-    contract = jc.Contract()
-    return st.OperationContract(
-      self.agent.make_delete_app_operation(
-        application=self.TEST_APP,
-        account_name=self.bindings['SPINNAKER_APPENGINE_ACCOUNT']),
-      contract=contract)
+        self.bucket = bindings["TEST_GCS_BUCKET"]
+        self.__test_repository_url = "gs://" + self.bucket
+        self.__pipeline_id = None
 
-  def make_deploy_stage(self):
-    return {
-      'clusters': [
-        {
-          'account': self.bindings['SPINNAKER_APPENGINE_ACCOUNT'],
-          'application': self.TEST_APP,
-          'cloudProvider': 'appengine',
-          'configFilepaths': [],
-          'configFiles': [self.__app_yaml],
-          'expectedArtifactId': self.__EXPECTED_ARTIFACT_ID,
-          'fromArtifact': True,
-          'gitCredentialType': 'NONE',
-          'interestingHealthProviderNames': [
-            'App Engine Service'
-          ],
-          'provider': 'appengine',
-          'region': self.bindings['TEST_GCE_REGION'],
-          'sourceType': 'gcs',
-          'stack': self.TEST_STACK,
-          'storageAccountName': self.bindings.get('TEST_STORAGE_ACCOUNT_NAME')
+    def create_app(self):
+        # Not testing create_app, since the operation is well tested elsewhere.
+        # Retryable to handle platform flakiness.
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_create_app_operation(
+                bindings=self.bindings,
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_APPENGINE_ACCOUNT"],
+                cloud_providers="appengine",
+            ),
+            contract=contract,
+        )
+
+    def delete_app(self):
+        # Not testing delete_app, since the operation is well tested elsewhere.
+        # Retryable to handle platform flakiness.
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_delete_app_operation(
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_APPENGINE_ACCOUNT"],
+            ),
+            contract=contract,
+        )
+
+    def make_deploy_stage(self):
+        return {
+            "clusters": [
+                {
+                    "account": self.bindings["SPINNAKER_APPENGINE_ACCOUNT"],
+                    "application": self.TEST_APP,
+                    "cloudProvider": "appengine",
+                    "configFilepaths": [],
+                    "configFiles": [self.__app_yaml],
+                    "expectedArtifactId": self.__EXPECTED_ARTIFACT_ID,
+                    "fromArtifact": True,
+                    "gitCredentialType": "NONE",
+                    "interestingHealthProviderNames": ["App Engine Service"],
+                    "provider": "appengine",
+                    "region": self.bindings["TEST_GCE_REGION"],
+                    "sourceType": "gcs",
+                    "stack": self.TEST_STACK,
+                    "storageAccountName": self.bindings.get(
+                        "TEST_STORAGE_ACCOUNT_NAME"
+                    ),
+                }
+            ],
+            "name": "Deploy",
+            "refId": "DEPLOY",
+            "requisiteStageRefIds": [],
+            "type": "deploy",
         }
-      ],
-      'name': 'Deploy',
-      'refId': 'DEPLOY',
-      'requisiteStageRefIds': [],
-      'type': 'deploy'
-    }
 
-  def make_pubsub_trigger(self):
-    return {
-      'attributeConstraints': {'eventType': 'OBJECT_FINALIZE'},
-      'constraints': {},
-      'enabled': True,
-      'expectedArtifactIds': [
-        self.__EXPECTED_ARTIFACT_ID
-      ],
-      'payloadConstraints': {},
-      'pubsubSystem': 'google',
-      'subscriptionName': self.__subscription_name, # Logical name assigned in Echo.
-      'type': 'pubsub'
-    }
+    def make_pubsub_trigger(self):
+        return {
+            "attributeConstraints": {"eventType": "OBJECT_FINALIZE"},
+            "constraints": {},
+            "enabled": True,
+            "expectedArtifactIds": [self.__EXPECTED_ARTIFACT_ID],
+            "payloadConstraints": {},
+            "pubsubSystem": "google",
+            "subscriptionName": self.__subscription_name,  # Logical name assigned in Echo.
+            "type": "pubsub",
+        }
 
-  def make_expected_artifact(self):
-    return {
-      'defaultArtifact': {
-        'kind': 'custom'
-      },
-      'id': self.__EXPECTED_ARTIFACT_ID,
-      'matchArtifact': {
-        'kind': 'gcs',
-        'name': 'gs://{}/app.tar'.format(self.bucket),
-        'type': 'gcs/object'
-      },
-      'useDefaultArtifact': False,
-      'usePriorExecution': False
-    }
+    def make_expected_artifact(self):
+        return {
+            "defaultArtifact": {"kind": "custom"},
+            "id": self.__EXPECTED_ARTIFACT_ID,
+            "matchArtifact": {
+                "kind": "gcs",
+                "name": "gs://{}/app.tar".format(self.bucket),
+                "type": "gcs/object",
+            },
+            "useDefaultArtifact": False,
+            "usePriorExecution": False,
+        }
 
-  def make_pipeline_spec(self, name):
-    return dict(
-      name=name,
-      stages=[self.make_deploy_stage()],
-      triggers=[self.make_pubsub_trigger()],
-      expectedArtifacts=[self.make_expected_artifact()],
-      application=self.TEST_APP,
-      stageCounter=1,
-      parallel=True,
-      limitConcurrent=True,
-      appConfig={},
-      index=0
-    )
+    def make_pipeline_spec(self, name):
+        return dict(
+            name=name,
+            stages=[self.make_deploy_stage()],
+            triggers=[self.make_pubsub_trigger()],
+            expectedArtifacts=[self.make_expected_artifact()],
+            application=self.TEST_APP,
+            stageCounter=1,
+            parallel=True,
+            limitConcurrent=True,
+            appConfig={},
+            index=0,
+        )
 
-  def make_dict_matcher(self, want):
-    spec = {}
-    for key, value in want.items():
-      if isinstance(value, dict):
-        spec[key] = self.make_dict_matcher(value)
-      elif isinstance(value, list):
-        list_spec = []
-        for elem in value:
-          if isinstance(elem, dict):
-            list_spec.append(self.make_dict_matcher(elem))
-          else:
-            list_spec.append(jp.CONTAINS(elem))
-        spec[key] = jp.LIST_MATCHES(list_spec)
-      else:
-        spec[key] = jp.CONTAINS(value)
+    def make_dict_matcher(self, want):
+        spec = {}
+        for key, value in want.items():
+            if isinstance(value, dict):
+                spec[key] = self.make_dict_matcher(value)
+            elif isinstance(value, list):
+                list_spec = []
+                for elem in value:
+                    if isinstance(elem, dict):
+                        list_spec.append(self.make_dict_matcher(elem))
+                    else:
+                        list_spec.append(jp.CONTAINS(elem))
+                spec[key] = jp.LIST_MATCHES(list_spec)
+            else:
+                spec[key] = jp.CONTAINS(value)
 
-    return jp.DICT_MATCHES(spec)
+        return jp.DICT_MATCHES(spec)
 
-  def create_deploy_pipeline(self):
-    name = 'GcsToGaePubsubDeploy'
-    self.pipeline_id = name
+    def create_deploy_pipeline(self):
+        name = "GcsToGaePubsubDeploy"
+        self.pipeline_id = name
 
-    pipeline_spec = self.make_pipeline_spec(name)
-    payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
+        pipeline_spec = self.make_pipeline_spec(name)
+        payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
 
-    pipeline_config_path = 'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP)
-    builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Pipeline', retryable_for_secs=15)
-     .get_url_path(pipeline_config_path)
-     .EXPECT(
-       jp.LIST_MATCHES([self.make_dict_matcher(pipeline_spec)])))
+        pipeline_config_path = "applications/{app}/pipelineConfigs".format(
+            app=self.TEST_APP
+        )
+        builder = st.HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder("Has Pipeline", retryable_for_secs=15)
+            .get_url_path(pipeline_config_path)
+            .EXPECT(jp.LIST_MATCHES([self.make_dict_matcher(pipeline_spec)]))
+        )
 
-    # Need to query Gate for the id of the pipeline we just created...
-    def create_pipeline_id_extractor(_ignored, context):
-      pipeline_config_resp = self.agent.get(pipeline_config_path)
-      pipeline_config_list = json.JSONDecoder().decode(pipeline_config_resp.output)
-      found = next((x for x in pipeline_config_list if x['name'] == self.pipeline_id), None)
-      if (found is not None):
-        context['pipelineId'] = found['id'] # I don't know how to reference this later, so I'm saving it in self for now.
-        self.__pipeline_id = found['id'] # I don't know how to reference this later, so I'm saving it in self for now.
-        logging.info('Created pipeline config with id: %s', context['pipelineId'])
+        # Need to query Gate for the id of the pipeline we just created...
+        def create_pipeline_id_extractor(_ignored, context):
+            pipeline_config_resp = self.agent.get(pipeline_config_path)
+            pipeline_config_list = json.JSONDecoder().decode(
+                pipeline_config_resp.output
+            )
+            found = next(
+                (x for x in pipeline_config_list if x["name"] == self.pipeline_id), None
+            )
+            if found is not None:
+                context["pipelineId"] = found[
+                    "id"
+                ]  # I don't know how to reference this later, so I'm saving it in self for now.
+                self.__pipeline_id = found[
+                    "id"
+                ]  # I don't know how to reference this later, so I'm saving it in self for now.
+                logging.info(
+                    "Created pipeline config with id: %s", context["pipelineId"]
+                )
 
-    return st.OperationContract(
-      self.new_post_operation(
-        title='create_gcs_gae_pubsub_pipeline', data=payload, path='pipelines',
-        status_class=st.SynchronousHttpOperationStatus),
-      contract=builder.build(),
-      status_extractor=create_pipeline_id_extractor)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_gcs_gae_pubsub_pipeline",
+                data=payload,
+                path="pipelines",
+                status_class=st.SynchronousHttpOperationStatus,
+            ),
+            contract=builder.build(),
+            status_extractor=create_pipeline_id_extractor,
+        )
 
-  def trigger_deploy_pipeline(self):
-    name = 'app.tar'
-    command = 'tar -cvf {tar} {git_dir}/{app_root}/*'.format(tar=name,
-                                                             git_dir=self.temp,
-                                                             app_root=self.bindings['APP_DIRECTORY_ROOT'])
-    logging.info('Tar-ing %s/%s for GCS upload', self.temp, self.bindings['APP_DIRECTORY_ROOT'])
-    subprocess.Popen(command, stderr=sys.stderr, shell=True).wait()
+    def trigger_deploy_pipeline(self):
+        name = "app.tar"
+        command = "tar -cvf {tar} {git_dir}/{app_root}/*".format(
+            tar=name, git_dir=self.temp, app_root=self.bindings["APP_DIRECTORY_ROOT"]
+        )
+        logging.info(
+            "Tar-ing %s/%s for GCS upload",
+            self.temp,
+            self.bindings["APP_DIRECTORY_ROOT"],
+        )
+        subprocess.Popen(command, stderr=sys.stderr, shell=True).wait()
 
-    group_name = frigga.Naming.server_group(
-        app=self.TEST_APP,
-        stack=self.bindings['TEST_STACK'],
-        version='v000')
+        group_name = frigga.Naming.server_group(
+            app=self.TEST_APP, stack=self.bindings["TEST_STACK"], version="v000"
+        )
 
-    # Triggered pipeline does a deploy, check for that server group.
-    server_group_path = 'applications/{app}/serverGroups'.format(app=self.TEST_APP)
-    builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('GAE Deploy Pipeline Succeeded',
-                                retryable_for_secs=300)
-     .get_url_path(server_group_path)
-     .EXPECT(
-       ov_factory.value_list_matches(
-         [jp.DICT_MATCHES({'name': jp.STR_EQ(group_name)})]
-       )))
+        # Triggered pipeline does a deploy, check for that server group.
+        server_group_path = "applications/{app}/serverGroups".format(app=self.TEST_APP)
+        builder = st.HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder(
+                "GAE Deploy Pipeline Succeeded", retryable_for_secs=300
+            )
+            .get_url_path(server_group_path)
+            .EXPECT(
+                ov_factory.value_list_matches(
+                    [jp.DICT_MATCHES({"name": jp.STR_EQ(group_name)})]
+                )
+            )
+        )
 
-    executions_path = 'executions?pipelineConfigIds={}'.format(self.__pipeline_id)
-    return st.OperationContract(
-      self.__gcs_pubsub_agent.new_gcs_pubsub_trigger_operation(
-        gate_agent=self.agent,
-        title='monitor_gcs_pubsub_pipeline',
-        bucket_name=self.bucket,
-        upload_path='{}'.format(name),
-        local_filename=os.path.abspath(name),
-        status_class=gate.GatePipelineStatus,
-        status_path=executions_path
-      ),
-      contract=builder.build())
+        executions_path = "executions?pipelineConfigIds={}".format(self.__pipeline_id)
+        return st.OperationContract(
+            self.__gcs_pubsub_agent.new_gcs_pubsub_trigger_operation(
+                gate_agent=self.agent,
+                title="monitor_gcs_pubsub_pipeline",
+                bucket_name=self.bucket,
+                upload_path="{}".format(name),
+                local_filename=os.path.abspath(name),
+                status_class=gate.GatePipelineStatus,
+                status_path=executions_path,
+            ),
+            contract=builder.build(),
+        )
 
-  def delete_load_balancer(self):
-    bindings = self.bindings
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'type': 'deleteLoadBalancer',
-            'cloudProvider': 'appengine',
-            'loadBalancerName': self.__lb_name,
-            'account': bindings['SPINNAKER_APPENGINE_ACCOUNT'],
-            'credentials': bindings['SPINNAKER_APPENGINE_ACCOUNT'],
-            'user': '[anonymous]'
-        }],
-        description='Delete Load Balancer: {0} in {1}'.format(
-            self.__lb_name,
-            bindings['SPINNAKER_APPENGINE_ACCOUNT']),
-        application=self.TEST_APP)
+    def delete_load_balancer(self):
+        bindings = self.bindings
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "type": "deleteLoadBalancer",
+                    "cloudProvider": "appengine",
+                    "loadBalancerName": self.__lb_name,
+                    "account": bindings["SPINNAKER_APPENGINE_ACCOUNT"],
+                    "credentials": bindings["SPINNAKER_APPENGINE_ACCOUNT"],
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Delete Load Balancer: {0} in {1}".format(
+                self.__lb_name, bindings["SPINNAKER_APPENGINE_ACCOUNT"]
+            ),
+            application=self.TEST_APP,
+        )
 
-    builder = gcp.GcpContractBuilder(self.appengine_observer)
-    (builder.new_clause_builder('Service Deleted', retryable_for_secs=30)
-     .inspect_resource('apps.services',
-                       self.__lb_name,
-                       appsId=self.__gcp_project)
-     .EXPECT(
-         ov_factory.error_list_contains(gcp.HttpErrorPredicate(http_code=404))))
+        builder = gcp.GcpContractBuilder(self.appengine_observer)
+        (
+            builder.new_clause_builder("Service Deleted", retryable_for_secs=30)
+            .inspect_resource(
+                "apps.services", self.__lb_name, appsId=self.__gcp_project
+            )
+            .EXPECT(
+                ov_factory.error_list_contains(gcp.HttpErrorPredicate(http_code=404))
+            )
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_load_balancer', data=payload, path='tasks'),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete_load_balancer", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
-  def delete_deploy_pipeline(self, pipeline_id):
-    payload = self.agent.make_json_payload_from_kwargs(id=pipeline_id)
-    path = os.path.join('pipelines', self.TEST_APP, pipeline_id)
+    def delete_deploy_pipeline(self, pipeline_id):
+        payload = self.agent.make_json_payload_from_kwargs(id=pipeline_id)
+        path = os.path.join("pipelines", self.TEST_APP, pipeline_id)
 
-    builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Pipeline',
-                                retryable_for_secs=5)
-     .get_url_path(
-       'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
-     .excludes_path_value('name', pipeline_id))
+        builder = st.HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder("Has Pipeline", retryable_for_secs=5)
+            .get_url_path(
+                "applications/{app}/pipelineConfigs".format(app=self.TEST_APP)
+            )
+            .excludes_path_value("name", pipeline_id)
+        )
 
-    return st.OperationContract(
-      self.new_delete_operation(
-        title='delete_deploy_pipeline', data=payload, path=path,
-        status_class=st.SynchronousHttpOperationStatus),
-      contract=builder.build())
+        return st.OperationContract(
+            self.new_delete_operation(
+                title="delete_deploy_pipeline",
+                data=payload,
+                path=path,
+                status_class=st.SynchronousHttpOperationStatus,
+            ),
+            contract=builder.build(),
+        )
+
 
 class AppengineGcsPubsubTest(st.AgentTestCase):
-  @classmethod
-  def setUpClass(cls):
-    runner = citest.base.TestRunner.global_runner()
-    scenario = runner.get_shared_data(AppengineGcsPubsubTestScenario)
-    bindings = scenario.bindings
+    @classmethod
+    def setUpClass(cls):
+        runner = citest.base.TestRunner.global_runner()
+        scenario = runner.get_shared_data(AppengineGcsPubsubTestScenario)
+        bindings = scenario.bindings
 
-    branch = bindings['BRANCH']
-    git_repo = bindings['GIT_REPO_URL']
+        branch = bindings["BRANCH"]
+        git_repo = bindings["GIT_REPO_URL"]
 
-    scenario.temp = tempfile.mkdtemp()
+        scenario.temp = tempfile.mkdtemp()
 
-    gcs_path = 'gs://{bucket}'.format(bucket=scenario.bucket)
-    topic = '{}-topic'.format(bindings['TEST_APP'])
-    subscription = '{}-subscription'.format(bindings['TEST_APP'])
+        gcs_path = "gs://{bucket}".format(bucket=scenario.bucket)
+        topic = "{}-topic".format(bindings["TEST_APP"])
+        subscription = "{}-subscription".format(bindings["TEST_APP"])
 
-    # App to tar and upload to GCS.
-    command = 'git clone {repo} -b {branch} {dir}'.format(
-      repo=git_repo, branch=branch, dir=scenario.temp)
-    logging.info('Fetching %s', git_repo)
-    subprocess.Popen(command, stderr=sys.stderr, shell=True).wait()
+        # App to tar and upload to GCS.
+        command = "git clone {repo} -b {branch} {dir}".format(
+            repo=git_repo, branch=branch, dir=scenario.temp
+        )
+        logging.info("Fetching %s", git_repo)
+        subprocess.Popen(command, stderr=sys.stderr, shell=True).wait()
 
+    @classmethod
+    def tearDownClass(cls):
+        runner = citest.base.TestRunner.global_runner()
+        scenario = runner.get_shared_data(AppengineGcsPubsubTestScenario)
+        bindings = scenario.bindings
+        shutil.rmtree(scenario.temp)
 
-  @classmethod
-  def tearDownClass(cls):
-    runner = citest.base.TestRunner.global_runner()
-    scenario = runner.get_shared_data(AppengineGcsPubsubTestScenario)
-    bindings = scenario.bindings
-    shutil.rmtree(scenario.temp)
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            AppengineGcsPubsubTestScenario
+        )
 
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(AppengineGcsPubsubTestScenario)
+    @property
+    def testing_agent(self):
+        return self.scenario.agent
 
-  @property
-  def testing_agent(self):
-    return self.scenario.agent
+    def test_a_create_app(self):
+        self.run_test_case(
+            self.scenario.create_app(), retry_interval_secs=8, max_retries=8
+        )
 
-  def test_a_create_app(self):
-    self.run_test_case(self.scenario.create_app(),
-                       retry_interval_secs=8, max_retries=8)
+    def test_b_create_pipeline(self):
+        self.run_test_case(
+            self.scenario.create_deploy_pipeline(), retry_interval_secs=8, max_retries=8
+        )
 
-  def test_b_create_pipeline(self):
-    self.run_test_case(self.scenario.create_deploy_pipeline(),
-                       retry_interval_secs=8, max_retries=8)
+    def test_d_run_pipeline(self):
+        time.sleep(60)
+        # Wait for Echo's cache to pick up the deploy pipeline.
+        # This is generally a bad strategy for synchronizing cache timing, so we'll investigate
+        # performing this check a different way in the future. One option is querying the
+        # Spinnaker services' metrics endpoint and inspecting metrics related to caching
+        # once they are instrumented.
+        self.run_test_case(self.scenario.trigger_deploy_pipeline(), poll_every_secs=5)
 
-  def test_d_run_pipeline(self):
-    time.sleep(60)
-    # Wait for Echo's cache to pick up the deploy pipeline.
-    # This is generally a bad strategy for synchronizing cache timing, so we'll investigate
-    # performing this check a different way in the future. One option is querying the
-    # Spinnaker services' metrics endpoint and inspecting metrics related to caching
-    # once they are instrumented.
-    self.run_test_case(self.scenario.trigger_deploy_pipeline(), poll_every_secs=5)
+    def test_x_delete_load_balancer(self):
+        self.run_test_case(
+            self.scenario.delete_load_balancer(), retry_interval_secs=8, max_retries=8
+        )
 
-  def test_x_delete_load_balancer(self):
-    self.run_test_case(self.scenario.delete_load_balancer(),
-                       retry_interval_secs=8, max_retries=8)
+    def test_y_delete_pipeline(self):
+        self.run_test_case(
+            self.scenario.delete_deploy_pipeline(self.scenario.pipeline_id)
+        )
 
-  def test_y_delete_pipeline(self):
-    self.run_test_case(
-      self.scenario.delete_deploy_pipeline(self.scenario.pipeline_id))
-
-  def test_z_delete_app(self):
-    # Give a total of a minute because it might also need
-    # an internal cache update
-    self.run_test_case(self.scenario.delete_app(),
-                       retry_interval_secs=8, max_retries=8)
+    def test_z_delete_app(self):
+        # Give a total of a minute because it might also need
+        # an internal cache update
+        self.run_test_case(
+            self.scenario.delete_app(), retry_interval_secs=8, max_retries=8
+        )
 
 
 def main():
-  defaults = {
-    'TEST_STACK': AppengineGcsPubsubTestScenario.DEFAULT_TEST_ID,
-    'TEST_APP': 'gae2' + AppengineGcsPubsubTestScenario.DEFAULT_TEST_ID
-  }
+    defaults = {
+        "TEST_STACK": AppengineGcsPubsubTestScenario.DEFAULT_TEST_ID,
+        "TEST_APP": "gae2" + AppengineGcsPubsubTestScenario.DEFAULT_TEST_ID,
+    }
 
-  return citest.base.TestRunner.main(
-    parser_inits=[AppengineGcsPubsubTestScenario.initArgumentParser],
-    default_binding_overrides=defaults,
-    test_case_list=[AppengineGcsPubsubTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[AppengineGcsPubsubTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[AppengineGcsPubsubTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/appengine_smoke_test.py
+++ b/testing/citest/tests/appengine_smoke_test.py
@@ -51,6 +51,7 @@ import citest.gcp_testing as gcp
 import citest.json_contract as jc
 import citest.json_predicate as jp
 import citest.service_testing as st
+
 ov_factory = jc.ObservationPredicateFactory()
 
 import spinnaker_testing as sk
@@ -60,407 +61,474 @@ import citest.base
 
 
 class AppengineSmokeTestScenario(sk.SpinnakerTestScenario):
-  """Defines the scenario for the integration test.
+    """Defines the scenario for the integration test.
 
-  We're going to:
-    Create a Spinnaker Application
-    Create a Spinnaker Server Group (implicitly creates a Load Balancer)
-    Create a Pipeline with the following stages
-      - Deploy
-      - Upsert Load Balancer
-    Delete Load Balancer (implicitly destroys the Server Groups
-    created within this test)
-    Delete Application
-  """
-  @classmethod
-  def new_agent(cls, bindings):
-    return gate.new_agent(bindings)
+    We're going to:
+      Create a Spinnaker Application
+      Create a Spinnaker Server Group (implicitly creates a Load Balancer)
+      Create a Pipeline with the following stages
+        - Deploy
+        - Upsert Load Balancer
+      Delete Load Balancer (implicitly destroys the Server Groups
+      created within this test)
+      Delete Application
+    """
 
-  @classmethod
-  def initArgumentParser(cls, parser, defaults=None):
-    """Initialize command line argument parser."""
-    super(AppengineSmokeTestScenario, cls).initArgumentParser(
-          parser, defaults=defaults)
-    parser.add_argument(
-        '--test_gcs_bucket', default=None,
-        help='URL to use for testing appengine deployment from a bucket.'
-             ' The test will write into this bucket'
-             ' then deploy what it writes.')
+    @classmethod
+    def new_agent(cls, bindings):
+        return gate.new_agent(bindings)
 
-    parser.add_argument(
-        '--test_storage_account_name', default=None,
-        help='Storage account when testing GCS buckets.'
-        ' If not specified, use the application default credentials.')
+    @classmethod
+    def initArgumentParser(cls, parser, defaults=None):
+        """Initialize command line argument parser."""
+        super(AppengineSmokeTestScenario, cls).initArgumentParser(
+            parser, defaults=defaults
+        )
+        parser.add_argument(
+            "--test_gcs_bucket",
+            default=None,
+            help="URL to use for testing appengine deployment from a bucket."
+            " The test will write into this bucket"
+            " then deploy what it writes.",
+        )
 
-    parser.add_argument(
-        '--test_appengine_region', default='us-central',
-        help='Region to use for AppEngine tests.')
+        parser.add_argument(
+            "--test_storage_account_name",
+            default=None,
+            help="Storage account when testing GCS buckets."
+            " If not specified, use the application default credentials.",
+        )
 
-    parser.add_argument('--git_repo_url', default=None,
-                        help='URL of a GIT source code repository used by Spinnaker to deploy to App Engine.')
-    parser.add_argument('--branch', default='master',
-                        help='Git branch to be used when deploying from source code repository.')
-    parser.add_argument('--app_directory_root', default=None,
-                        help='Path from the root of source code repository to the application directory.')
+        parser.add_argument(
+            "--test_appengine_region",
+            default="us-central",
+            help="Region to use for AppEngine tests.",
+        )
 
-  def __init__(self, bindings, agent=None):
-    super(AppengineSmokeTestScenario, self).__init__(bindings, agent)
+        parser.add_argument(
+            "--git_repo_url",
+            default=None,
+            help="URL of a GIT source code repository used by Spinnaker to deploy to App Engine.",
+        )
+        parser.add_argument(
+            "--branch",
+            default="master",
+            help="Git branch to be used when deploying from source code repository.",
+        )
+        parser.add_argument(
+            "--app_directory_root",
+            default=None,
+            help="Path from the root of source code repository to the application directory.",
+        )
 
-    if not bindings['GIT_REPO_URL']:
-      raise ValueError('Must supply value for --git_repo_url')
+    def __init__(self, bindings, agent=None):
+        super(AppengineSmokeTestScenario, self).__init__(bindings, agent)
 
-    if not bindings['APP_DIRECTORY_ROOT']:
-      raise ValueError('Must supply value for --app_directory_root')
+        if not bindings["GIT_REPO_URL"]:
+            raise ValueError("Must supply value for --git_repo_url")
 
-    self.TEST_APP = bindings['TEST_APP']
-    self.TEST_STACK = bindings['TEST_STACK']
-    self.__path = 'applications/%s/tasks' % self.TEST_APP
-    self.__gcp_project = bindings['APPENGINE_PRIMARY_MANAGED_PROJECT_ID']
-    self.__cluster_name = frigga.Naming.cluster(self.TEST_APP, self.TEST_STACK)
-    self.__server_group_name = frigga.Naming.server_group(self.TEST_APP, self.TEST_STACK)
-    self.__lb_name = self.__cluster_name
+        if not bindings["APP_DIRECTORY_ROOT"]:
+            raise ValueError("Must supply value for --app_directory_root")
 
-    # Python is clearly hard-coded as the runtime here, but we're just asking App Engine to be a static file server.
-    self.__app_yaml = ('\n'.join(['runtime: python27',
-                                  'api_version: 1',
-                                  'threadsafe: true',
-                                  'service: {service}',
-                                  'handlers:',
-                                  ' - url: /.*',
-                                  '   static_dir: .']).format(service=self.__lb_name))
+        self.TEST_APP = bindings["TEST_APP"]
+        self.TEST_STACK = bindings["TEST_STACK"]
+        self.__path = "applications/%s/tasks" % self.TEST_APP
+        self.__gcp_project = bindings["APPENGINE_PRIMARY_MANAGED_PROJECT_ID"]
+        self.__cluster_name = frigga.Naming.cluster(self.TEST_APP, self.TEST_STACK)
+        self.__server_group_name = frigga.Naming.server_group(
+            self.TEST_APP, self.TEST_STACK
+        )
+        self.__lb_name = self.__cluster_name
 
-    self.__app_directory_root = bindings['APP_DIRECTORY_ROOT']
-    self.__branch = bindings['BRANCH']
-    self.pipeline_id = None
+        # Python is clearly hard-coded as the runtime here, but we're just asking App Engine to be a static file server.
+        self.__app_yaml = "\n".join(
+            [
+                "runtime: python27",
+                "api_version: 1",
+                "threadsafe: true",
+                "service: {service}",
+                "handlers:",
+                " - url: /.*",
+                "   static_dir: .",
+            ]
+        ).format(service=self.__lb_name)
 
-    try:
-      repo_path = self.__clone_app_repo()
-      appengine_dir = self.bindings['APP_DIRECTORY_ROOT']
-      repo_appengine_path = os.path.join(repo_path, appengine_dir)
+        self.__app_directory_root = bindings["APP_DIRECTORY_ROOT"]
+        self.__branch = bindings["BRANCH"]
+        self.pipeline_id = None
 
-      self.__prepare_app_default_version(repo_appengine_path)
+        try:
+            repo_path = self.__clone_app_repo()
+            appengine_dir = self.bindings["APP_DIRECTORY_ROOT"]
+            repo_appengine_path = os.path.join(repo_path, appengine_dir)
 
-      test_bucket = bindings['TEST_GCS_BUCKET']
-      if test_bucket:
-        self.__prepare_bucket(test_bucket, repo_appengine_path)
-        self.__test_repository_url = 'gs://' + test_bucket
-      else:
-        self.__test_repository_url = bindings['GIT_REPO_URL']
-    finally:
-      shutil.rmtree(repo_path)
+            self.__prepare_app_default_version(repo_appengine_path)
 
-  def __clone_app_repo(self):
-    temp = tempfile.mkdtemp()
+            test_bucket = bindings["TEST_GCS_BUCKET"]
+            if test_bucket:
+                self.__prepare_bucket(test_bucket, repo_appengine_path)
+                self.__test_repository_url = "gs://" + test_bucket
+            else:
+                self.__test_repository_url = bindings["GIT_REPO_URL"]
+        finally:
+            shutil.rmtree(repo_path)
 
-    git_repo = self.bindings['GIT_REPO_URL']
-    branch = self.bindings['BRANCH']
+    def __clone_app_repo(self):
+        temp = tempfile.mkdtemp()
 
-    command = 'git clone {repo} -b {branch} {dir}'.format(
-        repo=git_repo, branch=branch, dir=temp)
-    logging.info('Fetching %s', git_repo)
-    subprocess.Popen(command, stderr=sys.stderr, shell=True).wait()
+        git_repo = self.bindings["GIT_REPO_URL"]
+        branch = self.bindings["BRANCH"]
 
-    return temp
+        command = "git clone {repo} -b {branch} {dir}".format(
+            repo=git_repo, branch=branch, dir=temp
+        )
+        logging.info("Fetching %s", git_repo)
+        subprocess.Popen(command, stderr=sys.stderr, shell=True).wait()
 
-  def __prepare_bucket(self, bucket, repo_appengine_path):
-    root = self.bindings['APP_DIRECTORY_ROOT']
-    gcs_path = 'gs://{bucket}/{root}'.format(
-        bucket=self.bindings['TEST_GCS_BUCKET'], root=root)
+        return temp
 
-    command = 'gsutil -m rsync {local} {gcs}'.format(
-        local=repo_appengine_path, gcs=gcs_path)
-    logging.info('Preparing %s', gcs_path)
-    subprocess.Popen(command, stderr=sys.stderr, shell=True).wait()
+    def __prepare_bucket(self, bucket, repo_appengine_path):
+        root = self.bindings["APP_DIRECTORY_ROOT"]
+        gcs_path = "gs://{bucket}/{root}".format(
+            bucket=self.bindings["TEST_GCS_BUCKET"], root=root
+        )
 
-  def __prepare_app_default_version(self, repo_appengine_path):
-    if not self.__has_default_version():
-      deployable_path = os.path.join(repo_appengine_path, 'app.yaml')
-      command = 'gcloud app deploy {deployable} --project={project} --quiet'.format(
-          project=self.__gcp_project, deployable=deployable_path)
-      logging.info('Deploying AppEngine app with default version')
-      subprocess.Popen(command, stderr=sys.stderr, shell=True).wait()
+        command = "gsutil -m rsync {local} {gcs}".format(
+            local=repo_appengine_path, gcs=gcs_path
+        )
+        logging.info("Preparing %s", gcs_path)
+        subprocess.Popen(command, stderr=sys.stderr, shell=True).wait()
 
-  def __has_default_version(self):
-    command = 'gcloud app services list --project={project}'.format(
-        project=self.__gcp_project)
-    out, err = (subprocess.Popen(command,
-                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                 shell=True)
-                .communicate())
-    logging.debug(
-        'Checking if project has default app version: {command} returned: {out}'
-        .format(command=command, out=out))
+    def __prepare_app_default_version(self, repo_appengine_path):
+        if not self.__has_default_version():
+            deployable_path = os.path.join(repo_appengine_path, "app.yaml")
+            command = (
+                "gcloud app deploy {deployable} --project={project} --quiet".format(
+                    project=self.__gcp_project, deployable=deployable_path
+                )
+            )
+            logging.info("Deploying AppEngine app with default version")
+            subprocess.Popen(command, stderr=sys.stderr, shell=True).wait()
 
-    # Expect an output similar to:
-    # SERVICE        NUM_VERSIONS
-    # default        1
-    # other_version  1
-    return '\ndefault ' in out.decode(encoding='utf-8')
+    def __has_default_version(self):
+        command = "gcloud app services list --project={project}".format(
+            project=self.__gcp_project
+        )
+        out, err = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+        ).communicate()
+        logging.debug(
+            "Checking if project has default app version: {command} returned: {out}".format(
+                command=command, out=out
+            )
+        )
 
-  def create_app(self):
-    # Not testing create_app, since the operation is well tested elsewhere.
-    # Retryable to handle platform flakiness.
-    contract = jc.Contract()
-    return st.OperationContract(
-      self.agent.make_create_app_operation(
-        bindings=self.bindings,
-        application=self.TEST_APP,
-        account_name=self.bindings['SPINNAKER_APPENGINE_ACCOUNT'],
-        cloud_providers="appengine"),
-      contract=contract)
+        # Expect an output similar to:
+        # SERVICE        NUM_VERSIONS
+        # default        1
+        # other_version  1
+        return "\ndefault " in out.decode(encoding="utf-8")
 
-  def delete_app(self):
-    # Not testing delete_app, since the operation is well tested elsewhere.
-    # Retryable to handle platform flakiness.
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_delete_app_operation(
-            application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_APPENGINE_ACCOUNT']),
-        contract=contract)
+    def create_app(self):
+        # Not testing create_app, since the operation is well tested elsewhere.
+        # Retryable to handle platform flakiness.
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_create_app_operation(
+                bindings=self.bindings,
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_APPENGINE_ACCOUNT"],
+                cloud_providers="appengine",
+            ),
+            contract=contract,
+        )
 
-  def create_server_group(self):
-    group_name = frigga.Naming.server_group(
-        app=self.TEST_APP,
-        stack=self.bindings['TEST_STACK'],
-        version='v000')
-    job_spec = {
-        'application': self.TEST_APP,
-        'stack': self.TEST_STACK,
-        'credentials': self.bindings['SPINNAKER_APPENGINE_ACCOUNT'],
-        'repositoryUrl': self.__test_repository_url,
-        'applicationDirectoryRoot': self.__app_directory_root,
-        'configFiles': [self.__app_yaml],
-        'type': 'createServerGroup',
-        'cloudProvider': 'appengine',
-        'region': self.bindings['TEST_APPENGINE_REGION']
-      }
-    storageAccountName = self.bindings.get('TEST_STORAGE_ACCOUNT_NAME')
-    if storageAccountName is not None:
-      job_spec['storageAccountName'] = storageAccountName
+    def delete_app(self):
+        # Not testing delete_app, since the operation is well tested elsewhere.
+        # Retryable to handle platform flakiness.
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_delete_app_operation(
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_APPENGINE_ACCOUNT"],
+            ),
+            contract=contract,
+        )
 
-    if not self.__test_repository_url.startswith('gs://'):
-      job_spec.update({
-          'gitCredentialType': 'NONE',
-          'branch': self.__branch
-      })
-
-    payload = self.agent.make_json_payload_from_kwargs(job=[job_spec],
-      description='Create Server Group in ' + group_name,
-      application=self.TEST_APP)
-
-    builder = gcp.GcpContractBuilder(self.appengine_observer)
-    (builder.new_clause_builder('Version Added', retryable_for_secs=60)
-      .inspect_resource('apps.services.versions',
-                        group_name,
-                        appsId=self.__gcp_project,
-                        servicesId=self.__lb_name)
-     .EXPECT(ov_factory.value_list_path_contains(
-         'servingStatus', jp.STR_EQ('SERVING'))))
-
-    return st.OperationContract(
-        self.new_post_operation(
-            title='create_server_group', data=payload, path='tasks'),
-        contract=builder.build())
-
-  def make_deploy_stage(self):
-    cluster_spec = {
-        'account': self.bindings['SPINNAKER_APPENGINE_ACCOUNT'],
-        'applicationDirectoryRoot': self.__app_directory_root,
-        'configFiles': [self.__app_yaml],
-        'application': self.TEST_APP,
-        'cloudProvider': 'appengine',
-        'provider': 'appengine',
-        'region': self.bindings['TEST_APPENGINE_REGION'],
-        'repositoryUrl': self.__test_repository_url,
-        'stack': self.TEST_STACK
-    }
-    if not self.__test_repository_url.startswith('gs://'):
-      cluster_spec.update({
-          'gitCredentialType': 'NONE',
-          'branch': self.__branch
-      })
-
-    result = {
-      'clusters': [cluster_spec],
-      'name': 'Deploy',
-      'refId': '1',
-      'requisiteStageRefIds': [],
-      'type': 'deploy'
-    }
-    return result
-
-  def make_upsert_load_balancer_stage(self):
-    result = {
-        'cloudProvider': 'appengine',
-        'loadBalancers': [
-        {
-            'cloudProvider': 'appengine',
-            'credentials': self.bindings['SPINNAKER_APPENGINE_ACCOUNT'],
-            'loadBalancerName': self.__lb_name,
-            'migrateTraffic': False,
-            'name': self.__lb_name,
-            'region': self.bindings['TEST_APPENGINE_REGION'],
-            'splitDescription': {
-                'allocationDescriptions': [
-                {
-                    'allocation': 0.1,
-                    'cluster': self.__cluster_name,
-                    'locatorType': 'targetCoordinate',
-                   'target': 'current_asg_dynamic'
-                },
-                {
-                    'allocation': 0.9,
-                    'cluster': self.__cluster_name,
-                    'locatorType': 'targetCoordinate',
-                    'target': 'ancestor_asg_dynamic'
-                }
-                ],
-                'shardBy': 'IP'
-            }
+    def create_server_group(self):
+        group_name = frigga.Naming.server_group(
+            app=self.TEST_APP, stack=self.bindings["TEST_STACK"], version="v000"
+        )
+        job_spec = {
+            "application": self.TEST_APP,
+            "stack": self.TEST_STACK,
+            "credentials": self.bindings["SPINNAKER_APPENGINE_ACCOUNT"],
+            "repositoryUrl": self.__test_repository_url,
+            "applicationDirectoryRoot": self.__app_directory_root,
+            "configFiles": [self.__app_yaml],
+            "type": "createServerGroup",
+            "cloudProvider": "appengine",
+            "region": self.bindings["TEST_APPENGINE_REGION"],
         }
-      ],
-      'name': 'Edit Load Balancer',
-      'refId': '2',
-      'requisiteStageRefIds': ['1'],
-      'type': 'upsertAppEngineLoadBalancers'
-    }
-    return result
+        storageAccountName = self.bindings.get("TEST_STORAGE_ACCOUNT_NAME")
+        if storageAccountName is not None:
+            job_spec["storageAccountName"] = storageAccountName
 
-  def create_deploy_upsert_load_balancer_pipeline(self):
-    name = 'promoteServerGroupPipeline'
-    self.pipeline_id = name
-    deploy_stage = self.make_deploy_stage()
-    upsert_load_balancer_stage = self.make_upsert_load_balancer_stage()
+        if not self.__test_repository_url.startswith("gs://"):
+            job_spec.update({"gitCredentialType": "NONE", "branch": self.__branch})
 
-    pipeline_spec = dict(
-        name=name,
-        stages=[deploy_stage, upsert_load_balancer_stage],
-        triggers=[],
-        application=self.TEST_APP,
-        stageCounter=2,
-        parallel=True,
-        limitConcurrent=True,
-        appConfig={},
-        index=0
-    )
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[job_spec],
+            description="Create Server Group in " + group_name,
+            application=self.TEST_APP,
+        )
 
-    payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
+        builder = gcp.GcpContractBuilder(self.appengine_observer)
+        (
+            builder.new_clause_builder("Version Added", retryable_for_secs=60)
+            .inspect_resource(
+                "apps.services.versions",
+                group_name,
+                appsId=self.__gcp_project,
+                servicesId=self.__lb_name,
+            )
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "servingStatus", jp.STR_EQ("SERVING")
+                )
+            )
+        )
 
-    builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Pipeline',
-                                retryable_for_secs=5)
-     .get_url_path('applications/{0}/pipelineConfigs'.format(self.TEST_APP))
-     .contains_path_value(None, pipeline_spec))
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_server_group", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
-    return st.OperationContract(
-      self.new_post_operation(
-        title='create_deploy_upsert_load_balancer_pipeline', data=payload, path='pipelines',
-        status_class=st.SynchronousHttpOperationStatus),
-      contract=builder.build())
+    def make_deploy_stage(self):
+        cluster_spec = {
+            "account": self.bindings["SPINNAKER_APPENGINE_ACCOUNT"],
+            "applicationDirectoryRoot": self.__app_directory_root,
+            "configFiles": [self.__app_yaml],
+            "application": self.TEST_APP,
+            "cloudProvider": "appengine",
+            "provider": "appengine",
+            "region": self.bindings["TEST_APPENGINE_REGION"],
+            "repositoryUrl": self.__test_repository_url,
+            "stack": self.TEST_STACK,
+        }
+        if not self.__test_repository_url.startswith("gs://"):
+            cluster_spec.update({"gitCredentialType": "NONE", "branch": self.__branch})
 
-  def run_deploy_upsert_load_balancer_pipeline(self):
-    url_path = 'pipelines/{0}/{1}'.format(self.TEST_APP, self.pipeline_id)
+        result = {
+            "clusters": [cluster_spec],
+            "name": "Deploy",
+            "refId": "1",
+            "requisiteStageRefIds": [],
+            "type": "deploy",
+        }
+        return result
 
-    previous_group_name = frigga.Naming.server_group(
-        app=self.TEST_APP,
-        stack=self.TEST_STACK,
-        version='v000')
+    def make_upsert_load_balancer_stage(self):
+        result = {
+            "cloudProvider": "appengine",
+            "loadBalancers": [
+                {
+                    "cloudProvider": "appengine",
+                    "credentials": self.bindings["SPINNAKER_APPENGINE_ACCOUNT"],
+                    "loadBalancerName": self.__lb_name,
+                    "migrateTraffic": False,
+                    "name": self.__lb_name,
+                    "region": self.bindings["TEST_APPENGINE_REGION"],
+                    "splitDescription": {
+                        "allocationDescriptions": [
+                            {
+                                "allocation": 0.1,
+                                "cluster": self.__cluster_name,
+                                "locatorType": "targetCoordinate",
+                                "target": "current_asg_dynamic",
+                            },
+                            {
+                                "allocation": 0.9,
+                                "cluster": self.__cluster_name,
+                                "locatorType": "targetCoordinate",
+                                "target": "ancestor_asg_dynamic",
+                            },
+                        ],
+                        "shardBy": "IP",
+                    },
+                }
+            ],
+            "name": "Edit Load Balancer",
+            "refId": "2",
+            "requisiteStageRefIds": ["1"],
+            "type": "upsertAppEngineLoadBalancers",
+        }
+        return result
 
-    deployed_group_name = frigga.Naming.server_group(
-        app=self.TEST_APP,
-        stack=self.TEST_STACK,
-        version='v001')
+    def create_deploy_upsert_load_balancer_pipeline(self):
+        name = "promoteServerGroupPipeline"
+        self.pipeline_id = name
+        deploy_stage = self.make_deploy_stage()
+        upsert_load_balancer_stage = self.make_upsert_load_balancer_stage()
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        type='manual',
-        user='[anonymous]')
+        pipeline_spec = dict(
+            name=name,
+            stages=[deploy_stage, upsert_load_balancer_stage],
+            triggers=[],
+            application=self.TEST_APP,
+            stageCounter=2,
+            parallel=True,
+            limitConcurrent=True,
+            appConfig={},
+            index=0,
+        )
 
-    builder = gcp.GcpContractBuilder(self.appengine_observer)
-    (builder.new_clause_builder('Service Modified', retryable_for_secs=60)
-     .inspect_resource('apps.services',
-                       self.__lb_name,
-                       appsId=self.__gcp_project)
-     .EXPECT(
-         ov_factory.value_list_path_contains(
-             jp.build_path('split', 'allocations'),
-             jp.DICT_MATCHES({previous_group_name: jp.NUM_EQ(0.9),
-                              deployed_group_name: jp.NUM_EQ(0.1)}))))
+        payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='run_deploy_upsert_load_balancer_pipeline',
-            data=payload, path=url_path),
-        builder.build())
+        builder = st.HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder("Has Pipeline", retryable_for_secs=5)
+            .get_url_path("applications/{0}/pipelineConfigs".format(self.TEST_APP))
+            .contains_path_value(None, pipeline_spec)
+        )
 
-  def delete_load_balancer(self):
-    bindings = self.bindings
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'type': 'deleteLoadBalancer',
-            'cloudProvider': 'appengine',
-            'loadBalancerName': self.__lb_name,
-            'account': bindings['SPINNAKER_APPENGINE_ACCOUNT'],
-            'credentials': bindings['SPINNAKER_APPENGINE_ACCOUNT'],
-            'user': '[anonymous]'
-        }],
-        description='Delete Load Balancer: {0} in {1}'.format(
-            self.__lb_name,
-            bindings['SPINNAKER_APPENGINE_ACCOUNT']),
-        application=self.TEST_APP)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_deploy_upsert_load_balancer_pipeline",
+                data=payload,
+                path="pipelines",
+                status_class=st.SynchronousHttpOperationStatus,
+            ),
+            contract=builder.build(),
+        )
 
-    builder = gcp.GcpContractBuilder(self.appengine_observer)
-    (builder.new_clause_builder('Service Deleted', retryable_for_secs=60)
-     .inspect_resource('apps.services',
-                       self.__lb_name,
-                       appsId=self.__gcp_project)
-     .EXPECT(
-         ov_factory.error_list_contains(gcp.HttpErrorPredicate(http_code=404))))
+    def run_deploy_upsert_load_balancer_pipeline(self):
+        url_path = "pipelines/{0}/{1}".format(self.TEST_APP, self.pipeline_id)
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_load_balancer', data=payload, path='tasks'),
-        contract=builder.build())
+        previous_group_name = frigga.Naming.server_group(
+            app=self.TEST_APP, stack=self.TEST_STACK, version="v000"
+        )
+
+        deployed_group_name = frigga.Naming.server_group(
+            app=self.TEST_APP, stack=self.TEST_STACK, version="v001"
+        )
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            type="manual", user="[anonymous]"
+        )
+
+        builder = gcp.GcpContractBuilder(self.appengine_observer)
+        (
+            builder.new_clause_builder("Service Modified", retryable_for_secs=60)
+            .inspect_resource(
+                "apps.services", self.__lb_name, appsId=self.__gcp_project
+            )
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    jp.build_path("split", "allocations"),
+                    jp.DICT_MATCHES(
+                        {
+                            previous_group_name: jp.NUM_EQ(0.9),
+                            deployed_group_name: jp.NUM_EQ(0.1),
+                        }
+                    ),
+                )
+            )
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="run_deploy_upsert_load_balancer_pipeline",
+                data=payload,
+                path=url_path,
+            ),
+            builder.build(),
+        )
+
+    def delete_load_balancer(self):
+        bindings = self.bindings
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "type": "deleteLoadBalancer",
+                    "cloudProvider": "appengine",
+                    "loadBalancerName": self.__lb_name,
+                    "account": bindings["SPINNAKER_APPENGINE_ACCOUNT"],
+                    "credentials": bindings["SPINNAKER_APPENGINE_ACCOUNT"],
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Delete Load Balancer: {0} in {1}".format(
+                self.__lb_name, bindings["SPINNAKER_APPENGINE_ACCOUNT"]
+            ),
+            application=self.TEST_APP,
+        )
+
+        builder = gcp.GcpContractBuilder(self.appengine_observer)
+        (
+            builder.new_clause_builder("Service Deleted", retryable_for_secs=60)
+            .inspect_resource(
+                "apps.services", self.__lb_name, appsId=self.__gcp_project
+            )
+            .EXPECT(
+                ov_factory.error_list_contains(gcp.HttpErrorPredicate(http_code=404))
+            )
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete_load_balancer", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
+
 
 class AppengineSmokeTest(st.AgentTestCase):
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            AppengineSmokeTestScenario
+        )
 
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(AppengineSmokeTestScenario)
+    def test_a_create_app(self):
+        self.run_test_case(
+            self.scenario.create_app(), retry_interval_secs=8, max_retries=8
+        )
 
-  def test_a_create_app(self):
-    self.run_test_case(self.scenario.create_app(),
-                       retry_interval_secs=8, max_retries=8)
+    def test_b_create_server_group(self):
+        self.run_test_case(self.scenario.create_server_group())
 
-  def test_b_create_server_group(self):
-    self.run_test_case(self.scenario.create_server_group())
+    def test_c_create_pipeline(self):
+        self.run_test_case(self.scenario.create_deploy_upsert_load_balancer_pipeline())
 
-  def test_c_create_pipeline(self):
-    self.run_test_case(self.scenario.create_deploy_upsert_load_balancer_pipeline())
+    def test_d_run_pipeline(self):
+        self.run_test_case(self.scenario.run_deploy_upsert_load_balancer_pipeline())
 
-  def test_d_run_pipeline(self):
-    self.run_test_case(self.scenario.run_deploy_upsert_load_balancer_pipeline())
+    def test_y_delete_load_balancer(self):
+        self.run_test_case(
+            self.scenario.delete_load_balancer(), retry_interval_secs=8, max_retries=8
+        )
 
-  def test_y_delete_load_balancer(self):
-    self.run_test_case(self.scenario.delete_load_balancer(),
-                       retry_interval_secs=8, max_retries=8)
-
-  def test_z_delete_app(self):
-    self.run_test_case(self.scenario.delete_app(),
-                       retry_interval_secs=8, max_retries=8)
+    def test_z_delete_app(self):
+        self.run_test_case(
+            self.scenario.delete_app(), retry_interval_secs=8, max_retries=8
+        )
 
 
 def main():
-  defaults = {
-      'TEST_STACK': AppengineSmokeTestScenario.DEFAULT_TEST_ID,
-      'TEST_APP': 'gae1' + AppengineSmokeTestScenario.DEFAULT_TEST_ID,
-  }
+    defaults = {
+        "TEST_STACK": AppengineSmokeTestScenario.DEFAULT_TEST_ID,
+        "TEST_APP": "gae1" + AppengineSmokeTestScenario.DEFAULT_TEST_ID,
+    }
 
-  return citest.base.TestRunner.main(
-      parser_inits=[AppengineSmokeTestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[AppengineSmokeTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[AppengineSmokeTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[AppengineSmokeTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/aws_kato_test.py
+++ b/testing/citest/tests/aws_kato_test.py
@@ -65,187 +65,218 @@ import citest.aws_testing as aws
 import citest.json_predicate as jp
 import citest.service_testing as st
 from citest.json_contract import ObservationPredicateFactory
+
 ov_factory = ObservationPredicateFactory()
 
 # Spinnaker modules.
 import spinnaker_testing as sk
 import spinnaker_testing.kato as kato
 
-from botocore.exceptions import (BotoCoreError, ClientError)
+from botocore.exceptions import BotoCoreError, ClientError
 
 
 class AwsKatoTestScenario(sk.SpinnakerTestScenario):
-  """Defines the scenario for the test.
+    """Defines the scenario for the test.
 
-  This scenario defines the different test operations.
-  We're going to:
-    Create a Load Balancer
-    Delete a Load Balancer
-  """
-
-  __use_lb_name = ''     # The load balancer name.
-
-  @classmethod
-  def new_agent(cls, bindings):
-    """Implements the base class interface to create a new agent.
-
-    This method is called by the base classes during setup/initialization.
-
-    Args:
-      bindings: The bindings dictionary with configuration information
-        that this factory can draw from to initialize. If the factory would
-        like additional custom bindings it could add them to initArgumentParser.
-
-    Returns:
-      A citest.service_testing.BaseAgent that can interact with Kato.
-      This is the agent that test operations will be posted to.
+    This scenario defines the different test operations.
+    We're going to:
+      Create a Load Balancer
+      Delete a Load Balancer
     """
-    return kato.new_agent(bindings)
 
-  def __init__(self, bindings):
-    """Initialize scenario."""
-    super(AwsKatoTestScenario, self).__init__(bindings)
-    self.elb_client = self.aws_observer.make_boto_client('elb')
+    __use_lb_name = ""  # The load balancer name.
 
+    @classmethod
+    def new_agent(cls, bindings):
+        """Implements the base class interface to create a new agent.
 
-  def upsert_load_balancer(self):
-    """Creates OperationContract for upsertLoadBalancer.
+        This method is called by the base classes during setup/initialization.
 
-    Calls Spinnaker's upsertLoadBalancer with a configuration, then verifies
-    that the expected resources and configurations are visible on AWS. See
-    the contract builder for more info on what the expectations are.
-    """
-    detail_raw_name = 'katotestlb' + self.test_id
-    self.__use_lb_name = detail_raw_name
+        Args:
+          bindings: The bindings dictionary with configuration information
+            that this factory can draw from to initialize. If the factory would
+            like additional custom bindings it could add them to initArgumentParser.
 
-    bindings = self.bindings
-    region = bindings['TEST_AWS_REGION']
-    avail_zones = [region + 'a', region + 'b']
+        Returns:
+          A citest.service_testing.BaseAgent that can interact with Kato.
+          This is the agent that test operations will be posted to.
+        """
+        return kato.new_agent(bindings)
 
-    listener = {
-        'Listener': {
-            'InstancePort':7001,
-            'LoadBalancerPort':80
+    def __init__(self, bindings):
+        """Initialize scenario."""
+        super(AwsKatoTestScenario, self).__init__(bindings)
+        self.elb_client = self.aws_observer.make_boto_client("elb")
+
+    def upsert_load_balancer(self):
+        """Creates OperationContract for upsertLoadBalancer.
+
+        Calls Spinnaker's upsertLoadBalancer with a configuration, then verifies
+        that the expected resources and configurations are visible on AWS. See
+        the contract builder for more info on what the expectations are.
+        """
+        detail_raw_name = "katotestlb" + self.test_id
+        self.__use_lb_name = detail_raw_name
+
+        bindings = self.bindings
+        region = bindings["TEST_AWS_REGION"]
+        avail_zones = [region + "a", region + "b"]
+
+        listener = {"Listener": {"InstancePort": 7001, "LoadBalancerPort": 80}}
+        health_check = {
+            "HealthyThreshold": 8,
+            "UnhealthyThreshold": 3,
+            "Interval": 123,
+            "Timeout": 12,
+            "Target": "HTTP:%d/healthcheck" % listener["Listener"]["InstancePort"],
         }
-    }
-    health_check = {
-        'HealthyThreshold':8,
-        'UnhealthyThreshold':3,
-        'Interval':123,
-        'Timeout':12,
-        'Target':'HTTP:%d/healthcheck' % listener['Listener']['InstancePort']
-    }
 
-    payload = self.agent.type_to_payload(
-        'upsertAmazonLoadBalancerDescription',
-        {
-            'credentials': bindings['SPINNAKER_AWS_ACCOUNT'],
-            'clusterName': bindings['TEST_APP'],
-            'name': detail_raw_name,
-            'availabilityZones': {region: avail_zones},
-            'listeners': [{
-                'internalProtocol': 'HTTP',
-                'internalPort': listener['Listener']['InstancePort'],
-                'externalProtocol': 'HTTP',
-                'externalPort': listener['Listener']['LoadBalancerPort']
-            }],
-            'healthCheck': health_check['Target'],
-            'healthTimeout': health_check['Timeout'],
-            'healthInterval': health_check['Interval'],
-            'healthyThreshold': health_check['HealthyThreshold'],
-            'unhealthyThreshold': health_check['UnhealthyThreshold']
-        })
+        payload = self.agent.type_to_payload(
+            "upsertAmazonLoadBalancerDescription",
+            {
+                "credentials": bindings["SPINNAKER_AWS_ACCOUNT"],
+                "clusterName": bindings["TEST_APP"],
+                "name": detail_raw_name,
+                "availabilityZones": {region: avail_zones},
+                "listeners": [
+                    {
+                        "internalProtocol": "HTTP",
+                        "internalPort": listener["Listener"]["InstancePort"],
+                        "externalProtocol": "HTTP",
+                        "externalPort": listener["Listener"]["LoadBalancerPort"],
+                    }
+                ],
+                "healthCheck": health_check["Target"],
+                "healthTimeout": health_check["Timeout"],
+                "healthInterval": health_check["Interval"],
+                "healthyThreshold": health_check["HealthyThreshold"],
+                "unhealthyThreshold": health_check["UnhealthyThreshold"],
+            },
+        )
 
-    builder = aws.AwsPythonContractBuilder(self.aws_observer)
-    (builder.new_clause_builder('Load Balancer Added', retryable_for_secs=30)
-     .call_method(
-         self.elb_client.describe_load_balancers,
-         LoadBalancerNames=[self.__use_lb_name])
-     .EXPECT(ov_factory.value_list_path_contains(
-         'LoadBalancerDescriptions',
-          jp.LIST_MATCHES([jp.DICT_MATCHES({
-               'HealthCheck': jp.DICT_MATCHES(
-                   {key: jp.EQUIVALENT(value)
-                    for key, value in health_check.items()}),
-               'AvailabilityZones':
-                   jp.LIST_MATCHES([jp.STR_SUBSTR(zone) for zone in avail_zones]),
-               'ListenerDescriptions/Listener': jp.DICT_MATCHES(
-                   {key: jp.EQUIVALENT(value)
-                    for key, value in listener['Listener'].items()})
-          })]))
-      ))
+        builder = aws.AwsPythonContractBuilder(self.aws_observer)
+        (
+            builder.new_clause_builder("Load Balancer Added", retryable_for_secs=30)
+            .call_method(
+                self.elb_client.describe_load_balancers,
+                LoadBalancerNames=[self.__use_lb_name],
+            )
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "LoadBalancerDescriptions",
+                    jp.LIST_MATCHES(
+                        [
+                            jp.DICT_MATCHES(
+                                {
+                                    "HealthCheck": jp.DICT_MATCHES(
+                                        {
+                                            key: jp.EQUIVALENT(value)
+                                            for key, value in health_check.items()
+                                        }
+                                    ),
+                                    "AvailabilityZones": jp.LIST_MATCHES(
+                                        [jp.STR_SUBSTR(zone) for zone in avail_zones]
+                                    ),
+                                    "ListenerDescriptions/Listener": jp.DICT_MATCHES(
+                                        {
+                                            key: jp.EQUIVALENT(value)
+                                            for key, value in listener[
+                                                "Listener"
+                                            ].items()
+                                        }
+                                    ),
+                                }
+                            )
+                        ]
+                    ),
+                )
+            )
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='upsert_amazon_load_balancer', data=payload, path='ops'),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="upsert_amazon_load_balancer", data=payload, path="ops"
+            ),
+            contract=builder.build(),
+        )
 
-  def delete_load_balancer(self):
-    """Creates OperationContract for deleteLoadBalancer.
+    def delete_load_balancer(self):
+        """Creates OperationContract for deleteLoadBalancer.
 
-    To verify the operation, we just check that the AWS resources
-    created by upsert_load_balancer are no longer visible on AWS.
-    """
-    region = self.bindings['TEST_AWS_REGION']
-    payload = self.agent.type_to_payload(
-        'deleteAmazonLoadBalancerDescription',
-        {
-            'credentials': self.bindings['SPINNAKER_AWS_ACCOUNT'],
-            'regions': [region],
-            'loadBalancerName': self.__use_lb_name
-        })
+        To verify the operation, we just check that the AWS resources
+        created by upsert_load_balancer are no longer visible on AWS.
+        """
+        region = self.bindings["TEST_AWS_REGION"]
+        payload = self.agent.type_to_payload(
+            "deleteAmazonLoadBalancerDescription",
+            {
+                "credentials": self.bindings["SPINNAKER_AWS_ACCOUNT"],
+                "regions": [region],
+                "loadBalancerName": self.__use_lb_name,
+            },
+        )
 
-    builder = aws.AwsPythonContractBuilder(self.aws_observer)
-    (builder.new_clause_builder('Load Balancer Removed')
-     .call_method(
-         self.elb_client.describe_load_balancers,
-         LoadBalancerNames=[self.__use_lb_name])
-     .EXPECT(ov_factory.error_list_contains(
-         jp.ExceptionMatchesPredicate(
-               (BotoCoreError, ClientError), 'LoadBalancerNotFound'))))
+        builder = aws.AwsPythonContractBuilder(self.aws_observer)
+        (
+            builder.new_clause_builder("Load Balancer Removed")
+            .call_method(
+                self.elb_client.describe_load_balancers,
+                LoadBalancerNames=[self.__use_lb_name],
+            )
+            .EXPECT(
+                ov_factory.error_list_contains(
+                    jp.ExceptionMatchesPredicate(
+                        (BotoCoreError, ClientError), "LoadBalancerNotFound"
+                    )
+                )
+            )
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_amazon_load_balancer', data=payload, path='ops'),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete_amazon_load_balancer", data=payload, path="ops"
+            ),
+            contract=builder.build(),
+        )
 
 
 class AwsKatoIntegrationTest(st.AgentTestCase):
-  """The test fixture for the SmokeTest.
+    """The test fixture for the SmokeTest.
 
-  This is implemented using citest OperationContract instances that are
-  created by the AwsKatoTestScenario.
-  """
-  # pylint: disable=missing-docstring
+    This is implemented using citest OperationContract instances that are
+    created by the AwsKatoTestScenario.
+    """
 
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-        AwsKatoTestScenario)
+    # pylint: disable=missing-docstring
 
-  @property
-  def testing_agent(self):
-    return self.scenario.agent
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            AwsKatoTestScenario
+        )
 
-  def test_a_upsert_load_balancer(self):
-    self.run_test_case(self.scenario.upsert_load_balancer())
+    @property
+    def testing_agent(self):
+        return self.scenario.agent
 
-  def test_z_delete_load_balancer(self):
-    self.run_test_case(self.scenario.delete_load_balancer())
+    def test_a_upsert_load_balancer(self):
+        self.run_test_case(self.scenario.upsert_load_balancer())
+
+    def test_z_delete_load_balancer(self):
+        self.run_test_case(self.scenario.delete_load_balancer())
 
 
 def main():
-  """Implements the main method running this smoke test."""
+    """Implements the main method running this smoke test."""
 
-  defaults = {
-      'TEST_APP': 'awskatotest' + AwsKatoTestScenario.DEFAULT_TEST_ID
-  }
+    defaults = {"TEST_APP": "awskatotest" + AwsKatoTestScenario.DEFAULT_TEST_ID}
 
-  return citest.base.TestRunner.main(
-      parser_inits=[AwsKatoTestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[AwsKatoIntegrationTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[AwsKatoTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[AwsKatoIntegrationTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/aws_smoke_test.py
+++ b/testing/citest/tests/aws_smoke_test.py
@@ -58,464 +58,537 @@ import citest.json_predicate as jp
 import citest.service_testing as st
 import citest.base
 from citest.json_contract import ObservationPredicateFactory
+
 ov_factory = ObservationPredicateFactory()
 
 # Spinnaker modules.
 import spinnaker_testing as sk
 import spinnaker_testing.gate as gate
 
-from botocore.exceptions import (BotoCoreError, ClientError)
+from botocore.exceptions import BotoCoreError, ClientError
 
 
 class AwsSmokeTestScenario(sk.SpinnakerTestScenario):
-  """Defines the scenario for the smoke test.
+    """Defines the scenario for the smoke test.
 
-  The scenario remembers:
-     * The agent used to talk to gate.
-     * The name of the unique Spinnaker application we create for this test.
-     * The name of the load balancer we create used.
-  """
-
-  @classmethod
-  def new_agent(cls, bindings):
-    """Implements citest.service_testing.AgentTestScenario.new_agent."""
-    return gate.new_agent(bindings)
-
-  def __init__(self, bindings, agent=None):
-    """Constructor.
-
-    Args:
-      bindings: [dict] The data bindings to use to configure the scenario.
-      agent: [GateAgent] The agent for invoking the test operations on Gate.
+    The scenario remembers:
+       * The agent used to talk to gate.
+       * The name of the unique Spinnaker application we create for this test.
+       * The name of the load balancer we create used.
     """
-    super(AwsSmokeTestScenario, self).__init__(bindings, agent)
-    bindings = self.bindings
 
-    aws_observer = self.aws_observer
-    self.autoscaling_client = aws_observer.make_boto_client('autoscaling')
-    self.ec2_client = aws_observer.make_boto_client('ec2')
-    self.elb_client = aws_observer.make_boto_client('elb')
+    @classmethod
+    def new_agent(cls, bindings):
+        """Implements citest.service_testing.AgentTestScenario.new_agent."""
+        return gate.new_agent(bindings)
 
-    self.lb_detail = 'lb'
-    self.lb_name = '{app}-{stack}-{detail}'.format(
-        app=bindings['TEST_APP'], stack=bindings['TEST_STACK'],
-        detail=self.lb_detail)
+    def __init__(self, bindings, agent=None):
+        """Constructor.
 
-    # We'll call out the app name because it is widely used
-    # because it scopes the context of our activities.
-    # pylint: disable=invalid-name
-    self.TEST_APP = bindings['TEST_APP']
+        Args:
+          bindings: [dict] The data bindings to use to configure the scenario.
+          agent: [GateAgent] The agent for invoking the test operations on Gate.
+        """
+        super(AwsSmokeTestScenario, self).__init__(bindings, agent)
+        bindings = self.bindings
 
-  def create_app(self):
-    """Creates OperationContract that creates a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_create_app_operation(
-            bindings=self.bindings, application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_AWS_ACCOUNT'],
-            cloud_providers="aws"),
-        contract=contract)
+        aws_observer = self.aws_observer
+        self.autoscaling_client = aws_observer.make_boto_client("autoscaling")
+        self.ec2_client = aws_observer.make_boto_client("ec2")
+        self.elb_client = aws_observer.make_boto_client("elb")
 
-  def delete_app(self):
-    """Creates OperationContract that deletes a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_delete_app_operation(
-            application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_AWS_ACCOUNT']),
-        contract=contract)
+        self.lb_detail = "lb"
+        self.lb_name = "{app}-{stack}-{detail}".format(
+            app=bindings["TEST_APP"],
+            stack=bindings["TEST_STACK"],
+            detail=self.lb_detail,
+        )
 
-  def upsert_load_balancer(self, use_vpc):
-    """Creates OperationContract for upsertLoadBalancer.
+        # We'll call out the app name because it is widely used
+        # because it scopes the context of our activities.
+        # pylint: disable=invalid-name
+        self.TEST_APP = bindings["TEST_APP"]
 
-    Calls Spinnaker's upsertLoadBalancer with a configuration, then verifies
-    that the expected resources and configurations are visible on AWS. See
-    the contract builder for more info on what the expectations are.
+    def create_app(self):
+        """Creates OperationContract that creates a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_create_app_operation(
+                bindings=self.bindings,
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_AWS_ACCOUNT"],
+                cloud_providers="aws",
+            ),
+            contract=contract,
+        )
 
-    Args:
-      use_vpc: [bool] if True configure a VPC otherwise dont.
-    """
-    bindings = self.bindings
-    context = citest.base.ExecutionContext()
+    def delete_app(self):
+        """Creates OperationContract that deletes a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_delete_app_operation(
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_AWS_ACCOUNT"],
+            ),
+            contract=contract,
+        )
 
-    load_balancer_name = self.lb_name
+    def upsert_load_balancer(self, use_vpc):
+        """Creates OperationContract for upsertLoadBalancer.
 
-    if use_vpc:
-      # TODO(ewiseblatt): 20160301
-      # We're hardcoding the VPC here, but not sure which we really want.
-      # I think this comes from the spinnaker.io installation instructions.
-      # What's interesting about this is that it is a 10.* CidrBlock,
-      # as opposed to the others, which are public IPs. All this is sensitive
-      # as to where the TEST_AWS_VPC_ID came from so this is going to be
-      # brittle. Ideally we only need to know the vpc_id and can figure the
-      # rest out based on what we have available.
-      subnet_type = 'internal (defaultvpc)'
+        Calls Spinnaker's upsertLoadBalancer with a configuration, then verifies
+        that the expected resources and configurations are visible on AWS. See
+        the contract builder for more info on what the expectations are.
 
-      vpc_id = bindings['TEST_AWS_VPC_ID']
+        Args:
+          use_vpc: [bool] if True configure a VPC otherwise dont.
+        """
+        bindings = self.bindings
+        context = citest.base.ExecutionContext()
 
-      # Not really sure how to determine this value in general.
-      security_groups = [bindings['TEST_AWS_SECURITY_GROUP_ID']]
-      security_groups = ['default']
+        load_balancer_name = self.lb_name
 
-      # The resulting load balancer will only be available in the zone of
-      # the subnet we are using. We'll figure that out by looking up the
-      # subnet we want.
-      subnets_response = self.aws_observer.call_method(
-          context,
-          self.ec2_client.describe_subnets,
-          Filters=[{'Name': 'vpc-id', 'Values': [vpc_id]}])
-      subnet_details = subnets_response['Subnets']
+        if use_vpc:
+            # TODO(ewiseblatt): 20160301
+            # We're hardcoding the VPC here, but not sure which we really want.
+            # I think this comes from the spinnaker.io installation instructions.
+            # What's interesting about this is that it is a 10.* CidrBlock,
+            # as opposed to the others, which are public IPs. All this is sensitive
+            # as to where the TEST_AWS_VPC_ID came from so this is going to be
+            # brittle. Ideally we only need to know the vpc_id and can figure the
+            # rest out based on what we have available.
+            subnet_type = "internal (defaultvpc)"
 
-      try:
-        avail_zones = [detail['AvailabilityZone'] for detail in subnet_details]
-        region = avail_zones[0][:-1]
-        if len(avail_zones) > 2:
-          avail_zones = [avail_zones[0], avail_zones[-1]]  # just keep two
+            vpc_id = bindings["TEST_AWS_VPC_ID"]
 
-      except KeyError:
-        raise ValueError('vpc_id={0} appears to be unknown'.format(vpc_id))
-    else:
-      # We're assuming that the given region has 'A' and 'B' availability
-      # zones. This seems conservative but might be brittle since we permit
-      # any region.
-      region = bindings['TEST_AWS_REGION']
-      avail_zones = [region + 'a', region + 'b']
+            # Not really sure how to determine this value in general.
+            security_groups = [bindings["TEST_AWS_SECURITY_GROUP_ID"]]
+            security_groups = ["default"]
 
-      subnet_type = ""
-      vpc_id = None
-      security_groups = None
+            # The resulting load balancer will only be available in the zone of
+            # the subnet we are using. We'll figure that out by looking up the
+            # subnet we want.
+            subnets_response = self.aws_observer.call_method(
+                context,
+                self.ec2_client.describe_subnets,
+                Filters=[{"Name": "vpc-id", "Values": [vpc_id]}],
+            )
+            subnet_details = subnets_response["Subnets"]
 
-      # This will be a second load balancer not used in other tests.
-      # Decorate the name so as not to confuse it.
-      load_balancer_name += '-pub'
+            try:
+                avail_zones = [detail["AvailabilityZone"] for detail in subnet_details]
+                region = avail_zones[0][:-1]
+                if len(avail_zones) > 2:
+                    avail_zones = [avail_zones[0], avail_zones[-1]]  # just keep two
 
+            except KeyError:
+                raise ValueError("vpc_id={0} appears to be unknown".format(vpc_id))
+        else:
+            # We're assuming that the given region has 'A' and 'B' availability
+            # zones. This seems conservative but might be brittle since we permit
+            # any region.
+            region = bindings["TEST_AWS_REGION"]
+            avail_zones = [region + "a", region + "b"]
 
-    listener = {
-        'Listener': {
-            'InstancePort':80,
-            'LoadBalancerPort':80
+            subnet_type = ""
+            vpc_id = None
+            security_groups = None
+
+            # This will be a second load balancer not used in other tests.
+            # Decorate the name so as not to confuse it.
+            load_balancer_name += "-pub"
+
+        listener = {"Listener": {"InstancePort": 80, "LoadBalancerPort": 80}}
+        health_check = {
+            "HealthyThreshold": 8,
+            "UnhealthyThreshold": 3,
+            "Interval": 12,
+            "Timeout": 6,
+            "Target": "HTTP:%d/" % listener["Listener"]["InstancePort"],
         }
-    }
-    health_check = {
-        'HealthyThreshold': 8,
-        'UnhealthyThreshold': 3,
-        'Interval': 12,
-        'Timeout': 6,
-        'Target':'HTTP:%d/' % listener['Listener']['InstancePort']
-    }
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'type': 'upsertLoadBalancer',
-            'cloudProvider': 'aws',
-            # 'loadBalancerName': load_balancer_name,
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "type": "upsertLoadBalancer",
+                    "cloudProvider": "aws",
+                    # 'loadBalancerName': load_balancer_name,
+                    "credentials": bindings["SPINNAKER_AWS_ACCOUNT"],
+                    "name": load_balancer_name,
+                    "stack": bindings["TEST_STACK"],
+                    "detail": self.lb_detail,
+                    "region": bindings["TEST_AWS_REGION"],
+                    "availabilityZones": {region: avail_zones},
+                    "regionZones": avail_zones,
+                    "listeners": [
+                        {
+                            "internalProtocol": "HTTP",
+                            "internalPort": listener["Listener"]["InstancePort"],
+                            "externalProtocol": "HTTP",
+                            "externalPort": listener["Listener"]["LoadBalancerPort"],
+                        }
+                    ],
+                    "healthCheck": health_check["Target"],
+                    "healthCheckProtocol": "HTTP",
+                    "healthCheckPort": listener["Listener"]["LoadBalancerPort"],
+                    "healthCheckPath": "/",
+                    "healthTimeout": health_check["Timeout"],
+                    "healthInterval": health_check["Interval"],
+                    "healthyThreshold": health_check["HealthyThreshold"],
+                    "unhealthyThreshold": health_check["UnhealthyThreshold"],
+                    "user": "[anonymous]",
+                    "usePreferredZones": True,
+                    "vpcId": vpc_id,
+                    "subnetType": subnet_type,
+                    # If I set security group to this then I get an error it is missing.
+                    # bindings['TEST_AWS_SECURITY_GROUP_ID']],
+                    "securityGroups": security_groups,
+                }
+            ],
+            description="Create Load Balancer: " + load_balancer_name,
+            application=self.TEST_APP,
+        )
 
+        builder = aws.AwsPythonContractBuilder(self.aws_observer)
+        (
+            builder.new_clause_builder("Load Balancer Added", retryable_for_secs=10)
+            .call_method(
+                self.elb_client.describe_load_balancers,
+                LoadBalancerNames=[load_balancer_name],
+            )
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "LoadBalancerDescriptions",
+                    jp.LIST_MATCHES(
+                        [
+                            jp.DICT_MATCHES(
+                                {
+                                    "HealthCheck": jp.DICT_MATCHES(
+                                        {
+                                            key: jp.EQUIVALENT(value)
+                                            for key, value in health_check.items()
+                                        }
+                                    ),
+                                    "AvailabilityZones": jp.LIST_SIMILAR(avail_zones),
+                                    "ListenerDescriptions/Listener": jp.DICT_MATCHES(
+                                        {
+                                            key: jp.NUM_EQ(value)
+                                            for key, value in listener[
+                                                "Listener"
+                                            ].items()
+                                        }
+                                    ),
+                                }
+                            )
+                        ]
+                    ),
+                )
+            )
+        )
 
-            'credentials': bindings['SPINNAKER_AWS_ACCOUNT'],
-            'name': load_balancer_name,
-            'stack': bindings['TEST_STACK'],
-            'detail': self.lb_detail,
-            'region': bindings['TEST_AWS_REGION'],
+        title_decorator = "_with_vpc" if use_vpc else "_without_vpc"
+        return st.OperationContract(
+            self.new_post_operation(
+                title="upsert_load_balancer" + title_decorator,
+                data=payload,
+                path="tasks",
+            ),
+            contract=builder.build(),
+        )
 
-            'availabilityZones': {region: avail_zones},
-            'regionZones': avail_zones,
-            'listeners': [{
-                'internalProtocol': 'HTTP',
-                'internalPort': listener['Listener']['InstancePort'],
-                'externalProtocol': 'HTTP',
-                'externalPort': listener['Listener']['LoadBalancerPort']
-            }],
-            'healthCheck': health_check['Target'],
-            'healthCheckProtocol': 'HTTP',
-            'healthCheckPort': listener['Listener']['LoadBalancerPort'],
-            'healthCheckPath': '/',
-            'healthTimeout': health_check['Timeout'],
-            'healthInterval': health_check['Interval'],
-            'healthyThreshold': health_check['HealthyThreshold'],
-            'unhealthyThreshold': health_check['UnhealthyThreshold'],
+    def delete_load_balancer(self, use_vpc):
+        """Creates OperationContract for deleteLoadBalancer.
 
-            'user': '[anonymous]',
-            'usePreferredZones': True,
-            'vpcId': vpc_id,
-            'subnetType': subnet_type,
-            # If I set security group to this then I get an error it is missing.
-            # bindings['TEST_AWS_SECURITY_GROUP_ID']],
-            'securityGroups': security_groups
-        }],
-        description='Create Load Balancer: ' + load_balancer_name,
-        application=self.TEST_APP)
+        To verify the operation, we just check that the AWS resources
+        created by upsert_load_balancer are no longer visible on AWS.
 
-    builder = aws.AwsPythonContractBuilder(self.aws_observer)
-    (builder.new_clause_builder('Load Balancer Added', retryable_for_secs=10)
-     .call_method(
-         self.elb_client.describe_load_balancers,
-         LoadBalancerNames=[load_balancer_name])
-     .EXPECT(ov_factory.value_list_path_contains(
-         'LoadBalancerDescriptions',
-         jp.LIST_MATCHES([jp.DICT_MATCHES({
-             'HealthCheck':
-                 jp.DICT_MATCHES({
-                     key: jp.EQUIVALENT(value)
-                     for key, value in health_check.items()}),
-             'AvailabilityZones': jp.LIST_SIMILAR(avail_zones),
-             'ListenerDescriptions/Listener':
-                 jp.DICT_MATCHES({
-                     key: jp.NUM_EQ(value)
-                     for key, value in listener['Listener'].items()})
-         })]))
-     ))
+        Args:
+          use_vpc: [bool] if True delete the VPC load balancer, otherwise
+             the non-VPC load balancer.
+        """
+        load_balancer_name = self.lb_name
+        if not use_vpc:
+            # This is the second load balancer, where we decorated the name in upsert.
+            load_balancer_name += "-pub"
 
-    title_decorator = '_with_vpc' if use_vpc else '_without_vpc'
-    return st.OperationContract(
-        self.new_post_operation(
-            title='upsert_load_balancer' + title_decorator,
-            data=payload,
-            path='tasks'),
-        contract=builder.build())
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "type": "deleteLoadBalancer",
+                    "cloudProvider": "aws",
+                    "credentials": self.bindings["SPINNAKER_AWS_ACCOUNT"],
+                    "regions": [self.bindings["TEST_AWS_REGION"]],
+                    "loadBalancerName": load_balancer_name,
+                }
+            ],
+            description="Delete Load Balancer: {0} in {1}:{2}".format(
+                load_balancer_name,
+                self.bindings["SPINNAKER_AWS_ACCOUNT"],
+                self.bindings["TEST_AWS_REGION"],
+            ),
+            application=self.TEST_APP,
+        )
 
-  def delete_load_balancer(self, use_vpc):
-    """Creates OperationContract for deleteLoadBalancer.
+        builder = aws.AwsPythonContractBuilder(self.aws_observer)
+        (
+            builder.new_clause_builder("Load Balancer Removed")
+            .call_method(
+                self.elb_client.describe_load_balancers,
+                LoadBalancerNames=[load_balancer_name],
+            )
+            .EXPECT(
+                ov_factory.error_list_contains(
+                    jp.ExceptionMatchesPredicate(
+                        (BotoCoreError, ClientError), "LoadBalancerNotFound"
+                    )
+                )
+            )
+        )
 
-    To verify the operation, we just check that the AWS resources
-    created by upsert_load_balancer are no longer visible on AWS.
+        title_decorator = "_with_vpc" if use_vpc else "_without_vpc"
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete_load_balancer" + title_decorator,
+                data=payload,
+                path="tasks",
+            ),
+            contract=builder.build(),
+        )
 
-    Args:
-      use_vpc: [bool] if True delete the VPC load balancer, otherwise
-         the non-VPC load balancer.
-    """
-    load_balancer_name = self.lb_name
-    if not use_vpc:
-      # This is the second load balancer, where we decorated the name in upsert.
-      load_balancer_name += '-pub'
+    def create_server_group(self):
+        """Creates OperationContract for createServerGroup.
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'type': 'deleteLoadBalancer',
-            'cloudProvider': 'aws',
+        To verify the operation, we just check that the AWS Auto Scaling Group
+        for the server group was created.
+        """
+        bindings = self.bindings
 
-            'credentials': self.bindings['SPINNAKER_AWS_ACCOUNT'],
-            'regions': [self.bindings['TEST_AWS_REGION']],
-            'loadBalancerName': load_balancer_name
-        }],
-        description='Delete Load Balancer: {0} in {1}:{2}'.format(
-            load_balancer_name,
-            self.bindings['SPINNAKER_AWS_ACCOUNT'],
-            self.bindings['TEST_AWS_REGION']),
-        application=self.TEST_APP)
+        # Spinnaker determines the group name created,
+        # which will be the following:
+        group_name = "{app}-{stack}-v000".format(
+            app=self.TEST_APP, stack=bindings["TEST_STACK"]
+        )
 
-    builder = aws.AwsPythonContractBuilder(self.aws_observer)
-    (builder.new_clause_builder('Load Balancer Removed')
-     .call_method(
-         self.elb_client.describe_load_balancers,
-         LoadBalancerNames=[load_balancer_name])
-     .EXPECT(
-         ov_factory.error_list_contains(
-             jp.ExceptionMatchesPredicate(
-                   (BotoCoreError, ClientError), 'LoadBalancerNotFound'))))
+        region = bindings["TEST_AWS_REGION"]
+        avail_zones = [region + "a", region + "b"]
 
-    title_decorator = '_with_vpc' if use_vpc else '_without_vpc'
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_load_balancer' + title_decorator,
-            data=payload,
-            path='tasks'),
-        contract=builder.build())
+        test_security_group_id = bindings["TEST_AWS_SECURITY_GROUP_ID"]
+        test_security_group_id = "default"
 
-  def create_server_group(self):
-    """Creates OperationContract for createServerGroup.
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "type": "createServerGroup",
+                    "cloudProvider": "aws",
+                    "application": self.TEST_APP,
+                    "credentials": bindings["SPINNAKER_AWS_ACCOUNT"],
+                    "strategy": "",
+                    "capacity": {"min": 2, "max": 2, "desired": 2},
+                    "targetHealthyDeployPercentage": 100,
+                    "loadBalancers": [self.lb_name],
+                    "cooldown": 8,
+                    "healthCheckType": "EC2",
+                    "healthCheckGracePeriod": 40,
+                    "instanceMonitoring": False,
+                    "ebsOptimized": False,
+                    "iamRole": bindings["AWS_IAM_ROLE"],
+                    "terminationPolicies": ["Default"],
+                    "availabilityZones": {region: avail_zones},
+                    "keyPair": bindings["TEST_AWS_KEYPAIR"],
+                    "suspendedProcesses": [],
+                    # TODO(ewiseblatt): Inquiring about how this value is determined.
+                    # It seems to be the "Name" tag value of one of the VPCs
+                    # but is not the default VPC, which is what we using as the VPC_ID.
+                    # So I suspect something is out of whack. This name comes from
+                    # spinnaker.io tutorial. But using the default vpc would probably
+                    # be more adaptive to the particular deployment.
+                    "subnetType": "internal (defaultvpc)",
+                    "securityGroups": [test_security_group_id],
+                    "virtualizationType": "paravirtual",
+                    "stack": bindings["TEST_STACK"],
+                    "freeFormDetails": "",
+                    "amiName": bindings["TEST_AWS_AMI"],
+                    "instanceType": "m1.small",
+                    "useSourceCapacity": False,
+                    "account": bindings["SPINNAKER_AWS_ACCOUNT"],
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Create Server Group in " + group_name,
+            application=self.TEST_APP,
+        )
 
-    To verify the operation, we just check that the AWS Auto Scaling Group
-    for the server group was created.
-    """
-    bindings = self.bindings
+        builder = aws.AwsPythonContractBuilder(self.aws_observer)
+        (
+            builder.new_clause_builder(
+                "Auto Server Group Added", retryable_for_secs=600
+            )
+            .call_method(
+                self.autoscaling_client.describe_auto_scaling_groups,
+                AutoScalingGroupNames=[group_name],
+            )
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "AutoScalingGroups",
+                    jp.LIST_MATCHES([jp.DICT_MATCHES({"MaxSize": jp.NUM_EQ(2)})]),
+                )
+            )
+        )
 
-    # Spinnaker determines the group name created,
-    # which will be the following:
-    group_name = '{app}-{stack}-v000'.format(
-        app=self.TEST_APP, stack=bindings['TEST_STACK'])
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_server_group", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
-    region = bindings['TEST_AWS_REGION']
-    avail_zones = [region + 'a', region + 'b']
+    def delete_server_group(self):
+        """Creates OperationContract for deleteServerGroup.
 
-    test_security_group_id = bindings['TEST_AWS_SECURITY_GROUP_ID']
-    test_security_group_id = 'default'
+        To verify the operation, we just check that the AWS Auto Scaling Group
+        is no longer visible on AWS (or is in the process of terminating).
+        """
+        bindings = self.bindings
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'type': 'createServerGroup',
-            'cloudProvider': 'aws',
-            'application': self.TEST_APP,
-            'credentials': bindings['SPINNAKER_AWS_ACCOUNT'],
-            'strategy':'',
-            'capacity': {'min':2, 'max':2, 'desired':2},
-            'targetHealthyDeployPercentage': 100,
-            'loadBalancers': [self.lb_name],
-            'cooldown': 8,
-            'healthCheckType': 'EC2',
-            'healthCheckGracePeriod': 40,
-            'instanceMonitoring': False,
-            'ebsOptimized': False,
-            'iamRole': bindings['AWS_IAM_ROLE'],
-            'terminationPolicies': ['Default'],
+        group_name = "{app}-{stack}-v000".format(
+            app=self.TEST_APP, stack=bindings["TEST_STACK"]
+        )
 
-            'availabilityZones': {region: avail_zones},
-            'keyPair': bindings['TEST_AWS_KEYPAIR'],
-            'suspendedProcesses': [],
-            # TODO(ewiseblatt): Inquiring about how this value is determined.
-            # It seems to be the "Name" tag value of one of the VPCs
-            # but is not the default VPC, which is what we using as the VPC_ID.
-            # So I suspect something is out of whack. This name comes from
-            # spinnaker.io tutorial. But using the default vpc would probably
-            # be more adaptive to the particular deployment.
-            'subnetType': 'internal (defaultvpc)',
-            'securityGroups': [test_security_group_id],
-            'virtualizationType': 'paravirtual',
-            'stack': bindings['TEST_STACK'],
-            'freeFormDetails': '',
-            'amiName': bindings['TEST_AWS_AMI'],
-            'instanceType': 'm1.small',
-            'useSourceCapacity': False,
-            'account': bindings['SPINNAKER_AWS_ACCOUNT'],
-            'user': '[anonymous]'
-        }],
-        description='Create Server Group in ' + group_name,
-        application=self.TEST_APP)
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "aws",
+                    "type": "destroyServerGroup",
+                    "serverGroupName": group_name,
+                    "asgName": group_name,
+                    "region": bindings["TEST_AWS_REGION"],
+                    "regions": [bindings["TEST_AWS_REGION"]],
+                    "credentials": bindings["SPINNAKER_AWS_ACCOUNT"],
+                    "user": "[anonymous]",
+                }
+            ],
+            application=self.TEST_APP,
+            description="DestroyServerGroup: " + group_name,
+        )
 
-    builder = aws.AwsPythonContractBuilder(self.aws_observer)
-    (builder.new_clause_builder('Auto Server Group Added',
-                                retryable_for_secs=600)
-     .call_method(
-         self.autoscaling_client.describe_auto_scaling_groups,
-         AutoScalingGroupNames=[group_name])
-     .EXPECT(
-         ov_factory.value_list_path_contains(
-             'AutoScalingGroups',
-             jp.LIST_MATCHES([jp.DICT_MATCHES({'MaxSize': jp.NUM_EQ(2)})]))
-     ))
+        builder = aws.AwsPythonContractBuilder(self.aws_observer)
+        (
+            builder.new_clause_builder("Auto Scaling Group Removed")
+            .call_method(
+                self.autoscaling_client.describe_auto_scaling_groups,
+                AutoScalingGroupNames=[group_name],
+            )
+            .EXPECT(
+                ov_factory.error_list_contains(
+                    jp.ExceptionMatchesPredicate(
+                        (BotoCoreError, ClientError), "AutoScalingGroupNotFound"
+                    )
+                )
+            )
+            .OR(
+                ov_factory.value_list_path_contains(
+                    "AutoScalingGroups", jp.LIST_MATCHES([])
+                )
+            )
+            .OR(
+                ov_factory.value_list_path_contains(
+                    "AutoScalingGroups",
+                    jp.LIST_MATCHES(
+                        [
+                            jp.DICT_MATCHES(
+                                {
+                                    "Status": jp.STR_SUBSTR("Delete"),
+                                    "MaxSize": jp.NUM_EQ(0),
+                                }
+                            )
+                        ]
+                    ),
+                )
+            )
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='create_server_group', data=payload, path='tasks'),
-        contract=builder.build())
-
-  def delete_server_group(self):
-    """Creates OperationContract for deleteServerGroup.
-
-    To verify the operation, we just check that the AWS Auto Scaling Group
-    is no longer visible on AWS (or is in the process of terminating).
-    """
-    bindings = self.bindings
-
-    group_name = '{app}-{stack}-v000'.format(
-        app=self.TEST_APP, stack=bindings['TEST_STACK'])
-
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'aws',
-            'type': 'destroyServerGroup',
-            'serverGroupName': group_name,
-            'asgName': group_name,
-            'region': bindings['TEST_AWS_REGION'],
-            'regions': [bindings['TEST_AWS_REGION']],
-            'credentials': bindings['SPINNAKER_AWS_ACCOUNT'],
-            'user': '[anonymous]'
-        }],
-        application=self.TEST_APP,
-        description='DestroyServerGroup: ' + group_name)
-
-    builder = aws.AwsPythonContractBuilder(self.aws_observer)
-    (builder.new_clause_builder('Auto Scaling Group Removed')
-     .call_method(
-         self.autoscaling_client.describe_auto_scaling_groups,
-         AutoScalingGroupNames=[group_name])
-     .EXPECT(
-         ov_factory.error_list_contains(
-             jp.ExceptionMatchesPredicate(
-                   (BotoCoreError, ClientError), 'AutoScalingGroupNotFound')))
-     .OR(
-         ov_factory.value_list_path_contains(
-             'AutoScalingGroups',
-           jp.LIST_MATCHES([])))
-     .OR(
-         ov_factory.value_list_path_contains(
-             'AutoScalingGroups',
-             jp.LIST_MATCHES([
-                 jp.DICT_MATCHES({'Status': jp.STR_SUBSTR('Delete'),
-                                  'MaxSize': jp.NUM_EQ(0)})])))
-     )
-
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_server_group', data=payload, path='tasks'),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete_server_group", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
 
 class AwsSmokeTest(st.AgentTestCase):
-  """The test fixture for the SmokeTest.
+    """The test fixture for the SmokeTest.
 
-  This is implemented using citest OperationContract instances that are
-  created by the AwsSmokeTestScenario.
-  """
-  # pylint: disable=missing-docstring
+    This is implemented using citest OperationContract instances that are
+    created by the AwsSmokeTestScenario.
+    """
 
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-        AwsSmokeTestScenario)
+    # pylint: disable=missing-docstring
 
-  @property
-  def testing_agent(self):
-    return self.scenario.agent
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            AwsSmokeTestScenario
+        )
 
-  def test_a_create_app(self):
-    self.run_test_case(self.scenario.create_app())
+    @property
+    def testing_agent(self):
+        return self.scenario.agent
 
-  def test_b_upsert_load_balancer_public(self):
-    self.run_test_case(self.scenario.upsert_load_balancer(use_vpc=False))
+    def test_a_create_app(self):
+        self.run_test_case(self.scenario.create_app())
 
-  def test_b_upsert_load_balancer_vpc(self):
-    self.run_test_case(self.scenario.upsert_load_balancer(use_vpc=True))
+    def test_b_upsert_load_balancer_public(self):
+        self.run_test_case(self.scenario.upsert_load_balancer(use_vpc=False))
 
-  def test_c_create_server_group(self):
-    # We'll permit this to timeout for now
-    # because it might be waiting on confirmation
-    # but we'll continue anyway because side effects
-    # should have still taken place.
-    self.run_test_case(self.scenario.create_server_group(),
-                       poll_every_secs=5, timeout_ok=True)
+    def test_b_upsert_load_balancer_vpc(self):
+        self.run_test_case(self.scenario.upsert_load_balancer(use_vpc=True))
 
-  def test_x_delete_server_group(self):
-    self.run_test_case(self.scenario.delete_server_group(),
-                       max_retries=5, poll_every_secs=5)
+    def test_c_create_server_group(self):
+        # We'll permit this to timeout for now
+        # because it might be waiting on confirmation
+        # but we'll continue anyway because side effects
+        # should have still taken place.
+        self.run_test_case(
+            self.scenario.create_server_group(), poll_every_secs=5, timeout_ok=True
+        )
 
-  def test_y_delete_load_balancer_vpc(self):
-    self.run_test_case(self.scenario.delete_load_balancer(use_vpc=True),
-                       max_retries=5)
+    def test_x_delete_server_group(self):
+        self.run_test_case(
+            self.scenario.delete_server_group(), max_retries=5, poll_every_secs=5
+        )
 
-  def test_y_delete_load_balancer_pub(self):
-    self.run_test_case(self.scenario.delete_load_balancer(use_vpc=False),
-                       max_retries=5)
+    def test_y_delete_load_balancer_vpc(self):
+        self.run_test_case(
+            self.scenario.delete_load_balancer(use_vpc=True), max_retries=5
+        )
 
-  def test_z_delete_app(self):
-    # Give a total of a minute because it might also need
-    # an internal cache update
-    self.run_test_case(self.scenario.delete_app(),
-                       retry_interval_secs=8, max_retries=8)
+    def test_y_delete_load_balancer_pub(self):
+        self.run_test_case(
+            self.scenario.delete_load_balancer(use_vpc=False), max_retries=5
+        )
+
+    def test_z_delete_app(self):
+        # Give a total of a minute because it might also need
+        # an internal cache update
+        self.run_test_case(
+            self.scenario.delete_app(), retry_interval_secs=8, max_retries=8
+        )
 
 
 def main():
-  """Implements the main method running this smoke test."""
+    """Implements the main method running this smoke test."""
 
-  defaults = {
-      'TEST_STACK': str(AwsSmokeTestScenario.DEFAULT_TEST_ID),
-      'TEST_APP': 'smoketest' + AwsSmokeTestScenario.DEFAULT_TEST_ID
-  }
+    defaults = {
+        "TEST_STACK": str(AwsSmokeTestScenario.DEFAULT_TEST_ID),
+        "TEST_APP": "smoketest" + AwsSmokeTestScenario.DEFAULT_TEST_ID,
+    }
 
-  return citest.base.TestRunner.main(
-      parser_inits=[AwsSmokeTestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[AwsSmokeTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[AwsSmokeTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[AwsSmokeTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/azure_smoke_test.py
+++ b/testing/citest/tests/azure_smoke_test.py
@@ -25,7 +25,7 @@ Sample Usage:
     "--host_platform=native", \
     "--test_azure_rg_location=$TEST_AZURE_RG_LOCATION", \
     "--azure_storage_account_name=$AZURE_STORAGE_ACCOUNT_NAME", \
-    "--azure_storage_account_key=$AZURE_STORAGE_ACCOUNT_KEY", \        
+    "--azure_storage_account_key=$AZURE_STORAGE_ACCOUNT_KEY", \
 
 """
 # Standard python modules.

--- a/testing/citest/tests/bake_and_deploy_test.py
+++ b/testing/citest/tests/bake_and_deploy_test.py
@@ -101,715 +101,825 @@ import citest.service_testing as st
 # Spinnaker modules.
 import spinnaker_testing as sk
 import spinnaker_testing.gate as gate
+
 ov_factory = jc.ObservationPredicateFactory()
+
 
 class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
 
-  MINIMUM_PROJECT_QUOTA = {
-      'INSTANCE_TEMPLATES': 1,
-      'HEALTH_CHECKS': 1,
-      'FORWARDING_RULES': 1,
-      'IN_USE_ADDRESSES': 1,
-      'TARGET_POOLS': 1,
-      'IMAGES': 1,
-  }
+    MINIMUM_PROJECT_QUOTA = {
+        "INSTANCE_TEMPLATES": 1,
+        "HEALTH_CHECKS": 1,
+        "FORWARDING_RULES": 1,
+        "IN_USE_ADDRESSES": 1,
+        "TARGET_POOLS": 1,
+        "IMAGES": 1,
+    }
 
-  MINIMUM_REGION_QUOTA = {
-      'CPUS': 1,
-      'IN_USE_ADDRESSES': 1,
-      'INSTANCE_GROUP_MANAGERS': 1,
-      'INSTANCES': 1,
-  }
+    MINIMUM_REGION_QUOTA = {
+        "CPUS": 1,
+        "IN_USE_ADDRESSES": 1,
+        "INSTANCE_GROUP_MANAGERS": 1,
+        "INSTANCES": 1,
+    }
 
-  @classmethod
-  def new_agent(cls, bindings):
-    return gate.new_agent(bindings)
+    @classmethod
+    def new_agent(cls, bindings):
+        return gate.new_agent(bindings)
 
-  @classmethod
-  def initArgumentParser(cls, parser, defaults=None):
-    """Initialize command line argument parser.
+    @classmethod
+    def initArgumentParser(cls, parser, defaults=None):
+        """Initialize command line argument parser.
 
-    Args:
-      parser: argparse.ArgumentParser
-    """
-    super(BakeAndDeployTestScenario, cls).initArgumentParser(
-        parser, defaults=defaults)
+        Args:
+          parser: argparse.ArgumentParser
+        """
+        super(BakeAndDeployTestScenario, cls).initArgumentParser(
+            parser, defaults=defaults
+        )
 
-    defaults = defaults or {}
-    parser.add_argument(
-      '--jenkins_master', default='',
-      help='The name of the jenkins master as configured in igor.'
-           ' You may need to override this to an alias depending on firewalls.'
-           ' The Spinnaker server may have permissions, but the citest machine'
-           ' may not. Otherwise, this defaults to Spinnaker\'s binding.')
-    parser.add_argument(
-      '--jenkins_job', default='NoOpTrigger',
-      help='The name of the jenkins job to trigger off.'
-           ' You will need to add this to your --jenkins_master.')
-    parser.add_argument(
-      '--jenkins_auth_path', default=None,
-      help='The path to a file containing the jenkins username password pair.'
-           'The contents should look like: <username> <password>.')
-    parser.add_argument(
-      '--jenkins_token', default='TRIGGER_TOKEN',
-      help='The authentication token for the jenkins build trigger.'
-      ' This corresponds to the --jenkins_job on the --jenkins_url server')
+        defaults = defaults or {}
+        parser.add_argument(
+            "--jenkins_master",
+            default="",
+            help="The name of the jenkins master as configured in igor."
+            " You may need to override this to an alias depending on firewalls."
+            " The Spinnaker server may have permissions, but the citest machine"
+            " may not. Otherwise, this defaults to Spinnaker's binding.",
+        )
+        parser.add_argument(
+            "--jenkins_job",
+            default="NoOpTrigger",
+            help="The name of the jenkins job to trigger off."
+            " You will need to add this to your --jenkins_master.",
+        )
+        parser.add_argument(
+            "--jenkins_auth_path",
+            default=None,
+            help="The path to a file containing the jenkins username password pair."
+            "The contents should look like: <username> <password>.",
+        )
+        parser.add_argument(
+            "--jenkins_token",
+            default="TRIGGER_TOKEN",
+            help="The authentication token for the jenkins build trigger."
+            " This corresponds to the --jenkins_job on the --jenkins_url server",
+        )
 
-    parser.add_argument(
-      '--jenkins_url', default='',
-      help='The baseUrl of the jenkins service,'
-           ' i.e. <protocol>://<host>[:port]/[basePath].'
-           ' You may need to override this to an alias depending on firewalls.'
-           ' The Spinnaker server may have permissions, but the citest machine'
-           ' may not. Otherwise, this can be empty for Spinnaker\'s current'
-           ' binding.')
-    parser.add_argument(
-      '--test_google', action='store_true',
-      help='Test Google pipelines.')
-    parser.add_argument(
-      '--test_aws', action='store_true',
-      help='Test AWS pipelines.')
+        parser.add_argument(
+            "--jenkins_url",
+            default="",
+            help="The baseUrl of the jenkins service,"
+            " i.e. <protocol>://<host>[:port]/[basePath]."
+            " You may need to override this to an alias depending on firewalls."
+            " The Spinnaker server may have permissions, but the citest machine"
+            " may not. Otherwise, this can be empty for Spinnaker's current"
+            " binding.",
+        )
+        parser.add_argument(
+            "--test_google", action="store_true", help="Test Google pipelines."
+        )
+        parser.add_argument(
+            "--test_aws", action="store_true", help="Test AWS pipelines."
+        )
 
-  def _do_init_bindings(self):
-    logger = logging.getLogger(__name__)
-    bindings = self.bindings
-    deployed = self.agent.deployed_config
-    yaml_node_path = 'services.jenkins.defaultMaster'
-    if not bindings.get('JENKINS_MASTER'):
-      bindings['JENKINS_MASTER'] = deployed[yaml_node_path + '.name']
-      logger.info('Infering JENKINS_MASTER %s', bindings['JENKINS_MASTER'])
+    def _do_init_bindings(self):
+        logger = logging.getLogger(__name__)
+        bindings = self.bindings
+        deployed = self.agent.deployed_config
+        yaml_node_path = "services.jenkins.defaultMaster"
+        if not bindings.get("JENKINS_MASTER"):
+            bindings["JENKINS_MASTER"] = deployed[yaml_node_path + ".name"]
+            logger.info("Infering JENKINS_MASTER %s", bindings["JENKINS_MASTER"])
 
-    if not bindings.get('JENKINS_URL'):
-      bindings['JENKINS_URL'] = deployed[yaml_node_path + '.baseUrl']
-      logger.info('Infering JENKINS_URL %s', bindings['JENKINS_URL'])
+        if not bindings.get("JENKINS_URL"):
+            bindings["JENKINS_URL"] = deployed[yaml_node_path + ".baseUrl"]
+            logger.info("Infering JENKINS_URL %s", bindings["JENKINS_URL"])
 
-  def __init__(self, bindings, agent=None):
-    super(BakeAndDeployTestScenario, self).__init__(bindings, agent)
-    self.logger = logging.getLogger(__name__)
+    def __init__(self, bindings, agent=None):
+        super(BakeAndDeployTestScenario, self).__init__(bindings, agent)
+        self.logger = logging.getLogger(__name__)
 
-    bindings = self.bindings
+        bindings = self.bindings
 
-    # We'll call out the app name because it is widely used
-    # because it scopes the context of our activities.
-    self.TEST_APP = bindings['TEST_APP']
+        # We'll call out the app name because it is widely used
+        # because it scopes the context of our activities.
+        self.TEST_APP = bindings["TEST_APP"]
 
-    self.__short_lb_name = 'lb'
-    self.__full_lb_name = '{app}-{stack}-{detail}'.format(
-            app=self.TEST_APP, stack=bindings['TEST_STACK'],
-            detail=self.__short_lb_name)
-    self.aws_bake_pipeline_id = None
-    self.aws_destroy_pipeline_id = None
-    self.google_bake_pipeline_id = None
-    self.google_destroy_pipeline_id = None
-    self.__image_id_to_delete = None # Id of the baked image we need to clean up after the B & D pipelines run.
-    self.docker_pipeline_id = None
-    self.test_google = bindings['TEST_GOOGLE']
-    self.test_aws = bindings['TEST_AWS']
-    # This test has been exceeding the default timeout of 13 minutes for the Jenkins agent,
-    # so increase the timeout to 20 minutes.
-    self.jenkins_agent = sk.JenkinsAgent(bindings['JENKINS_URL'],
-                                         bindings['JENKINS_AUTH_PATH'],
-                                         self.agent, None, 1200)
-    self.run_tests = True
+        self.__short_lb_name = "lb"
+        self.__full_lb_name = "{app}-{stack}-{detail}".format(
+            app=self.TEST_APP, stack=bindings["TEST_STACK"], detail=self.__short_lb_name
+        )
+        self.aws_bake_pipeline_id = None
+        self.aws_destroy_pipeline_id = None
+        self.google_bake_pipeline_id = None
+        self.google_destroy_pipeline_id = None
+        self.__image_id_to_delete = None  # Id of the baked image we need to clean up after the B & D pipelines run.
+        self.docker_pipeline_id = None
+        self.test_google = bindings["TEST_GOOGLE"]
+        self.test_aws = bindings["TEST_AWS"]
+        # This test has been exceeding the default timeout of 13 minutes for the Jenkins agent,
+        # so increase the timeout to 20 minutes.
+        self.jenkins_agent = sk.JenkinsAgent(
+            bindings["JENKINS_URL"],
+            bindings["JENKINS_AUTH_PATH"],
+            self.agent,
+            None,
+            1200,
+        )
+        self.run_tests = True
 
-    if not (self.test_google or self.test_aws):
-      self.run_tests = False
-      self.logger.warning(
-          'Neither --test_google nor --test_aws were set. '
-          'No tests will be run.')
+        if not (self.test_google or self.test_aws):
+            self.run_tests = False
+            self.logger.warning(
+                "Neither --test_google nor --test_aws were set. "
+                "No tests will be run."
+            )
 
-  def create_app(self):
-    builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Application', retryable_for_secs=60)
-       .get_url_path('applications')
-       .contains_path_value('name', self.TEST_APP))
+    def create_app(self):
+        builder = st.HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder("Has Application", retryable_for_secs=60)
+            .get_url_path("applications")
+            .contains_path_value("name", self.TEST_APP)
+        )
 
-    return st.OperationContract(
-        self.agent.make_create_app_operation(
-            bindings=self.bindings, application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-            cloud_providers="gce,aws"),
-        builder.build())
+        return st.OperationContract(
+            self.agent.make_create_app_operation(
+                bindings=self.bindings,
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                cloud_providers="gce,aws",
+            ),
+            builder.build(),
+        )
 
-  def delete_app(self):
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_delete_app_operation(
+    def delete_app(self):
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_delete_app_operation(
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+            ),
+            contract=contract,
+        )
+
+    def create_load_balancer(self):
+        bindings = self.bindings
+        load_balancer_name = self.__full_lb_name
+
+        spec = {
+            "checkIntervalSec": 5,
+            "healthyThreshold": 2,
+            "unhealthyThreshold": 2,
+            "timeoutSec": 5,
+            "port": 80,
+        }
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "gce",
+                    "provider": "gce",
+                    "stack": bindings["TEST_STACK"],
+                    "detail": self.__short_lb_name,
+                    "credentials": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    "region": bindings["TEST_GCE_REGION"],
+                    "ipProtocol": "TCP",
+                    "portRange": spec["port"],
+                    "loadBalancerName": load_balancer_name,
+                    "healthCheck": {
+                        "port": spec["port"],
+                        "timeoutSec": spec["timeoutSec"],
+                        "checkIntervalSec": spec["checkIntervalSec"],
+                        "healthyThreshold": spec["healthyThreshold"],
+                        "unhealthyThreshold": spec["unhealthyThreshold"],
+                    },
+                    "type": "upsertLoadBalancer",
+                    "availabilityZones": {bindings["TEST_GCE_REGION"]: []},
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Create Load Balancer: " + load_balancer_name,
             application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_GOOGLE_ACCOUNT']),
-        contract=contract)
+        )
 
-  def create_load_balancer(self):
-    bindings = self.bindings
-    load_balancer_name = self.__full_lb_name
+        # We arent testing load balancers, so assume it is working,
+        # but we'll look for at the health check to know it is ready.
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Health Check Added", retryable_for_secs=30)
+            .list_resource("httpHealthChecks")
+            .contains_path_value("name", load_balancer_name + "-hc")
+        )
 
-    spec = {
-      'checkIntervalSec': 5,
-      'healthyThreshold': 2,
-      'unhealthyThreshold': 2,
-      'timeoutSec': 5,
-      'port': 80
-    }
+        (
+            builder.new_clause_builder("Load Balancer Created", retryable_for_secs=60)
+            .list_resource("forwardingRules")
+            .contains_path_value("name", self.__full_lb_name)
+        )
 
-    payload = self.agent.make_json_payload_from_kwargs(
-      job=[{
-          'cloudProvider': 'gce',
-          'provider': 'gce',
-          'stack': bindings['TEST_STACK'],
-          'detail': self.__short_lb_name,
-          'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-          'region': bindings['TEST_GCE_REGION'],
-          'ipProtocol': 'TCP',
-          'portRange': spec['port'],
-          'loadBalancerName': load_balancer_name,
-          'healthCheck': {
-              'port': spec['port'],
-              'timeoutSec': spec['timeoutSec'],
-              'checkIntervalSec': spec['checkIntervalSec'],
-              'healthyThreshold': spec['healthyThreshold'],
-              'unhealthyThreshold': spec['unhealthyThreshold'],
-          },
-          'type': 'upsertLoadBalancer',
-          'availabilityZones': {bindings['TEST_GCE_REGION']: []},
-          'user': '[anonymous]'
-      }],
-      description='Create Load Balancer: ' + load_balancer_name,
-      application=self.TEST_APP)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_load_balancer",
+                data=payload,
+                path=("applications/{app}/tasks").format(app=self.TEST_APP),
+            ),
+            contract=builder.build(),
+        )
 
-    # We arent testing load balancers, so assume it is working,
-    # but we'll look for at the health check to know it is ready.
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Health Check Added',
-                                retryable_for_secs=30)
-         .list_resource('httpHealthChecks')
-         .contains_path_value('name', load_balancer_name + '-hc'))
+    def delete_load_balancer(self):
+        bindings = self.bindings
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "type": "deleteLoadBalancer",
+                    "cloudProvider": "gce",
+                    "loadBalancerName": self.__full_lb_name,
+                    "region": bindings["TEST_GCE_REGION"],
+                    "regions": [bindings["TEST_GCE_REGION"]],
+                    "credentials": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Delete Load Balancer: {0} in {1}:{2}".format(
+                self.__full_lb_name,
+                bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                bindings["TEST_GCE_REGION"],
+            ),
+            application=self.TEST_APP,
+        )
 
-    (builder.new_clause_builder('Load Balancer Created',
-                                retryable_for_secs=60)
-         .list_resource('forwardingRules')
-         .contains_path_value('name', self.__full_lb_name))
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Health Check Removed", retryable_for_secs=30)
+            .list_resource("httpHealthChecks")
+            .excludes_path_value("name", self.__full_lb_name + "-hc")
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='create_load_balancer', data=payload,
-            path=('applications/{app}/tasks').format(app=self.TEST_APP)),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete_load_balancer",
+                data=payload,
+                path=("applications/{app}/tasks").format(app=self.TEST_APP),
+            ),
+            contract=builder.build(),
+        )
 
-  def delete_load_balancer(self):
-    bindings = self.bindings
-    payload = self.agent.make_json_payload_from_kwargs(
-       job=[{
-          'type': 'deleteLoadBalancer',
-          'cloudProvider': 'gce',
-          'loadBalancerName': self.__full_lb_name,
-          'region': bindings['TEST_GCE_REGION'],
-          'regions': [bindings['TEST_GCE_REGION']],
-          'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-          'user': '[anonymous]'
-       }],
-       description='Delete Load Balancer: {0} in {1}:{2}'.format(
-          self.__full_lb_name,
-          bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-          bindings['TEST_GCE_REGION']),
-      application=self.TEST_APP)
+    def make_jenkins_trigger(self):
+        return {
+            "enabled": True,
+            "type": "jenkins",
+            "master": self.bindings["JENKINS_MASTER"],
+            "job": self.bindings["JENKINS_JOB"],
+        }
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Health Check Removed', retryable_for_secs=30)
-         .list_resource('httpHealthChecks')
-         .excludes_path_value('name', self.__full_lb_name + '-hc'))
+    def make_bake_stage(self, package, providerType, requisiteStages=None, **kwargs):
+        result = {
+            "requisiteStageRefIds": requisiteStages or [],
+            "refId": "BAKE",
+            "type": "bake",
+            "name": "Bake",
+            "user": "[anonymous]",
+            "baseOs": "xenial" if providerType == "gce" else "trusty",
+            "baseLabel": "release",
+            "cloudProvider": providerType,
+            "cloudProviderType": providerType,
+            "package": package,
+            "rebake": True,
+        }
+        result.update(kwargs)
+        return result
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_load_balancer', data=payload,
-            path=('applications/{app}/tasks').format(app=self.TEST_APP)),
-        contract=builder.build())
+    def make_deploy_google_stage(self, requisiteStages=None):
+        return {
+            "requisiteStageRefIds": requisiteStages or [],
+            "refId": "DEPLOY",
+            "type": "deploy",
+            "name": "Deploy",
+            "clusters": [
+                {
+                    "application": self.TEST_APP,
+                    "strategy": "",
+                    "stack": self.bindings["TEST_STACK"],
+                    "freeFormDetails": "",
+                    "loadBalancers": [self.__full_lb_name],
+                    "securityGroups": [],
+                    "capacity": {"min": 1, "max": 1, "desired": 1},
+                    "zone": self.bindings["TEST_GCE_ZONE"],
+                    "network": "default",
+                    "instanceMetadata": {"load-balancer-names": self.__full_lb_name},
+                    "tags": [],
+                    "availabilityZones": {
+                        self.bindings["TEST_GCE_REGION"]: [
+                            self.bindings["TEST_GCE_ZONE"]
+                        ]
+                    },
+                    "cloudProvider": "gce",
+                    "provider": "gce",
+                    "instanceType": "f1-micro",
+                    "targetSize": 1,
+                    "account": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                }
+            ],
+        }
 
-  def make_jenkins_trigger(self):
-    return {
-      'enabled': True,
-      'type': 'jenkins',
-      'master': self.bindings['JENKINS_MASTER'],
-      'job': self.bindings['JENKINS_JOB']
-      }
+    def make_destroy_group_stage(self, cloudProvider, requisiteStages, **kwargs):
+        result = {
+            "cloudProvider": cloudProvider,
+            "cloudProviderType": cloudProvider,
+            "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+            "name": "Destroy Server Group",
+            "refId": "DESTROY",
+            "requisiteStageRefIds": requisiteStages or [],
+            "target": "current_asg_dynamic",
+            "regions": [self.bindings["TEST_GCE_REGION"]],
+            "cluster": "{app}-{stack}".format(
+                app=self.TEST_APP, stack=self.bindings["TEST_STACK"]
+            ),
+            "type": "destroyServerGroup",
+        }
+        result.update(kwargs)
+        return result
 
-  def make_bake_stage(self, package, providerType, requisiteStages=None,
-      **kwargs):
-    result = {
-        'requisiteStageRefIds':requisiteStages or [],
-        'refId': 'BAKE',
-        'type': 'bake',
-        'name': 'Bake',
-        'user': '[anonymous]',
-        'baseOs': 'xenial' if providerType == 'gce' else 'trusty',
-        'baseLabel': 'release',
-        'cloudProvider': providerType,
-        'cloudProviderType': providerType,
-        'package': package,
-        'rebake': True
-    }
-    result.update(kwargs)
-    return result
+    def make_disable_group_stage(self, cloudProvider, requisiteStages=None, **kwargs):
+        result = {
+            "requisiteStageRefIds": requisiteStages or [],
+            "refId": "DISABLE",
+            "type": "disableServerGroup",
+            "name": "Disable Server Group",
+            "cloudProviderType": cloudProvider,
+            "cloudProvider": cloudProvider,
+            "target": "current_asg_dynamic",
+            "cluster": "{app}-{stack}".format(
+                app=self.TEST_APP, stack=self.bindings["TEST_STACK"]
+            ),
+            "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+        }
+        result.update(kwargs)
+        return result
 
-  def make_deploy_google_stage(self, requisiteStages=None):
-    return {
-      'requisiteStageRefIds': requisiteStages or [],
-      'refId': 'DEPLOY',
-      'type': 'deploy',
-      'name': 'Deploy',
-      'clusters':[{
-        'application': self.TEST_APP,
-        'strategy': '',
-        'stack': self.bindings['TEST_STACK'],
-        'freeFormDetails': '',
-        'loadBalancers': [self.__full_lb_name],
-        'securityGroups': [],
-        'capacity': {
-          'min':1,
-          'max':1,
-          'desired':1
-        },
-        'zone': self.bindings['TEST_GCE_ZONE'],
-        'network': 'default',
-        'instanceMetadata': {
-          'load-balancer-names': self.__full_lb_name
-        },
-        'tags': [],
-        'availabilityZones': {
-          self.bindings['TEST_GCE_REGION']: [self.bindings['TEST_GCE_ZONE']]
-        },
+    def create_bake_docker_pipeline(self):
+        name = "BakeDocker"
+        self.docker_pipeline_id = name
+        bake_stage = self.make_bake_stage(
+            package="libatm1", providerType="docker", region="global"
+        )
 
-        'cloudProvider': 'gce',
-        'provider': 'gce',
-        'instanceType': 'f1-micro',
-        'targetSize': 1,
-        'account': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
-      }]
-    }
+        pipeline_spec = dict(
+            name=name,
+            stages=[bake_stage],
+            triggers=[self.make_jenkins_trigger()],
+            application=self.TEST_APP,
+            stageCounter=1,
+            parallel=True,
+            limitConcurrent=True,
+            appConfig={},
+        )
+        payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
 
-  def make_destroy_group_stage(self, cloudProvider, requisiteStages,
-      **kwargs):
-    result = {
-      'cloudProvider': cloudProvider,
-      'cloudProviderType': cloudProvider,
-      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      'name': 'Destroy Server Group',
-      'refId': 'DESTROY',
-      'requisiteStageRefIds': requisiteStages or [],
-      'target': 'current_asg_dynamic',
-      'regions': [self.bindings['TEST_GCE_REGION']],
-      'cluster': '{app}-{stack}'.format(
-          app=self.TEST_APP, stack=self.bindings['TEST_STACK']),
-      'type': 'destroyServerGroup'
-    }
-    result.update(kwargs)
-    return result
+        builder = st.HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder("Has Pipeline", retryable_for_secs=5)
+            .get_url_path(
+                "applications/{app}/pipelineConfigs".format(app=self.TEST_APP)
+            )
+            .contains_path_value(None, pipeline_spec)
+        )
 
-  def make_disable_group_stage(self, cloudProvider, requisiteStages=None,
-      **kwargs):
-    result = {
-      'requisiteStageRefIds': requisiteStages or [],
-      'refId': 'DISABLE',
-      'type': 'disableServerGroup',
-      'name': 'Disable Server Group',
-      'cloudProviderType': cloudProvider,
-      'cloudProvider': cloudProvider,
-      'target': 'current_asg_dynamic',
-      'cluster': '{app}-{stack}'.format(
-          app=self.TEST_APP, stack=self.bindings['TEST_STACK']),
-      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
-    }
-    result.update(kwargs)
-    return result
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_bake_docker_pipeline",
+                data=payload,
+                path="pipelines",
+                status_class=st.SynchronousHttpOperationStatus,
+            ),
+            contract=builder.build(),
+        )
 
-  def create_bake_docker_pipeline(self):
-    name = 'BakeDocker'
-    self.docker_pipeline_id = name
-    bake_stage = self.make_bake_stage(
-        package='libatm1', providerType='docker', region='global')
+    def create_bake_and_deploy_google_pipeline(self):
+        name = "BakeAndDeployGoogle"
+        self.google_bake_pipeline_id = name
+        bake_stage = self.make_bake_stage(
+            package="libatm1", providerType="gce", region="global"
+        )
+        deploy_stage = self.make_deploy_google_stage(requisiteStages=["BAKE"])
 
-    pipeline_spec = dict(
-      name=name,
-      stages=[bake_stage],
-      triggers=[self.make_jenkins_trigger()],
-      application=self.TEST_APP,
-      stageCounter=1,
-      parallel=True,
-      limitConcurrent=True,
-      appConfig={}
-    )
-    payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
+        pipeline_spec = dict(
+            name=name,
+            stages=[bake_stage, deploy_stage],
+            triggers=[self.make_jenkins_trigger()],
+            application=self.TEST_APP,
+            stageCounter=2,
+            parallel=True,
+            limitConcurrent=True,
+            appConfig={},
+        )
 
-    builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Pipeline', retryable_for_secs=5)
-       .get_url_path(
-           'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
-       .contains_path_value(None, pipeline_spec))
+        payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='create_bake_docker_pipeline', data=payload, path='pipelines',
-            status_class=st.SynchronousHttpOperationStatus),
-        contract=builder.build())
+        builder = st.HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder("Has Pipeline", retryable_for_secs=5)
+            .get_url_path(
+                "applications/{app}/pipelineConfigs".format(app=self.TEST_APP)
+            )
+            .contains_path_value(None, pipeline_spec)
+        )
 
-  def create_bake_and_deploy_google_pipeline(self):
-    name = 'BakeAndDeployGoogle'
-    self.google_bake_pipeline_id = name
-    bake_stage = self.make_bake_stage(
-        package='libatm1', providerType='gce', region='global')
-    deploy_stage = self.make_deploy_google_stage(requisiteStages=['BAKE'])
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_bake_google_pipeline",
+                data=payload,
+                path="pipelines",
+                status_class=st.SynchronousHttpOperationStatus,
+            ),
+            contract=builder.build(),
+        )
 
-    pipeline_spec = dict(
-      name=name,
-      stages=[bake_stage, deploy_stage],
-      triggers=[self.make_jenkins_trigger()],
-      application=self.TEST_APP,
-      stageCounter=2,
-      parallel=True,
-      limitConcurrent=True,
-      appConfig={}
-    )
+    def create_disable_and_destroy_google_pipeline(self):
+        name = "DisableAndDestroyGoogle"
+        self.google_destroy_pipeline_id = name
+        disable_stage = self.make_disable_group_stage(
+            cloudProvider="gce", regions=[self.bindings["TEST_GCE_REGION"]]
+        )
+        destroy_stage = self.make_destroy_group_stage(
+            cloudProvider="gce", requisiteStages=["DISABLE"]
+        )
 
-    payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
+        pipeline_spec = dict(
+            name=name,
+            stages=[disable_stage, destroy_stage],
+            application=self.TEST_APP,
+            stageCounter=2,
+            parallel=True,
+            limitConcurrent=True,
+            appConfig={},
+        )
 
-    builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Pipeline', retryable_for_secs=5)
-       .get_url_path(
-           'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
-       .contains_path_value(None, pipeline_spec))
+        payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='create_bake_google_pipeline', data=payload, path='pipelines',
-            status_class=st.SynchronousHttpOperationStatus),
-        contract=builder.build())
+        builder = st.HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder("Has Pipeline", retryable_for_secs=5)
+            .get_url_path(
+                "applications/{app}/pipelineConfigs".format(app=self.TEST_APP)
+            )
+            .contains_path_value(None, pipeline_spec)
+        )
 
-  def create_disable_and_destroy_google_pipeline(self):
-    name = 'DisableAndDestroyGoogle'
-    self.google_destroy_pipeline_id = name
-    disable_stage = self.make_disable_group_stage(
-      cloudProvider='gce', regions=[self.bindings['TEST_GCE_REGION']])
-    destroy_stage = self.make_destroy_group_stage(
-      cloudProvider='gce', requisiteStages=['DISABLE'])
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_destroy_google_pipeline",
+                data=payload,
+                path="pipelines",
+                status_class=st.SynchronousHttpOperationStatus,
+            ),
+            contract=builder.build(),
+        )
 
-    pipeline_spec = dict(
-      name=name,
-      stages=[disable_stage, destroy_stage],
-      application=self.TEST_APP,
-      stageCounter=2,
-      parallel=True,
-      limitConcurrent=True,
-      appConfig={}
-    )
+    def create_bake_and_deploy_aws_pipeline(self):
+        name = "BakeAndDeployAws"
+        self.aws_bake_pipeline_id = name
+        bake_stage = self.make_bake_stage(
+            package="libatm1",
+            providerType="aws",
+            regions=[self.bindings["TEST_AWS_REGION"]],
+            vmType="hvm",
+            storeType="ebs",
+        )
+        # FIXME(jacobkiefer): this is creating a gce deploy stage in an aws
+        # pipeline. Not good.
+        deploy_stage = self.make_deploy_google_stage(requisiteStages=["BAKE"])
 
-    payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
+        pipeline_spec = dict(
+            name=name,
+            stages=[bake_stage, deploy_stage],
+            triggers=[self.make_jenkins_trigger()],
+            application=self.TEST_APP,
+            stageCounter=2,
+            parallel=True,
+        )
+        payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
 
-    builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Pipeline', retryable_for_secs=5)
-       .get_url_path(
-           'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
-       .contains_path_value(None, pipeline_spec))
+        builder = st.HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder("Has Pipeline", retryable_for_secs=5)
+            .get_url_path(
+                "applications/{app}/pipelineConfigs".format(app=self.TEST_APP)
+            )
+            .contains_path_value(None, pipeline_spec)
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='create_destroy_google_pipeline',
-            data=payload, path='pipelines',
-            status_class=st.SynchronousHttpOperationStatus),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_bake_aws_pipeline",
+                data=payload,
+                path="pipelines",
+                status_class=st.SynchronousHttpOperationStatus,
+            ),
+            contract=builder.build(),
+        )
 
-  def create_bake_and_deploy_aws_pipeline(self):
-    name = 'BakeAndDeployAws'
-    self.aws_bake_pipeline_id = name
-    bake_stage = self.make_bake_stage(
-        package='libatm1',
-        providerType='aws',
-        regions=[self.bindings['TEST_AWS_REGION']],
-        vmType='hvm', storeType='ebs')
-    # FIXME(jacobkiefer): this is creating a gce deploy stage in an aws
-    # pipeline. Not good.
-    deploy_stage = self.make_deploy_google_stage(requisiteStages=['BAKE'])
+    def create_disable_and_destroy_aws_pipeline(self):
+        name = "DisableAndDestroyAws"
+        self.aws_destroy_pipeline_id = name
+        disable_stage = self.make_disable_group_stage(
+            cloudProvider="aws", regions=[self.bindings["TEST_AWS_REGION"]]
+        )
+        destroy_stage = self.make_destroy_group_stage(
+            cloudProvider="aws",
+            zones=[self.bindings["TEST_AWS_ZONE"]],
+            requisiteStages=["DISABLE"],
+        )
 
-    pipeline_spec = dict(
-      name=name,
-      stages=[bake_stage, deploy_stage],
-      triggers=[self.make_jenkins_trigger()],
-      application=self.TEST_APP,
-      stageCounter=2,
-      parallel=True
-    )
-    payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
+        pipeline_spec = dict(
+            name=name,
+            stages=[disable_stage, destroy_stage],
+            triggers=[self.make_jenkins_trigger()],
+            application=self.TEST_APP,
+            stageCounter=2,
+            parallel=True,
+        )
+        payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
 
-    builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Pipeline', retryable_for_secs=5)
-       .get_url_path(
-           'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
-       .contains_path_value(None, pipeline_spec))
+        builder = st.HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder("Has Pipeline", retryable_for_secs=5)
+            .get_url_path(
+                "applications/{app}/pipelineConfigs".format(app=self.TEST_APP)
+            )
+            .contains_path_value(None, pipeline_spec)
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='create_bake_aws_pipeline', data=payload, path='pipelines',
-            status_class=st.SynchronousHttpOperationStatus),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_destroy_aws_pipeline",
+                data=payload,
+                path="pipelines",
+                status_class=st.SynchronousHttpOperationStatus,
+            ),
+            contract=builder.build(),
+        )
 
-  def create_disable_and_destroy_aws_pipeline(self):
-    name = 'DisableAndDestroyAws'
-    self.aws_destroy_pipeline_id = name
-    disable_stage = self.make_disable_group_stage(
-      cloudProvider='aws', regions=[self.bindings['TEST_AWS_REGION']])
-    destroy_stage = self.make_destroy_group_stage(
-      cloudProvider='aws', zones=[self.bindings['TEST_AWS_ZONE']],
-      requisiteStages=['DISABLE'])
+    def delete_pipeline(self, pipeline_id):
+        payload = self.agent.make_json_payload_from_kwargs(id=pipeline_id)
+        path = os.path.join("pipelines", self.TEST_APP, pipeline_id)
 
-    pipeline_spec = dict(
-      name=name,
-      stages=[disable_stage, destroy_stage],
-      triggers=[self.make_jenkins_trigger()],
-      application=self.TEST_APP,
-      stageCounter=2,
-      parallel=True
-    )
-    payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
+        builder = st.HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder("Has Pipeline", retryable_for_secs=5)
+            .get_url_path(
+                "applications/{app}/pipelineConfigs".format(app=self.TEST_APP)
+            )
+            .excludes_path_value("name", pipeline_id)
+        )
 
-    builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Pipeline', retryable_for_secs=5)
-       .get_url_path(
-           'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
-       .contains_path_value(None, pipeline_spec))
+        return st.OperationContract(
+            self.new_delete_operation(
+                title="delete_bake_pipeline",
+                data=payload,
+                path=path,
+                status_class=st.SynchronousHttpOperationStatus,
+            ),
+            contract=builder.build(),
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='create_destroy_aws_pipeline', data=payload, path='pipelines',
-            status_class=st.SynchronousHttpOperationStatus),
-        contract=builder.build())
+    def trigger_bake_and_deploy_google_pipeline(self):
+        path = "applications/{app}/pipelines".format(app=self.TEST_APP)
 
-  def delete_pipeline(self, pipeline_id):
-    payload = self.agent.make_json_payload_from_kwargs(id=pipeline_id)
-    path = os.path.join('pipelines', self.TEST_APP, pipeline_id)
+        group_name = "{app}-{stack}-v000".format(
+            app=self.TEST_APP, stack=self.bindings["TEST_STACK"]
+        )
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder(
+                "Managed Instance Group Deployed", retryable_for_secs=30
+            )
+            .inspect_resource("instanceGroupManagers", group_name)
+            .EXPECT(ov_factory.value_list_path_contains("targetSize", jp.NUM_EQ(1)))
+        )
 
-    builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Pipeline',
-                                retryable_for_secs=5)
-       .get_url_path(
-           'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
-       .excludes_path_value('name', pipeline_id))
+        return st.OperationContract(
+            self.jenkins_agent.new_jenkins_trigger_operation(
+                title="monitor_bake_pipeline",
+                job=self.bindings["JENKINS_JOB"],
+                token=self.bindings["JENKINS_TOKEN"],
+                status_class=gate.GatePipelineStatus,
+                status_path=path,
+                max_wait_secs=1080,
+            ),  # Allow 18 mins to bake and deploy.
+            contract=builder.build(),
+            cleanup=self.capture_baked_image,
+        )
 
-    return st.OperationContract(
-        self.new_delete_operation(
-            title='delete_bake_pipeline', data=payload, path=path,
-            status_class=st.SynchronousHttpOperationStatus),
-        contract=builder.build())
+    def run_disable_and_destroy_google_pipeline(self, pipeline_id):
+        path = "pipelines/{app}/{id}".format(
+            app=self.TEST_APP, id=self.google_destroy_pipeline_id
+        )
+        group_name = "{app}-{stack}-v000".format(
+            app=self.TEST_APP, stack=self.bindings["TEST_STACK"]
+        )
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Managed Instance Group Destroyed")
+            .inspect_resource("instanceGroupManagers", group_name)
+            .EXPECT(
+                ov_factory.error_list_contains(gcp.HttpErrorPredicate(http_code=404))
+            )
+            .OR(ov_factory.value_list_path_contains("targetSize", jp.NUM_EQ(0)))
+        )
 
-  def trigger_bake_and_deploy_google_pipeline(self):
-    path = 'applications/{app}/pipelines'.format(app=self.TEST_APP)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="run_destroy_pipeline", data="", path=path, max_wait_secs=1080
+            ),  # Allow 18 mins to disable and destroy.
+            contract=jc.Contract(),
+            cleanup=self.delete_baked_image,
+        )
 
-    group_name = '{app}-{stack}-v000'.format(
-        app=self.TEST_APP, stack=self.bindings['TEST_STACK'])
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Managed Instance Group Deployed',
-                                retryable_for_secs=30)
-     .inspect_resource('instanceGroupManagers', group_name)
-     .EXPECT(ov_factory.value_list_path_contains('targetSize', jp.NUM_EQ(1))))
+    def new_jenkins_build_operation(self):
+        return None
 
-    return st.OperationContract(
-        self.jenkins_agent.new_jenkins_trigger_operation(
-            title='monitor_bake_pipeline',
-            job=self.bindings['JENKINS_JOB'],
-            token=self.bindings['JENKINS_TOKEN'],
-            status_class=gate.GatePipelineStatus,
-            status_path=path,
-            max_wait_secs=1080), # Allow 18 mins to bake and deploy.
-        contract=builder.build(),
-        cleanup=self.capture_baked_image)
+    def capture_baked_image(self, execution_context):
+        """Saves the baked image name from the triggered Bake & Deploy pipeline to delete later."""
+        status = execution_context.get("OperationStatus", None)
+        if status is None:
+            self.logger.info(
+                "Operation could not be performed so there is no image to delete."
+            )
+            return
 
-  def run_disable_and_destroy_google_pipeline(self, pipeline_id):
-    path = 'pipelines/{app}/{id}'.format(app=self.TEST_APP,
-                                         id=self.google_destroy_pipeline_id)
-    group_name = '{app}-{stack}-v000'.format(
-        app=self.TEST_APP, stack=self.bindings['TEST_STACK'])
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Managed Instance Group Destroyed')
-     .inspect_resource('instanceGroupManagers', group_name)
-     .EXPECT(ov_factory.error_list_contains(
-         gcp.HttpErrorPredicate(http_code=404)))
-     .OR(ov_factory.value_list_path_contains('targetSize', jp.NUM_EQ(0))))
+        status = status.trigger_status
+        detail = status.detail_doc
+        if isinstance(detail, list):
+            if not detail:
+                self.logger.error(
+                    "No trigger_status, so baked image is unknown\n" "%s\n\n", status
+                )
+                return
+            self.logger.info("Using first status.")
+            detail = detail[0]
+        stages = detail.get("stages", [])
+        image_id = stages[0].get("context", {}).get("imageId") if stages else None
+        self.logger.info('Capturing the baked image="%s" to delete', image_id)
+        self.__image_id_to_delete = image_id
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='run_destroy_pipeline',
-            data='',
-            path=path,
-            max_wait_secs=1080), # Allow 18 mins to disable and destroy.
-        contract=jc.Contract(),
-        cleanup=self.delete_baked_image)
+    def delete_baked_image(self, _unused_execution_context):
+        """Deletes the baked image when we are done using it."""
+        if self.__image_id_to_delete:
+            execution_context = citest.base.ExecutionContext()
+            self.gcp_observer.invoke_resource(
+                execution_context,
+                "delete",
+                "images",
+                resource_id=self.__image_id_to_delete,
+            )
 
-  def new_jenkins_build_operation(self):
-    return None
-
-  def capture_baked_image(self, execution_context):
-    """Saves the baked image name from the triggered Bake & Deploy pipeline to delete later."""
-    status = execution_context.get('OperationStatus', None)
-    if status is None:
-      self.logger.info(
-          'Operation could not be performed so there is no image to delete.')
-      return
-
-    status = status.trigger_status
-    detail = status.detail_doc
-    if isinstance(detail, list):
-      if not detail:
-        self.logger.error('No trigger_status, so baked image is unknown\n'
-                          '%s\n\n', status)
-        return
-      self.logger.info('Using first status.')
-      detail = detail[0]
-    stages = detail.get('stages', [])
-    image_id = (stages[0].get('context', {}).get('imageId')
-                if stages
-                else None)
-    self.logger.info('Capturing the baked image="%s" to delete', image_id)
-    self.__image_id_to_delete = image_id
-
-  def delete_baked_image(self, _unused_execution_context):
-    """Deletes the baked image when we are done using it."""
-    if self.__image_id_to_delete:
-      execution_context = citest.base.ExecutionContext()
-      self.gcp_observer.invoke_resource(
-          execution_context, 'delete', 'images', resource_id=self.__image_id_to_delete)
 
 class BakeAndDeployTest(st.AgentTestCase):
-  @staticmethod
-  def setUpClass():
-    runner = citest.base.TestRunner.global_runner()
-    scenario = runner.get_shared_data(BakeAndDeployTestScenario)
-    if not scenario.test_google:
-      return
+    @staticmethod
+    def setUpClass():
+        runner = citest.base.TestRunner.global_runner()
+        scenario = runner.get_shared_data(BakeAndDeployTestScenario)
+        if not scenario.test_google:
+            return
 
-    managed_region = scenario.bindings['TEST_GCE_REGION']
-    title = 'Check Quota for {0}'.format(scenario.__class__.__name__)
+        managed_region = scenario.bindings["TEST_GCE_REGION"]
+        title = "Check Quota for {0}".format(scenario.__class__.__name__)
 
-    verify_results = gcp.verify_quota(
-        title,
-        scenario.gcp_observer,
-        project_quota=BakeAndDeployTestScenario.MINIMUM_PROJECT_QUOTA,
-        regions=[(managed_region,
-                  BakeAndDeployTestScenario.MINIMUM_REGION_QUOTA)])
-    if not verify_results:
-      raise RuntimeError('Insufficient Quota: {0}'.format(verify_results))
+        verify_results = gcp.verify_quota(
+            title,
+            scenario.gcp_observer,
+            project_quota=BakeAndDeployTestScenario.MINIMUM_PROJECT_QUOTA,
+            regions=[(managed_region, BakeAndDeployTestScenario.MINIMUM_REGION_QUOTA)],
+        )
+        if not verify_results:
+            raise RuntimeError("Insufficient Quota: {0}".format(verify_results))
 
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-        BakeAndDeployTestScenario)
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            BakeAndDeployTestScenario
+        )
 
-  @property
-  def testing_agent(self):
-    return self.scenario.agent
+    @property
+    def testing_agent(self):
+        return self.scenario.agent
 
-  def test_a_create_app(self):
-    if not self.scenario.run_tests:
-      self.skipTest("No --test_{google, aws} flags were set")
-    else:
-      self.run_test_case(self.scenario.create_app())
+    def test_a_create_app(self):
+        if not self.scenario.run_tests:
+            self.skipTest("No --test_{google, aws} flags were set")
+        else:
+            self.run_test_case(self.scenario.create_app())
 
-  def test_b_create_load_balancer(self):
-    if not self.scenario.run_tests:
-      self.skipTest("No --test_{google, aws} flags were set")
-    else:
-      self.run_test_case(self.scenario.create_load_balancer())
+    def test_b_create_load_balancer(self):
+        if not self.scenario.run_tests:
+            self.skipTest("No --test_{google, aws} flags were set")
+        else:
+            self.run_test_case(self.scenario.create_load_balancer())
 
-  def test_c1_create_bake_and_deploy_google_pipeline(self):
-    if not self.scenario.test_google:
-      self.skipTest("--test_google flag not set")
-    else:
-      self.run_test_case(self.scenario.create_bake_and_deploy_google_pipeline())
+    def test_c1_create_bake_and_deploy_google_pipeline(self):
+        if not self.scenario.test_google:
+            self.skipTest("--test_google flag not set")
+        else:
+            self.run_test_case(self.scenario.create_bake_and_deploy_google_pipeline())
 
-  def test_d1_create_disable_and_destroy_google_pipeline(self):
-    if not self.scenario.test_google:
-      self.skipTest("--test_google flag not set")
-    else:
-      self.run_test_case(
-          self.scenario.create_disable_and_destroy_google_pipeline())
+    def test_d1_create_disable_and_destroy_google_pipeline(self):
+        if not self.scenario.test_google:
+            self.skipTest("--test_google flag not set")
+        else:
+            self.run_test_case(
+                self.scenario.create_disable_and_destroy_google_pipeline()
+            )
 
-  def test_c2_create_bake_and_deploy_aws_pipeline(self):
-    if not self.scenario.test_aws:
-      self.skipTest("--test_aws flag not set")
-    else:
-      self.run_test_case(self.scenario.create_bake_and_deploy_aws_pipeline())
+    def test_c2_create_bake_and_deploy_aws_pipeline(self):
+        if not self.scenario.test_aws:
+            self.skipTest("--test_aws flag not set")
+        else:
+            self.run_test_case(self.scenario.create_bake_and_deploy_aws_pipeline())
 
-  def test_d2_create_disable_and_destroy_aws_pipeline(self):
-    if not self.scenario.test_aws:
-      self.skipTest("--test_aws flag not set")
-    else:
-      self.run_test_case(
-          self.scenario.create_disable_and_destroy_aws_pipeline())
+    def test_d2_create_disable_and_destroy_aws_pipeline(self):
+        if not self.scenario.test_aws:
+            self.skipTest("--test_aws flag not set")
+        else:
+            self.run_test_case(self.scenario.create_disable_and_destroy_aws_pipeline())
 
-  def test_e1_trigger_bake_and_deploy_google_pipeline(self):
-    if not self.scenario.test_google:
-      self.skipTest("--test_google flag not set")
-    else:
-      # Wait for Echo's cache to pick up the pipeline.
-      time.sleep(20)
-      self.run_test_case(
-          self.scenario.trigger_bake_and_deploy_google_pipeline(),
-          poll_every_secs=5)
+    def test_e1_trigger_bake_and_deploy_google_pipeline(self):
+        if not self.scenario.test_google:
+            self.skipTest("--test_google flag not set")
+        else:
+            # Wait for Echo's cache to pick up the pipeline.
+            time.sleep(20)
+            self.run_test_case(
+                self.scenario.trigger_bake_and_deploy_google_pipeline(),
+                poll_every_secs=5,
+            )
 
-  def test_w1_run_disable_and_destroy_google_pipeline(self):
-    if not self.scenario.test_google:
-      self.skipTest("--test_google flag not set")
-    else:
-      self.run_test_case(
-          self.scenario.run_disable_and_destroy_google_pipeline(
-              self.scenario.google_destroy_pipeline_id),
-          poll_every_secs=5)
+    def test_w1_run_disable_and_destroy_google_pipeline(self):
+        if not self.scenario.test_google:
+            self.skipTest("--test_google flag not set")
+        else:
+            self.run_test_case(
+                self.scenario.run_disable_and_destroy_google_pipeline(
+                    self.scenario.google_destroy_pipeline_id
+                ),
+                poll_every_secs=5,
+            )
 
-  def test_x1_delete_google_bake_pipeline(self):
-    if not self.scenario.test_google:
-      self.skipTest("--test_google flag not set")
-    else:
-      self.run_test_case(
-        self.scenario.delete_pipeline(self.scenario.google_bake_pipeline_id))
+    def test_x1_delete_google_bake_pipeline(self):
+        if not self.scenario.test_google:
+            self.skipTest("--test_google flag not set")
+        else:
+            self.run_test_case(
+                self.scenario.delete_pipeline(self.scenario.google_bake_pipeline_id)
+            )
 
-  def test_x1_delete_google_destroy_pipeline(self):
-    if not self.scenario.test_google:
-      self.skipTest("--test_google flag not set")
-    else:
-      self.run_test_case(
-        self.scenario.delete_pipeline(self.scenario.google_destroy_pipeline_id))
+    def test_x1_delete_google_destroy_pipeline(self):
+        if not self.scenario.test_google:
+            self.skipTest("--test_google flag not set")
+        else:
+            self.run_test_case(
+                self.scenario.delete_pipeline(self.scenario.google_destroy_pipeline_id)
+            )
 
-  def test_x2_delete_aws_pipeline(self):
-    if not self.scenario.test_aws:
-      self.skipTest("--test_aws flag not set")
-    else:
-      self.run_test_case(
-        self.scenario.delete_pipeline(self.scenario.aws_pipeline_id))
+    def test_x2_delete_aws_pipeline(self):
+        if not self.scenario.test_aws:
+            self.skipTest("--test_aws flag not set")
+        else:
+            self.run_test_case(
+                self.scenario.delete_pipeline(self.scenario.aws_pipeline_id)
+            )
 
-  def test_y_delete_load_balancer(self):
-    if not self.scenario.run_tests:
-      self.skipTest("No --test_{google, aws} flags were set")
-    else:
-      self.run_test_case(self.scenario.delete_load_balancer(),
-                       max_retries=5)
+    def test_y_delete_load_balancer(self):
+        if not self.scenario.run_tests:
+            self.skipTest("No --test_{google, aws} flags were set")
+        else:
+            self.run_test_case(self.scenario.delete_load_balancer(), max_retries=5)
 
-  def test_z_delete_app(self):
-    if not self.scenario.run_tests:
-      self.skipTest("No --test_{google, aws} flags were set")
-    # Give a total of a minute because it might also need
-    # an internal cache update
-    else:
-      self.run_test_case(self.scenario.delete_app(),
-                       retry_interval_secs=8, max_retries=8)
+    def test_z_delete_app(self):
+        if not self.scenario.run_tests:
+            self.skipTest("No --test_{google, aws} flags were set")
+        # Give a total of a minute because it might also need
+        # an internal cache update
+        else:
+            self.run_test_case(
+                self.scenario.delete_app(), retry_interval_secs=8, max_retries=8
+            )
 
 
 def main():
-  defaults = {
-    'TEST_STACK': 'baketest' + BakeAndDeployTestScenario.DEFAULT_TEST_ID,
-    'TEST_APP': 'baketest' + BakeAndDeployTestScenario.DEFAULT_TEST_ID
-  }
+    defaults = {
+        "TEST_STACK": "baketest" + BakeAndDeployTestScenario.DEFAULT_TEST_ID,
+        "TEST_APP": "baketest" + BakeAndDeployTestScenario.DEFAULT_TEST_ID,
+    }
 
-  return citest.base.TestRunner.main(
-      parser_inits=[BakeAndDeployTestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[BakeAndDeployTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[BakeAndDeployTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[BakeAndDeployTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/dcos_smoke_test.py
+++ b/testing/citest/tests/dcos_smoke_test.py
@@ -47,7 +47,7 @@ import citest.base
 
 class DcosSmokeTestScenario(sk.SpinnakerTestScenario):
     """Defines the scenario for the smoke test.
-  
+
     This scenario defines the different test operations.
     We're going to:
       Create a Spinnaker Application
@@ -67,7 +67,7 @@ class DcosSmokeTestScenario(sk.SpinnakerTestScenario):
 
     def __init__(self, bindings, agent=None):
         """Constructor.
-    
+
         Args:
           bindings: [dict] The data bindings to use to configure the scenario.
           agent: [GateAgent] The agent for invoking the test operations on Gate.
@@ -78,24 +78,27 @@ class DcosSmokeTestScenario(sk.SpinnakerTestScenario):
         self.pipeline_id = None
 
         # No detail because name length is restricted too much to afford one!
-        self.__lb_detail = ''
+        self.__lb_detail = ""
         self.__lb_name = frigga.Naming.cluster(
-            app=bindings['TEST_APP'],
-            stack=bindings['TEST_STACK'])
+            app=bindings["TEST_APP"], stack=bindings["TEST_STACK"]
+        )
 
         # We'll call out the app name because it is widely used
         # because it scopes the context of our activities.
         # pylint: disable=invalid-name
-        self.TEST_APP = bindings['TEST_APP']
+        self.TEST_APP = bindings["TEST_APP"]
 
     def create_app(self):
         """Creates OperationContract that creates a new Spinnaker Application."""
         contract = jc.Contract()
         return st.OperationContract(
             self.agent.make_create_app_operation(
-                bindings=self.bindings, application=self.TEST_APP,
-                account_name=self.bindings['SPINNAKER_DCOS_ACCOUNT']),
-            contract=contract)
+                bindings=self.bindings,
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_DCOS_ACCOUNT"],
+            ),
+            contract=contract,
+        )
 
     def delete_app(self):
         """Creates OperationContract that deletes a new Spinnaker Application."""
@@ -103,12 +106,14 @@ class DcosSmokeTestScenario(sk.SpinnakerTestScenario):
         return st.OperationContract(
             self.agent.make_delete_app_operation(
                 application=self.TEST_APP,
-                account_name=self.bindings['SPINNAKER_DCOS_ACCOUNT']),
-            contract=contract)
+                account_name=self.bindings["SPINNAKER_DCOS_ACCOUNT"],
+            ),
+            contract=contract,
+        )
 
     def create_server_group(self):
         """Creates OperationContract for createServerGroup.
-    
+
         To verify the operation, we just check that the server group was created.
         """
         bindings = self.bindings
@@ -116,120 +121,136 @@ class DcosSmokeTestScenario(sk.SpinnakerTestScenario):
         # Spinnaker determines the group name created,
         # which will be the following:
         group_name = frigga.Naming.server_group(
-            app=self.TEST_APP,
-            stack=bindings['TEST_STACK'],
-            version='v000')
+            app=self.TEST_APP, stack=bindings["TEST_STACK"], version="v000"
+        )
 
         payload = self.agent.make_json_payload_from_kwargs(
-            job=[{
-                'cloudProvider': 'dcos',
-                'application': self.TEST_APP,
-                'account': bindings['SPINNAKER_DCOS_ACCOUNT'],
-                'env': {},
-                'desiredCapacity': 1,
-                'cpus': 0.1,
-                'mem': 64,
-                'docker': {
-                    'image': {
-                        'repository': 'nginx',
-                        'tag': 'canary',
-                        'imageId': 'nginx',
-                        'registry': 'docker.io',
-                        'account': bindings['SPINNAKER_DOCKER_ACCOUNT']
-                    }
-                },
-                'networkType': 'BRIDGE',
-                'stack': bindings['TEST_STACK'],
-                'type': 'createServerGroup',
-                'region': bindings['SPINNAKER_DCOS_CLUSTER'],
-                'dcosCluster': bindings['SPINNAKER_DCOS_CLUSTER'],
-                'user': '[anonymous]'
-            }],
-            description='Create Server Group in ' + group_name,
-            application=self.TEST_APP)
+            job=[
+                {
+                    "cloudProvider": "dcos",
+                    "application": self.TEST_APP,
+                    "account": bindings["SPINNAKER_DCOS_ACCOUNT"],
+                    "env": {},
+                    "desiredCapacity": 1,
+                    "cpus": 0.1,
+                    "mem": 64,
+                    "docker": {
+                        "image": {
+                            "repository": "nginx",
+                            "tag": "canary",
+                            "imageId": "nginx",
+                            "registry": "docker.io",
+                            "account": bindings["SPINNAKER_DOCKER_ACCOUNT"],
+                        }
+                    },
+                    "networkType": "BRIDGE",
+                    "stack": bindings["TEST_STACK"],
+                    "type": "createServerGroup",
+                    "region": bindings["SPINNAKER_DCOS_CLUSTER"],
+                    "dcosCluster": bindings["SPINNAKER_DCOS_CLUSTER"],
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Create Server Group in " + group_name,
+            application=self.TEST_APP,
+        )
 
         builder = dcos.DcosContractBuilder(self.dcos_observer)
-        (builder.new_clause_builder('Marathon App Added', retryable_for_secs=240)
-         .get_marathon_resources('app'.format(bindings['SPINNAKER_DCOS_ACCOUNT']))
-         .contains_path_value('id',
-                              '/{0}/{1}'.format(bindings['SPINNAKER_DCOS_ACCOUNT'], group_name)))
+        (
+            builder.new_clause_builder("Marathon App Added", retryable_for_secs=240)
+            .get_marathon_resources("app".format(bindings["SPINNAKER_DCOS_ACCOUNT"]))
+            .contains_path_value(
+                "id", "/{0}/{1}".format(bindings["SPINNAKER_DCOS_ACCOUNT"], group_name)
+            )
+        )
 
         return st.OperationContract(
             self.new_post_operation(
-                title='create_server_group', data=payload, path='tasks'),
-            contract=builder.build())
+                title="create_server_group", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
-    def delete_server_group(self, version='v000'):
+    def delete_server_group(self, version="v000"):
         """Creates OperationContract for deleteServerGroup.
-    
+
         To verify the operation, we just check that the DC/OS application
         is no longer visible (or is in the process of terminating).
         """
         bindings = self.bindings
         group_name = frigga.Naming.server_group(
-            app=self.TEST_APP, stack=bindings['TEST_STACK'], version=version)
+            app=self.TEST_APP, stack=bindings["TEST_STACK"], version=version
+        )
 
         payload = self.agent.make_json_payload_from_kwargs(
-            job=[{
-                'cloudProvider': 'dcos',
-                'type': 'destroyServerGroup',
-                'account': bindings['SPINNAKER_DCOS_ACCOUNT'],
-                'credentials': bindings['SPINNAKER_DCOS_ACCOUNT'],
-                'user': '[anonymous]',
-                'serverGroupName': group_name,
-                'asgName': group_name,
-                'regions': [bindings['SPINNAKER_DCOS_CLUSTER']],
-                'region': bindings['SPINNAKER_DCOS_CLUSTER'],
-                'dcosCluster': bindings['SPINNAKER_DCOS_CLUSTER'],
-                'zones': [bindings['SPINNAKER_DCOS_CLUSTER']]
-            }],
+            job=[
+                {
+                    "cloudProvider": "dcos",
+                    "type": "destroyServerGroup",
+                    "account": bindings["SPINNAKER_DCOS_ACCOUNT"],
+                    "credentials": bindings["SPINNAKER_DCOS_ACCOUNT"],
+                    "user": "[anonymous]",
+                    "serverGroupName": group_name,
+                    "asgName": group_name,
+                    "regions": [bindings["SPINNAKER_DCOS_CLUSTER"]],
+                    "region": bindings["SPINNAKER_DCOS_CLUSTER"],
+                    "dcosCluster": bindings["SPINNAKER_DCOS_CLUSTER"],
+                    "zones": [bindings["SPINNAKER_DCOS_CLUSTER"]],
+                }
+            ],
             application=self.TEST_APP,
-            description='Destroy Server Group: ' + group_name)
+            description="Destroy Server Group: " + group_name,
+        )
 
         builder = dcos.DcosContractBuilder(self.dcos_observer)
-        (builder.new_clause_builder('Marathon App Deleted', retryable_for_secs=240)
-         .get_marathon_resources('app'.format(bindings['SPINNAKER_DCOS_ACCOUNT']))
-         .excludes_path_value('id',
-                              '/{0}/{1}'.format(bindings['SPINNAKER_DCOS_ACCOUNT'], group_name)))
+        (
+            builder.new_clause_builder("Marathon App Deleted", retryable_for_secs=240)
+            .get_marathon_resources("app".format(bindings["SPINNAKER_DCOS_ACCOUNT"]))
+            .excludes_path_value(
+                "id", "/{0}/{1}".format(bindings["SPINNAKER_DCOS_ACCOUNT"], group_name)
+            )
+        )
 
         contract = jc.Contract()
         return st.OperationContract(
             self.new_post_operation(
-                title='delete_server_group', data=payload, path='tasks'),
-            contract=contract)
+                title="delete_server_group", data=payload, path="tasks"
+            ),
+            contract=contract,
+        )
 
     def make_deploy_stage(self, requisiteStages=[], **kwargs):
         bindings = self.bindings
         result = {
-            'requisiteStageRefIds': requisiteStages,
-            'refId': 'DEPLOY',
-            'type': 'deploy',
-            'name': 'Deploy server group',
-            'clusters': [
+            "requisiteStageRefIds": requisiteStages,
+            "refId": "DEPLOY",
+            "type": "deploy",
+            "name": "Deploy server group",
+            "clusters": [
                 {
-                    'cloudProvider': 'dcos',
-                    'application': self.TEST_APP,
-                    'account': bindings['SPINNAKER_DCOS_ACCOUNT'],
-                    'env': {},
-                    'desiredCapacity': 1,
-                    'cpus': 0.1,
-                    'mem': 64,
-                    'docker': {
-                        'image': {
-                            'repository': 'nginx',
-                            'tag': 'canary',
-                            'imageId': 'nginx',
-                            'registry': 'docker.io',
-                            'account': bindings['SPINNAKER_DOCKER_ACCOUNT']
+                    "cloudProvider": "dcos",
+                    "application": self.TEST_APP,
+                    "account": bindings["SPINNAKER_DCOS_ACCOUNT"],
+                    "env": {},
+                    "desiredCapacity": 1,
+                    "cpus": 0.1,
+                    "mem": 64,
+                    "docker": {
+                        "image": {
+                            "repository": "nginx",
+                            "tag": "canary",
+                            "imageId": "nginx",
+                            "registry": "docker.io",
+                            "account": bindings["SPINNAKER_DOCKER_ACCOUNT"],
                         }
                     },
-                    'networkType': 'BRIDGE',
-                    'stack': bindings['TEST_STACK'],
-                    'region': bindings['SPINNAKER_DCOS_CLUSTER'],
-                    'dcosCluster': bindings['SPINNAKER_DCOS_CLUSTER'],
-                    'user': '[anonymous]'
+                    "networkType": "BRIDGE",
+                    "stack": bindings["TEST_STACK"],
+                    "region": bindings["SPINNAKER_DCOS_CLUSTER"],
+                    "dcosCluster": bindings["SPINNAKER_DCOS_CLUSTER"],
+                    "user": "[anonymous]",
                 }
-            ]
+            ],
         }
 
         result.update(kwargs)
@@ -239,38 +260,36 @@ class DcosSmokeTestScenario(sk.SpinnakerTestScenario):
         bindings = self.bindings
 
         result = {
-            'action': 'scale_exact',
-            'capacity': {
-                'desired': 3
-            },
-            'cloudProvider': 'dcos',
-            'cloudProviderType': 'dcos',
-            'cluster': cluster,
-            'credentials': bindings['SPINNAKER_DCOS_ACCOUNT'],
-            'name': 'Resize Server Group',
-            'refId': 'RESIZE',
-            'regions': [
-                bindings['SPINNAKER_DCOS_CLUSTER']
-            ],
-            'requisiteStageRefIds': requisiteStages,
-            'resizeType': 'exact',
-            'target': 'current_asg_dynamic',
-            'type': 'resizeServerGroup'
+            "action": "scale_exact",
+            "capacity": {"desired": 3},
+            "cloudProvider": "dcos",
+            "cloudProviderType": "dcos",
+            "cluster": cluster,
+            "credentials": bindings["SPINNAKER_DCOS_ACCOUNT"],
+            "name": "Resize Server Group",
+            "refId": "RESIZE",
+            "regions": [bindings["SPINNAKER_DCOS_CLUSTER"]],
+            "requisiteStageRefIds": requisiteStages,
+            "resizeType": "exact",
+            "target": "current_asg_dynamic",
+            "type": "resizeServerGroup",
         }
 
         result.update(kwargs)
         return result
 
     def create_deploy_pipeline(self):
-        name = 'deployServerPipeline'
+        name = "deployServerPipeline"
 
         cluster = frigga.Naming.cluster(
-            app=self.TEST_APP,
-            stack=self.bindings['TEST_STACK'])
+            app=self.TEST_APP, stack=self.bindings["TEST_STACK"]
+        )
 
         self.pipeline_id = name
         deploy_stage = self.make_deploy_stage(requisiteStages=[])
-        resize_stage = self.make_resize_stage(requisiteStages=['DEPLOY'], cluster=cluster)
+        resize_stage = self.make_resize_stage(
+            requisiteStages=["DEPLOY"], cluster=cluster
+        )
 
         pipeline_spec = dict(
             name=name,
@@ -280,57 +299,73 @@ class DcosSmokeTestScenario(sk.SpinnakerTestScenario):
             stageCounter=2,
             parallel=True,
             limitConcurrent=True,
-            executionEngine='v2',
+            executionEngine="v2",
             appConfig={},
-            index=0
+            index=0,
         )
 
         payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
 
         builder = st.HttpContractBuilder(self.agent)
-        (builder.new_clause_builder('Has Pipeline',
-                                    retryable_for_secs=15)
-         .get_url_path(
-            'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
-         .contains_path_value(None, pipeline_spec))
+        (
+            builder.new_clause_builder("Has Pipeline", retryable_for_secs=15)
+            .get_url_path(
+                "applications/{app}/pipelineConfigs".format(app=self.TEST_APP)
+            )
+            .contains_path_value(None, pipeline_spec)
+        )
 
         return st.OperationContract(
             self.new_post_operation(
-                title='create_deploy_pipeline', data=payload, path='pipelines',
-                status_class=st.SynchronousHttpOperationStatus),
-            contract=builder.build())
+                title="create_deploy_pipeline",
+                data=payload,
+                path="pipelines",
+                status_class=st.SynchronousHttpOperationStatus,
+            ),
+            contract=builder.build(),
+        )
 
     def run_deploy_pipeline(self):
-        path = 'pipelines/{0}/{1}'.format(self.TEST_APP, self.pipeline_id)
+        path = "pipelines/{0}/{1}".format(self.TEST_APP, self.pipeline_id)
         bindings = self.bindings
         group_name = frigga.Naming.server_group(
-            app=self.TEST_APP,
-            stack=bindings['TEST_STACK'],
-            version='v001')
+            app=self.TEST_APP, stack=bindings["TEST_STACK"], version="v001"
+        )
 
         payload = self.agent.make_json_payload_from_kwargs(
-            type='manual',
-            user='[anonymous]')
+            type="manual", user="[anonymous]"
+        )
 
         builder = dcos.DcosContractBuilder(self.dcos_observer)
-        (builder.new_clause_builder('Marathon App deployed via pipeline', retryable_for_secs=240)
-         .get_marathon_resources('app'.format(bindings['SPINNAKER_DCOS_ACCOUNT']))
-         .contains_path_value('id',
-                              '/{0}/{1}'.format(bindings['SPINNAKER_DCOS_ACCOUNT'], group_name)))
+        (
+            builder.new_clause_builder(
+                "Marathon App deployed via pipeline", retryable_for_secs=240
+            )
+            .get_marathon_resources("app".format(bindings["SPINNAKER_DCOS_ACCOUNT"]))
+            .contains_path_value(
+                "id", "/{0}/{1}".format(bindings["SPINNAKER_DCOS_ACCOUNT"], group_name)
+            )
+        )
 
-        (builder.new_clause_builder('Marathon App has expected # instances', retryable_for_secs=240)
-         .get_marathon_resources('app'.format(bindings['SPINNAKER_DCOS_ACCOUNT']))
-         .contains_path_eq('instances', 3))
+        (
+            builder.new_clause_builder(
+                "Marathon App has expected # instances", retryable_for_secs=240
+            )
+            .get_marathon_resources("app".format(bindings["SPINNAKER_DCOS_ACCOUNT"]))
+            .contains_path_eq("instances", 3)
+        )
 
         return st.OperationContract(
             self.new_post_operation(
-                title='run_deploy_pipeline', data=payload, path=path),
-            builder.build())
+                title="run_deploy_pipeline", data=payload, path=path
+            ),
+            builder.build(),
+        )
 
 
 class DcosSmokeTest(st.AgentTestCase):
     """The test fixture for the DcosSmokeTest.
-  
+
     This is implemented using citest OperationContract instances that are
     created by the DcosSmokeTestScenario.
     """
@@ -340,15 +375,16 @@ class DcosSmokeTest(st.AgentTestCase):
     @property
     def scenario(self):
         return citest.base.TestRunner.global_runner().get_shared_data(
-            DcosSmokeTestScenario)
+            DcosSmokeTestScenario
+        )
 
     def test_a_create_app(self):
         self.run_test_case(self.scenario.create_app())
 
     def test_b_create_server_group(self):
-        self.run_test_case(self.scenario.create_server_group(),
-                           max_retries=1,
-                           timeout_ok=True)
+        self.run_test_case(
+            self.scenario.create_server_group(), max_retries=1, timeout_ok=True
+        )
 
     def test_c_create_deploy_pipeline(self):
         self.run_test_case(self.scenario.create_deploy_pipeline())
@@ -357,31 +393,33 @@ class DcosSmokeTest(st.AgentTestCase):
         self.run_test_case(self.scenario.run_deploy_pipeline())
 
     def test_x_delete_server_group(self):
-        self.run_test_case(self.scenario.delete_server_group('v000'), max_retries=2)
+        self.run_test_case(self.scenario.delete_server_group("v000"), max_retries=2)
 
     def test_x2_delete_server_group(self):
-        self.run_test_case(self.scenario.delete_server_group('v001'), max_retries=2)
+        self.run_test_case(self.scenario.delete_server_group("v001"), max_retries=2)
 
     def test_z_delete_app(self):
         # Give a total of a minute because it might also need
         # an internal cache update
-        self.run_test_case(self.scenario.delete_app(),
-                           retry_interval_secs=8, max_retries=8)
+        self.run_test_case(
+            self.scenario.delete_app(), retry_interval_secs=8, max_retries=8
+        )
 
 
 def main():
     """Implements the main method running this smoke test."""
 
     defaults = {
-        'TEST_STACK': 'tst',
-        'TEST_APP': 'dcossmok' + DcosSmokeTestScenario.DEFAULT_TEST_ID
+        "TEST_STACK": "tst",
+        "TEST_APP": "dcossmok" + DcosSmokeTestScenario.DEFAULT_TEST_ID,
     }
 
     return citest.base.TestRunner.main(
         parser_inits=[DcosSmokeTestScenario.initArgumentParser],
         default_binding_overrides=defaults,
-        test_case_list=[DcosSmokeTest])
+        test_case_list=[DcosSmokeTest],
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/testing/citest/tests/gcs_front50_test.py
+++ b/testing/citest/tests/gcs_front50_test.py
@@ -20,10 +20,10 @@ import logging
 import sys
 
 if sys.version_info[0] > 2:
-  basestring = str
-  from urllib.parse import quote as UrlQuote
+    basestring = str
+    from urllib.parse import quote as UrlQuote
 else:
-  from urllib import quote as UrlQuote
+    from urllib import quote as UrlQuote
 
 from citest.base import ExecutionContext
 
@@ -32,6 +32,7 @@ import citest.gcp_testing as gcp
 import citest.json_contract as jc
 import citest.json_predicate as jp
 import citest.service_testing as st
+
 ov_factory = jc.ObservationPredicateFactory()
 
 # Spinnaker modules.
@@ -40,405 +41,537 @@ import spinnaker_testing.front50 as front50
 
 
 class GcsFront50TestScenario(sk.SpinnakerTestScenario):
-  @classmethod
-  def new_agent(cls, bindings):
-    """Implements citest.service_testing.AgentTestScenario.new_agent."""
-    return front50.new_agent(bindings)
+    @classmethod
+    def new_agent(cls, bindings):
+        """Implements citest.service_testing.AgentTestScenario.new_agent."""
+        return front50.new_agent(bindings)
 
-  @classmethod
-  def initArgumentParser(cls, parser, defaults=None):
-    """Initialize command line argument parser.
+    @classmethod
+    def initArgumentParser(cls, parser, defaults=None):
+        """Initialize command line argument parser.
 
-    Args:
-      parser: argparse.ArgumentParser
-    """
-    parser.add_argument(
-        '--gcs_json_path', default='',
-        help='The path to the Google Cloud Storage service credentials JSON file.')
-    parser.add_argument(
-        '--gcs_bucket', default='',
-        help="The name of the Google Cloud Storage bucket to use, e.g. 'spinnaker-bucket'.")
-    parser.add_argument(
-        '--gcs_base_path', default='',
-        help="The root folder in the specified Google Cloud Storage bucket to place all of Spinnaker's persistent data.")
-
-    super(GcsFront50TestScenario, cls).initArgumentParser(
-        parser, defaults=defaults)
-
-  def _do_init_bindings(self):
-    """Hook to initialize custom test bindings so journaling is scoped."""
-    context = ExecutionContext()
-    config = self.agent.deployed_config
-    # If we're running this test and dont have a config, assume it is favorable.
-    enabled = config.get('spinnaker.gcs.enabled', True)
-    if enabled == False:
-      raise ValueError('spinnaker.gcs.enabled is not True')
-    if not self.bindings['GCS_BUCKET'] and not config['spinnaker.gcs.bucket']:
-      raise ValueError('The GCS bucket name is not specified')
-    if not self.bindings['GCS_BASE_PATH'] and not config['spinnaker.gcs.rootFolder']:
-      raise ValueError('The GCS rootFolder is not specified')
-
-    self.BUCKET = self.bindings['GCS_BUCKET'] or config['spinnaker.gcs.bucket']
-    self.BASE_PATH = self.bindings['GCS_BASE_PATH'] or config['spinnaker.gcs.rootFolder']
-    self.TEST_APP = self.bindings['TEST_APP']
-    self.TEST_PIPELINE_NAME = 'My {app} Pipeline'.format(app=self.TEST_APP)
-    self.TEST_PIPELINE_ID = '{app}-pipeline-id'.format(app=self.TEST_APP)
-    self.gcs_observer = gcp.GcpStorageAgent.make_agent(
-        credentials_path=self.bindings['GCS_JSON_PATH'],
-        scopes=gcp.gcp_storage_agent.STORAGE_FULL_SCOPE
+        Args:
+          parser: argparse.ArgumentParser
+        """
+        parser.add_argument(
+            "--gcs_json_path",
+            default="",
+            help="The path to the Google Cloud Storage service credentials JSON file.",
+        )
+        parser.add_argument(
+            "--gcs_bucket",
+            default="",
+            help="The name of the Google Cloud Storage bucket to use, e.g. 'spinnaker-bucket'.",
+        )
+        parser.add_argument(
+            "--gcs_base_path",
+            default="",
+            help="The root folder in the specified Google Cloud Storage bucket to place all of Spinnaker's persistent data.",
         )
 
-    metadata = self.gcs_observer.inspect_bucket(context, self.BUCKET)
-    self.versioning_enabled = (metadata.get('versioning', {})
-                               .get('enabled', False))
-    if not self.versioning_enabled:
-      self.logger.info('bucket=%s versioning enabled=%s',
-                       self.BUCKET, self.versioning_enabled)
+        super(GcsFront50TestScenario, cls).initArgumentParser(parser, defaults=defaults)
 
-  def __init__(self, bindings, agent=None):
-    """Constructor.
+    def _do_init_bindings(self):
+        """Hook to initialize custom test bindings so journaling is scoped."""
+        context = ExecutionContext()
+        config = self.agent.deployed_config
+        # If we're running this test and dont have a config, assume it is favorable.
+        enabled = config.get("spinnaker.gcs.enabled", True)
+        if enabled == False:
+            raise ValueError("spinnaker.gcs.enabled is not True")
+        if not self.bindings["GCS_BUCKET"] and not config["spinnaker.gcs.bucket"]:
+            raise ValueError("The GCS bucket name is not specified")
+        if (
+            not self.bindings["GCS_BASE_PATH"]
+            and not config["spinnaker.gcs.rootFolder"]
+        ):
+            raise ValueError("The GCS rootFolder is not specified")
 
-    Args:
-      bindings: [dict] The data bindings to use to configure the scenario.
-      agent: [Front50Agent] The agent for invoking the test operations on
-          Front50
-    """
-    self.logger = logging.getLogger(__name__)
-    super(GcsFront50TestScenario, self).__init__(bindings, agent)
-    self.app_history = []
-    self.pipeline_history = []
+        self.BUCKET = self.bindings["GCS_BUCKET"] or config["spinnaker.gcs.bucket"]
+        self.BASE_PATH = (
+            self.bindings["GCS_BASE_PATH"] or config["spinnaker.gcs.rootFolder"]
+        )
+        self.TEST_APP = self.bindings["TEST_APP"]
+        self.TEST_PIPELINE_NAME = "My {app} Pipeline".format(app=self.TEST_APP)
+        self.TEST_PIPELINE_ID = "{app}-pipeline-id".format(app=self.TEST_APP)
+        self.gcs_observer = gcp.GcpStorageAgent.make_agent(
+            credentials_path=self.bindings["GCS_JSON_PATH"],
+            scopes=gcp.gcp_storage_agent.STORAGE_FULL_SCOPE,
+        )
 
-    self.initial_app_spec = {
-        "name" : self.TEST_APP,
-        "description" : "My Application Description.",
-        "email" : "test@google.com",
-        "accounts" : "my-aws-account,my-google-account",
-        "updateTs" : "1463667655844",
-        "createTs" : "1463666817476",
-        "platformHealthOnly" : False,
-        "cloudProviders" : "gce,aws"
-    }
+        metadata = self.gcs_observer.inspect_bucket(context, self.BUCKET)
+        self.versioning_enabled = metadata.get("versioning", {}).get("enabled", False)
+        if not self.versioning_enabled:
+            self.logger.info(
+                "bucket=%s versioning enabled=%s", self.BUCKET, self.versioning_enabled
+            )
 
-    self.initial_pipeline_spec = {
-        "keepWaitingPipelines": False,
-        "limitConcurrent": True,
-        "application": self.TEST_APP,
-        "parallel": True,
-        "lastModifiedBy": "anonymous",
-        "name": self.TEST_PIPELINE_NAME,
-        "stages": [],
-        "index": 0,
-        "id": self.TEST_PIPELINE_ID,
-        "triggers": []
-    }
+    def __init__(self, bindings, agent=None):
+        """Constructor.
 
+        Args:
+          bindings: [dict] The data bindings to use to configure the scenario.
+          agent: [Front50Agent] The agent for invoking the test operations on
+              Front50
+        """
+        self.logger = logging.getLogger(__name__)
+        super(GcsFront50TestScenario, self).__init__(bindings, agent)
+        self.app_history = []
+        self.pipeline_history = []
 
-  def create_app(self):
-    payload = self.agent.make_json_payload_from_object(self.initial_app_spec)
-    expect = dict(self.initial_app_spec)
-    expect['name'] = self.initial_app_spec['name'].upper()
-    expect['lastModifiedBy'] = 'anonymous'
+        self.initial_app_spec = {
+            "name": self.TEST_APP,
+            "description": "My Application Description.",
+            "email": "test@google.com",
+            "accounts": "my-aws-account,my-google-account",
+            "updateTs": "1463667655844",
+            "createTs": "1463666817476",
+            "platformHealthOnly": False,
+            "cloudProviders": "gce,aws",
+        }
 
-    contract = jc.Contract()
+        self.initial_pipeline_spec = {
+            "keepWaitingPipelines": False,
+            "limitConcurrent": True,
+            "application": self.TEST_APP,
+            "parallel": True,
+            "lastModifiedBy": "anonymous",
+            "name": self.TEST_PIPELINE_NAME,
+            "stages": [],
+            "index": 0,
+            "id": self.TEST_PIPELINE_ID,
+            "triggers": [],
+        }
 
-    # The update timestamp is determined by the server,
-    # and we dont know what that is, so lets ignore it
-    # and assume the unit tests verify it is properly updated.
-    expect = dict(expect)
-    del expect['updateTs']
-    self.app_history.insert(0, expect)
-    f50_builder = st.http_observer.HttpContractBuilder(self.agent)
+    def create_app(self):
+        payload = self.agent.make_json_payload_from_object(self.initial_app_spec)
+        expect = dict(self.initial_app_spec)
+        expect["name"] = self.initial_app_spec["name"].upper()
+        expect["lastModifiedBy"] = "anonymous"
 
-    gcs_builder = gcp.GcpStorageContractBuilder(self.gcs_observer)
-    (gcs_builder.new_clause_builder('Created Google Cloud Storage File',
-                                    retryable_for_secs=5)
-     .list_bucket(self.BUCKET, '/'.join([self.BASE_PATH, 'applications']))
-     .EXPECT(ov_factory.value_list_path_contains(
-         'name', jp.STR_SUBSTR(self.TEST_APP))))
-    (gcs_builder.new_clause_builder('Wrote File Content')
-     .retrieve_content(self.BUCKET,
-                       '/'.join([self.BASE_PATH, 'applications', self.TEST_APP,
-                                 'specification.json']),
-                       transform=json.JSONDecoder().decode)
-     .EXPECT(ov_factory.value_list_contains(
-         jp.DICT_MATCHES({
-             key: jp.EQUIVALENT(value)
-             for key, value in expect.items()}))))
-    for clause in gcs_builder.build().clauses:
-      contract.add_clause(clause)
+        contract = jc.Contract()
 
-    # These clauses are querying the Front50 http server directly
-    # to verify that it returns the application we added.
-    # We already verified the data was stored on GCS, but while we
-    # are here we will verify that it is also being returned when queried.
-    (f50_builder.new_clause_builder('Lists Application')
-     .get_url_path('/v2/applications')
-     .EXPECT(ov_factory.value_list_path_contains(
-         'name', jp.STR_SUBSTR(self.TEST_APP.upper()))))
-    (f50_builder.new_clause_builder('Returns Application')
-     .get_url_path('/v2/applications')
-     .EXPECT(ov_factory.value_list_contains(
-         jp.DICT_MATCHES({
-             key: jp.EQUIVALENT(value)
-             for key, value in self.app_history[0].items()}))))
-    for clause in f50_builder.build().clauses:
-      contract.add_clause(clause)
+        # The update timestamp is determined by the server,
+        # and we dont know what that is, so lets ignore it
+        # and assume the unit tests verify it is properly updated.
+        expect = dict(expect)
+        del expect["updateTs"]
+        self.app_history.insert(0, expect)
+        f50_builder = st.http_observer.HttpContractBuilder(self.agent)
 
-    path = '/v2/applications'
-    return st.OperationContract(
-        self.new_post_operation(
-            title='create_app', data=payload, path=path),
-        contract=contract)
+        gcs_builder = gcp.GcpStorageContractBuilder(self.gcs_observer)
+        (
+            gcs_builder.new_clause_builder(
+                "Created Google Cloud Storage File", retryable_for_secs=5
+            )
+            .list_bucket(self.BUCKET, "/".join([self.BASE_PATH, "applications"]))
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "name", jp.STR_SUBSTR(self.TEST_APP)
+                )
+            )
+        )
+        (
+            gcs_builder.new_clause_builder("Wrote File Content")
+            .retrieve_content(
+                self.BUCKET,
+                "/".join(
+                    [
+                        self.BASE_PATH,
+                        "applications",
+                        self.TEST_APP,
+                        "specification.json",
+                    ]
+                ),
+                transform=json.JSONDecoder().decode,
+            )
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {key: jp.EQUIVALENT(value) for key, value in expect.items()}
+                    )
+                )
+            )
+        )
+        for clause in gcs_builder.build().clauses:
+            contract.add_clause(clause)
 
-  def update_app(self):
-    contract = jc.Contract()
+        # These clauses are querying the Front50 http server directly
+        # to verify that it returns the application we added.
+        # We already verified the data was stored on GCS, but while we
+        # are here we will verify that it is also being returned when queried.
+        (
+            f50_builder.new_clause_builder("Lists Application")
+            .get_url_path("/v2/applications")
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "name", jp.STR_SUBSTR(self.TEST_APP.upper())
+                )
+            )
+        )
+        (
+            f50_builder.new_clause_builder("Returns Application")
+            .get_url_path("/v2/applications")
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            key: jp.EQUIVALENT(value)
+                            for key, value in self.app_history[0].items()
+                        }
+                    )
+                )
+            )
+        )
+        for clause in f50_builder.build().clauses:
+            contract.add_clause(clause)
 
-    spec = {}
-    for name, value in self.initial_app_spec.items():
-      if name == 'name':
-        spec[name] = value
-      elif name == 'cloudProviders':
-        spec[name] = value + ',kubernetes'
-      elif name in ['updateTs', 'createTs']:
-        spec[name] = str(int(value) + 1)
-      elif isinstance(value, basestring):
-        spec[name] = 'NEW_' + value
-    payload = self.agent.make_json_payload_from_object(spec)
-    expectUpdate = dict(spec)
+        path = "/v2/applications"
+        return st.OperationContract(
+            self.new_post_operation(title="create_app", data=payload, path=path),
+            contract=contract,
+        )
 
-    # The actual update is determined by front50.
-    # The createTs we gave ignored.
-    # As before, the name is upper-cased.
-    del expectUpdate['updateTs']
-    expectUpdate['createTs'] = self.initial_app_spec['createTs']
-    expectUpdate['name'] = self.initial_app_spec['name'].upper()
-    self.app_history.insert(0, expectUpdate)
+    def update_app(self):
+        contract = jc.Contract()
 
-    # TODO(ewiseblatt) 20160524:
-    # Add clauses that observe Front50 to verify the history method works
-    # and that the get method is the current version.
-    num_versions = 2 if self.versioning_enabled else 1
-    gcs_builder = gcp.GcpStorageContractBuilder(self.gcs_observer)
-    (gcs_builder.new_clause_builder('Google Cloud Storage Contains File',
-                                    retryable_for_secs=5)
+        spec = {}
+        for name, value in self.initial_app_spec.items():
+            if name == "name":
+                spec[name] = value
+            elif name == "cloudProviders":
+                spec[name] = value + ",kubernetes"
+            elif name in ["updateTs", "createTs"]:
+                spec[name] = str(int(value) + 1)
+            elif isinstance(value, basestring):
+                spec[name] = "NEW_" + value
+        payload = self.agent.make_json_payload_from_object(spec)
+        expectUpdate = dict(spec)
 
-     .list_bucket(self.BUCKET,
-                  '/'.join([self.BASE_PATH, 'applications', self.TEST_APP]),
-                  with_versions=True)
-     .contains_path_value('name', self.TEST_APP,
-                          min=num_versions, max=num_versions))
-    (gcs_builder.new_clause_builder('Updated File Content',
-                                    retryable_for_secs=5)
-     .retrieve_content(self.BUCKET,
-                       '/'.join([self.BASE_PATH, 'applications', self.TEST_APP,
-                                 'specification.json']),
-                       transform=json.JSONDecoder().decode)
-     .contains_match({key: jp.EQUIVALENT(value)
-                      for key, value in expectUpdate.items()}))
+        # The actual update is determined by front50.
+        # The createTs we gave ignored.
+        # As before, the name is upper-cased.
+        del expectUpdate["updateTs"]
+        expectUpdate["createTs"] = self.initial_app_spec["createTs"]
+        expectUpdate["name"] = self.initial_app_spec["name"].upper()
+        self.app_history.insert(0, expectUpdate)
 
-    for clause in gcs_builder.build().clauses:
-      contract.add_clause(clause)
+        # TODO(ewiseblatt) 20160524:
+        # Add clauses that observe Front50 to verify the history method works
+        # and that the get method is the current version.
+        num_versions = 2 if self.versioning_enabled else 1
+        gcs_builder = gcp.GcpStorageContractBuilder(self.gcs_observer)
+        (
+            gcs_builder.new_clause_builder(
+                "Google Cloud Storage Contains File", retryable_for_secs=5
+            )
+            .list_bucket(
+                self.BUCKET,
+                "/".join([self.BASE_PATH, "applications", self.TEST_APP]),
+                with_versions=True,
+            )
+            .contains_path_value(
+                "name", self.TEST_APP, min=num_versions, max=num_versions
+            )
+        )
+        (
+            gcs_builder.new_clause_builder("Updated File Content", retryable_for_secs=5)
+            .retrieve_content(
+                self.BUCKET,
+                "/".join(
+                    [
+                        self.BASE_PATH,
+                        "applications",
+                        self.TEST_APP,
+                        "specification.json",
+                    ]
+                ),
+                transform=json.JSONDecoder().decode,
+            )
+            .contains_match(
+                {key: jp.EQUIVALENT(value) for key, value in expectUpdate.items()}
+            )
+        )
 
-    f50_builder = st.http_observer.HttpContractBuilder(self.agent)
-    (f50_builder.new_clause_builder('History Records Changes')
-     .get_url_path('/v2/applications/{app}/history'
-                   .format(app=self.TEST_APP))
-     .contains_path_match(
-          '[0]', {key: jp.EQUIVALENT(value)
-                  for key, value in self.app_history[0].items()})
-     .contains_path_match(
-          '[1]', {key: jp.EQUIVALENT(value)
-                  for key, value in self.app_history[1].items()}))
+        for clause in gcs_builder.build().clauses:
+            contract.add_clause(clause)
 
-    for clause in f50_builder.build().clauses:
-      contract.add_clause(clause)
+        f50_builder = st.http_observer.HttpContractBuilder(self.agent)
+        (
+            f50_builder.new_clause_builder("History Records Changes")
+            .get_url_path("/v2/applications/{app}/history".format(app=self.TEST_APP))
+            .contains_path_match(
+                "[0]",
+                {
+                    key: jp.EQUIVALENT(value)
+                    for key, value in self.app_history[0].items()
+                },
+            )
+            .contains_path_match(
+                "[1]",
+                {
+                    key: jp.EQUIVALENT(value)
+                    for key, value in self.app_history[1].items()
+                },
+            )
+        )
 
-    # TODO(ewiseblatt): 20160524
-    # Add a mechanism here to check the previous version
-    # so that we can verify version recovery as well.
-    path = '/'.join(['/v2/applications', self.TEST_APP])
-    return st.OperationContract(
-        self.new_patch_operation(
-            title='update_app', data=payload, path=path),
-        contract=contract)
+        for clause in f50_builder.build().clauses:
+            contract.add_clause(clause)
 
-  def delete_app(self):
-    contract = jc.Contract()
+        # TODO(ewiseblatt): 20160524
+        # Add a mechanism here to check the previous version
+        # so that we can verify version recovery as well.
+        path = "/".join(["/v2/applications", self.TEST_APP])
+        return st.OperationContract(
+            self.new_patch_operation(title="update_app", data=payload, path=path),
+            contract=contract,
+        )
 
-    app_url_path = '/'.join(['/v2/applications', self.TEST_APP])
-    f50_builder = st.http_observer.HttpContractBuilder(self.agent)
-    # The application should be unlisted immediately (assuming 1 replica)
-    # However given GCS rate limiting on updating the timestamp file,
-    # there is a race condition in which the filesystem timestamp
-    # was rate limited from updating AND a scheduled update is in progress
-    # where the application was seen just before the delete so gets restored
-    # back. Because the timestamp was not updated, this observer will read
-    # from the cache thinking it is fresh. We need the extra second to allow
-    # for the retry on the timestamp update to write out to GCS.
-    (f50_builder.new_clause_builder('Unlists Application',
-                                    retryable_for_secs=8)
-     .get_url_path('/v2/applications')
-     .EXPECT(ov_factory.value_list_path_excludes(
-         'name', jp.STR_SUBSTR(self.TEST_APP.upper()))))
-    (f50_builder.new_clause_builder('Deletes Application')
-     .get_url_path(app_url_path)
-     .EXPECT(ov_factory.error_list_contains(
-         st.HttpAgentErrorPredicate(st.HttpResponsePredicate(http_code=404)))))
+    def delete_app(self):
+        contract = jc.Contract()
 
+        app_url_path = "/".join(["/v2/applications", self.TEST_APP])
+        f50_builder = st.http_observer.HttpContractBuilder(self.agent)
+        # The application should be unlisted immediately (assuming 1 replica)
+        # However given GCS rate limiting on updating the timestamp file,
+        # there is a race condition in which the filesystem timestamp
+        # was rate limited from updating AND a scheduled update is in progress
+        # where the application was seen just before the delete so gets restored
+        # back. Because the timestamp was not updated, this observer will read
+        # from the cache thinking it is fresh. We need the extra second to allow
+        # for the retry on the timestamp update to write out to GCS.
+        (
+            f50_builder.new_clause_builder("Unlists Application", retryable_for_secs=8)
+            .get_url_path("/v2/applications")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.TEST_APP.upper())
+                )
+            )
+        )
+        (
+            f50_builder.new_clause_builder("Deletes Application")
+            .get_url_path(app_url_path)
+            .EXPECT(
+                ov_factory.error_list_contains(
+                    st.HttpAgentErrorPredicate(st.HttpResponsePredicate(http_code=404))
+                )
+            )
+        )
 
-    (f50_builder.new_clause_builder('History Retains Application',
-                                    retryable_for_secs=5)
-     .get_url_path('/v2/applications/{app}/history'
-                   .format(app=self.TEST_APP))
-     .EXPECT(ov_factory.value_list_matches([
-         jp.DICT_MATCHES({key: jp.EQUIVALENT(value)
-                          for key, value in self.app_history[0].items()}),
-         jp.DICT_MATCHES({key: jp.EQUIVALENT(value)
-                          for key, value in self.app_history[1].items()})
-       ])))
+        (
+            f50_builder.new_clause_builder(
+                "History Retains Application", retryable_for_secs=5
+            )
+            .get_url_path("/v2/applications/{app}/history".format(app=self.TEST_APP))
+            .EXPECT(
+                ov_factory.value_list_matches(
+                    [
+                        jp.DICT_MATCHES(
+                            {
+                                key: jp.EQUIVALENT(value)
+                                for key, value in self.app_history[0].items()
+                            }
+                        ),
+                        jp.DICT_MATCHES(
+                            {
+                                key: jp.EQUIVALENT(value)
+                                for key, value in self.app_history[1].items()
+                            }
+                        ),
+                    ]
+                )
+            )
+        )
 
-    for clause in f50_builder.build().clauses:
-      contract.add_clause(clause)
+        for clause in f50_builder.build().clauses:
+            contract.add_clause(clause)
 
+        gcs_builder = gcp.GcpStorageContractBuilder(self.gcs_observer)
+        (
+            gcs_builder.new_clause_builder("Deleted File", retryable_for_secs=5)
+            .list_bucket(self.BUCKET, "/".join([self.BASE_PATH, "applications"]))
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.TEST_APP)
+                )
+            )
+        )
+        for clause in gcs_builder.build().clauses:
+            contract.add_clause(clause)
 
-    gcs_builder = gcp.GcpStorageContractBuilder(self.gcs_observer)
-    (gcs_builder.new_clause_builder('Deleted File', retryable_for_secs=5)
-     .list_bucket(self.BUCKET, '/'.join([self.BASE_PATH, 'applications']))
-     .EXPECT(ov_factory.value_list_path_excludes(
-         'name', jp.STR_SUBSTR(self.TEST_APP))))
-    for clause in gcs_builder.build().clauses:
-      contract.add_clause(clause)
+        return st.OperationContract(
+            self.new_delete_operation(title="delete_app", data=None, path=app_url_path),
+            contract=contract,
+        )
 
-    return st.OperationContract(
-        self.new_delete_operation(
-            title='delete_app', data=None, path=app_url_path),
-        contract=contract)
+    def create_pipeline(self):
+        payload = self.agent.make_json_payload_from_object(self.initial_pipeline_spec)
+        expect = dict(self.initial_pipeline_spec)
+        expect["lastModifiedBy"] = "anonymous"
+        self.pipeline_history.insert(0, expect)
 
-  def create_pipeline(self):
-    payload = self.agent.make_json_payload_from_object(
-        self.initial_pipeline_spec)
-    expect = dict(self.initial_pipeline_spec)
-    expect['lastModifiedBy'] = 'anonymous'
-    self.pipeline_history.insert(0, expect)
+        contract = jc.Contract()
 
-    contract = jc.Contract()
+        gcs_builder = gcp.GcpStorageContractBuilder(self.gcs_observer)
+        (
+            gcs_builder.new_clause_builder(
+                "Created Google Cloud Storage File", retryable_for_secs=5
+            )
+            .list_bucket(self.BUCKET, "/".join([self.BASE_PATH, "pipelines"]))
+            .contains_path_value(
+                "name",
+                "pipelines/{id}/specification.json".format(id=self.TEST_PIPELINE_ID),
+            )
+        )
+        (
+            gcs_builder.new_clause_builder("Wrote File Content")
+            .retrieve_content(
+                self.BUCKET,
+                "/".join(
+                    [
+                        self.BASE_PATH,
+                        "pipelines",
+                        self.TEST_PIPELINE_ID,
+                        "specification.json",
+                    ]
+                ),
+                transform=json.JSONDecoder().decode,
+            )
+            .contains_match(
+                {key: jp.EQUIVALENT(value) for key, value in expect.items()}
+            )
+        )
+        for clause in gcs_builder.build().clauses:
+            contract.add_clause(clause)
 
-    gcs_builder = gcp.GcpStorageContractBuilder(self.gcs_observer)
-    (gcs_builder.new_clause_builder('Created Google Cloud Storage File',
-                                    retryable_for_secs=5)
-     .list_bucket(self.BUCKET, '/'.join([self.BASE_PATH, 'pipelines']))
-     .contains_path_value('name',
-                          'pipelines/{id}/specification.json'
-                          .format(id=self.TEST_PIPELINE_ID)))
-    (gcs_builder.new_clause_builder('Wrote File Content')
-     .retrieve_content(self.BUCKET,
-                       '/'.join([self.BASE_PATH, 'pipelines',
-                                 self.TEST_PIPELINE_ID, 'specification.json']),
-                       transform=json.JSONDecoder().decode)
-     .contains_match({key: jp.EQUIVALENT(value)
-                      for key, value in expect.items()}))
-    for clause in gcs_builder.build().clauses:
-      contract.add_clause(clause)
+        f50_builder = st.http_observer.HttpContractBuilder(self.agent)
 
-    f50_builder = st.http_observer.HttpContractBuilder(self.agent)
+        # These clauses are querying the Front50 http server directly
+        # to verify that it returns the application we added.
+        # We already verified the data was stored on GCS, but while we
+        # are here we will verify that it is also being returned when queried.
+        (
+            f50_builder.new_clause_builder("Global Lists Pipeline")
+            .get_url_path("/pipelines")
+            .contains_path_value("name", self.TEST_PIPELINE_NAME)
+        )
+        (
+            f50_builder.new_clause_builder("Application Lists Pipeline")
+            .get_url_path("/pipelines/{app}".format(app=self.TEST_APP))
+            .contains_path_value("name", self.TEST_PIPELINE_NAME)
+        )
+        (
+            f50_builder.new_clause_builder("Returns Pipeline")
+            .get_url_path("/pipelines/{id}/history".format(id=self.TEST_PIPELINE_ID))
+            .contains_path_match(
+                "[0]",
+                {
+                    key: jp.EQUIVALENT(value)
+                    for key, value in self.pipeline_history[0].items()
+                },
+            )
+        )
+        for clause in f50_builder.build().clauses:
+            contract.add_clause(clause)
 
-    # These clauses are querying the Front50 http server directly
-    # to verify that it returns the application we added.
-    # We already verified the data was stored on GCS, but while we
-    # are here we will verify that it is also being returned when queried.
-    (f50_builder.new_clause_builder('Global Lists Pipeline')
-     .get_url_path('/pipelines')
-     .contains_path_value('name', self.TEST_PIPELINE_NAME))
-    (f50_builder.new_clause_builder('Application Lists Pipeline')
-     .get_url_path('/pipelines/{app}'.format(app=self.TEST_APP))
-     .contains_path_value('name', self.TEST_PIPELINE_NAME))
-    (f50_builder.new_clause_builder('Returns Pipeline')
-     .get_url_path('/pipelines/{id}/history'.format(id=self.TEST_PIPELINE_ID))
-     .contains_path_match(
-          '[0]', {key: jp.EQUIVALENT(value)
-                  for key, value in self.pipeline_history[0].items()}))
-    for clause in f50_builder.build().clauses:
-      contract.add_clause(clause)
+        path = "/pipelines"
+        return st.OperationContract(
+            self.new_post_operation(title="create_pipeline", data=payload, path=path),
+            contract=contract,
+        )
 
-    path = '/pipelines'
-    return st.OperationContract(
-        self.new_post_operation(
-            title='create_pipeline', data=payload, path=path),
-        contract=contract)
+    def delete_pipeline(self):
+        contract = jc.Contract()
 
-  def delete_pipeline(self):
-    contract = jc.Contract()
+        app_url_path = "pipelines/{app}/{pipeline}".format(
+            app=self.TEST_APP, pipeline=UrlQuote(self.TEST_PIPELINE_NAME)
+        )
 
-    app_url_path = 'pipelines/{app}/{pipeline}'.format(
-        app=self.TEST_APP,
-        pipeline=UrlQuote(self.TEST_PIPELINE_NAME))
+        f50_builder = st.http_observer.HttpContractBuilder(self.agent)
+        (
+            f50_builder.new_clause_builder(
+                "Global Unlists Pipeline", retryable_for_secs=5
+            )
+            .get_url_path("/pipelines")
+            .excludes_path_value("name", self.TEST_PIPELINE_NAME)
+        )
+        (
+            f50_builder.new_clause_builder(
+                "Application Unlists Pipeline", retryable_for_secs=5
+            )
+            .get_url_path("/pipelines/{app}".format(app=self.TEST_APP))
+            .excludes_path_value("id", self.TEST_PIPELINE_ID)
+        )
 
-    f50_builder = st.http_observer.HttpContractBuilder(self.agent)
-    (f50_builder.new_clause_builder('Global Unlists Pipeline',
-                                    retryable_for_secs=5)
-     .get_url_path('/pipelines')
-     .excludes_path_value('name', self.TEST_PIPELINE_NAME))
-    (f50_builder.new_clause_builder('Application Unlists Pipeline',
-                                    retryable_for_secs=5)
-     .get_url_path('/pipelines/{app}'.format(app=self.TEST_APP))
-     .excludes_path_value('id', self.TEST_PIPELINE_ID))
+        (
+            f50_builder.new_clause_builder(
+                "History Retains Pipeline", retryable_for_secs=5
+            )
+            .get_url_path("/pipelines/{id}/history".format(id=self.TEST_PIPELINE_ID))
+            .contains_path_match(
+                "[0]",
+                {
+                    key: jp.EQUIVALENT(value)
+                    for key, value in self.pipeline_history[0].items()
+                },
+            )
+        )
+        for clause in f50_builder.build().clauses:
+            contract.add_clause(clause)
 
-    (f50_builder.new_clause_builder('History Retains Pipeline',
-                                    retryable_for_secs=5)
-     .get_url_path('/pipelines/{id}/history'.format(id=self.TEST_PIPELINE_ID))
-     .contains_path_match(
-          '[0]', {key: jp.EQUIVALENT(value)
-                  for key, value in self.pipeline_history[0].items()}))
-    for clause in f50_builder.build().clauses:
-      contract.add_clause(clause)
+        gcs_builder = gcp.GcpStorageContractBuilder(self.gcs_observer)
+        (
+            gcs_builder.new_clause_builder("Deleted File", retryable_for_secs=5)
+            .list_bucket(self.BUCKET, "/".join([self.BASE_PATH, "pipelines"]))
+            .excludes_path_value("name", self.TEST_PIPELINE_ID)
+        )
+        for clause in gcs_builder.build().clauses:
+            contract.add_clause(clause)
 
-    gcs_builder = gcp.GcpStorageContractBuilder(self.gcs_observer)
-    (gcs_builder.new_clause_builder('Deleted File', retryable_for_secs=5)
-     .list_bucket(self.BUCKET, '/'.join([self.BASE_PATH, 'pipelines']))
-     .excludes_path_value('name', self.TEST_PIPELINE_ID))
-    for clause in gcs_builder.build().clauses:
-      contract.add_clause(clause)
-
-    return st.OperationContract(
-        self.new_delete_operation(
-            title='delete_pipeline', data=None, path=app_url_path),
-        contract=contract)
+        return st.OperationContract(
+            self.new_delete_operation(
+                title="delete_pipeline", data=None, path=app_url_path
+            ),
+            contract=contract,
+        )
 
 
 class GcsFront50Test(st.AgentTestCase):
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-        GcsFront50TestScenario)
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            GcsFront50TestScenario
+        )
 
-  def test_a_create_app(self):
-    self.run_test_case(self.scenario.create_app())
+    def test_a_create_app(self):
+        self.run_test_case(self.scenario.create_app())
 
-  def test_b_update_app(self):
-    self.run_test_case(self.scenario.update_app())
+    def test_b_update_app(self):
+        self.run_test_case(self.scenario.update_app())
 
-  def test_c_create_pipeline(self):
-    self.run_test_case(self.scenario.create_pipeline())
+    def test_c_create_pipeline(self):
+        self.run_test_case(self.scenario.create_pipeline())
 
-  def test_y_delete_pipeline(self):
-    self.run_test_case(self.scenario.delete_pipeline())
+    def test_y_delete_pipeline(self):
+        self.run_test_case(self.scenario.delete_pipeline())
 
-  def test_z_delete_app(self):
-    self.run_test_case(self.scenario.delete_app())
+    def test_z_delete_app(self):
+        self.run_test_case(self.scenario.delete_app())
 
 
 def main():
-  """Implements the main method running this smoke test."""
+    """Implements the main method running this smoke test."""
 
-  defaults = {
-      'TEST_APP': 'gcsfront50test' + GcsFront50TestScenario.DEFAULT_TEST_ID
-  }
+    defaults = {"TEST_APP": "gcsfront50test" + GcsFront50TestScenario.DEFAULT_TEST_ID}
 
-  return citest.base.TestRunner.main(
-      parser_inits=[GcsFront50TestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[GcsFront50Test])
+    return citest.base.TestRunner.main(
+        parser_inits=[GcsFront50TestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[GcsFront50Test],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/google_http_lb_upsert_scenario.py
+++ b/testing/citest/tests/google_http_lb_upsert_scenario.py
@@ -24,6 +24,7 @@ import citest.gcp_testing as gcp
 import citest.json_predicate as jp
 import citest.service_testing as st
 from citest.json_contract import ObservationPredicateFactory
+
 ov_factory = ObservationPredicateFactory()
 
 # Spinnaker modules.
@@ -32,675 +33,735 @@ import spinnaker_testing.gate as gate
 
 
 SCOPES = [gcp.COMPUTE_READ_WRITE_SCOPE]
-GCE_URL_PREFIX = 'https://www.googleapis.com/compute/v1/projects/'
+GCE_URL_PREFIX = "https://www.googleapis.com/compute/v1/projects/"
+
 
 class GoogleHttpLoadBalancerTestScenario(sk.SpinnakerTestScenario):
-  '''Defines the tests for L7 Load Balancers.
-  '''
+    """Defines the tests for L7 Load Balancers."""
 
-  MINIMUM_PROJECT_QUOTA = {
-    'INSTANCE_TEMPLATES': 1,
-    'BACKEND_SERVICES': 3,
-    'URL_MAPS': 1,
-    'HEALTH_CHECKS': 1,
-    'IN_USE_ADDRESSES': 2,
-    'SSL_CERTIFICATES': 2,
-    'TARGET_HTTP_PROXIES': 1,
-    'TARGET_HTTPS_PROXIES': 1,
-    'FORWARDING_RULES': 2
-  }
-
-  MINIMUM_REGION_QUOTA = {
-      'CPUS': 2,
-      'IN_USE_ADDRESSES': 2,
-      'INSTANCE_GROUP_MANAGERS': 1,
-      'INSTANCES': 2,
-  }
-
-  @classmethod
-  def new_agent(cls, bindings):
-    '''Implements citest.service_testing.AgentTestScenario.new_agent.'''
-    agent = gate.new_agent(bindings)
-    agent.default_max_wait_secs = 1200
-    return agent
-
-
-  def __init__(self, bindings, agent=None):
-    '''Constructor.
-
-    Args:
-      bindings: [dict] The data bindings to use to configure the scenario.
-      agent: [GateAgent] The agent for invoking the test operations on Gate.
-    '''
-    super(GoogleHttpLoadBalancerTestScenario, self).__init__(bindings, agent)
-
-    bindings = self.bindings
-
-    self.__lb_detail = 'httplb'
-    self.TEST_APP = bindings['TEST_APP']
-    self.__lb_name = '{app}-{stack}-{detail}'.format(
-        app=bindings['TEST_APP'], stack=bindings['TEST_STACK'],
-        detail=self.__lb_detail)
-    self.__first_cert = 'first-cert-%s' % (bindings['TEST_APP'])
-    self.__proto_hc = {
-      'name': 'basic-' + self.TEST_APP,
-      'requestPath': '/',
-      'port': 80,
-      'checkIntervalSec': 2,
-      'timeoutSec': 1,
-      'healthyThreshold': 3,
-      'unhealthyThreshold': 4,
-      'healthCheckType': 'HTTP'
+    MINIMUM_PROJECT_QUOTA = {
+        "INSTANCE_TEMPLATES": 1,
+        "BACKEND_SERVICES": 3,
+        "URL_MAPS": 1,
+        "HEALTH_CHECKS": 1,
+        "IN_USE_ADDRESSES": 2,
+        "SSL_CERTIFICATES": 2,
+        "TARGET_HTTP_PROXIES": 1,
+        "TARGET_HTTPS_PROXIES": 1,
+        "FORWARDING_RULES": 2,
     }
-    self.__proto_delete = {
-      'type': 'deleteLoadBalancer',
-      'cloudProvider': 'gce',
-      'loadBalancerType': 'HTTP',
-      'loadBalancerName': self.__lb_name,
-      'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      'user': '[anonymous]'
+
+    MINIMUM_REGION_QUOTA = {
+        "CPUS": 2,
+        "IN_USE_ADDRESSES": 2,
+        "INSTANCE_GROUP_MANAGERS": 1,
+        "INSTANCES": 2,
     }
-    self.__proto_upsert = {
-      'cloudProvider': 'gce',
-      'provider': 'gce',
-      'stack': bindings['TEST_STACK'],
-      'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      'region': bindings['TEST_GCE_REGION'],
-      'loadBalancerType': 'HTTP',
-      'loadBalancerName': self.__lb_name,
-      'urlMapName': self.__lb_name,
-      'listenersToDelete': [],
-      'portRange': '80',
-      'defaultService': {
-        'name': 'default-' + self.TEST_APP,
-        'backends': [],
-        'healthCheck': self.__proto_hc,
-      },
-      'certificate': self.__first_cert,
-      'hostRules': [
-        {
-          'hostPatterns': ['host1.com', 'host2.com'],
-          'pathMatcher': {
-            'pathRules': [
-              {
-                'paths': ['/path', '/path2/more'],
-                'backendService': {
-                  'name': 'bs-' + self.TEST_APP,
-                  'backends': [],
-                  'healthCheck': self.__proto_hc,
+
+    @classmethod
+    def new_agent(cls, bindings):
+        """Implements citest.service_testing.AgentTestScenario.new_agent."""
+        agent = gate.new_agent(bindings)
+        agent.default_max_wait_secs = 1200
+        return agent
+
+    def __init__(self, bindings, agent=None):
+        """Constructor.
+
+        Args:
+          bindings: [dict] The data bindings to use to configure the scenario.
+          agent: [GateAgent] The agent for invoking the test operations on Gate.
+        """
+        super(GoogleHttpLoadBalancerTestScenario, self).__init__(bindings, agent)
+
+        bindings = self.bindings
+
+        self.__lb_detail = "httplb"
+        self.TEST_APP = bindings["TEST_APP"]
+        self.__lb_name = "{app}-{stack}-{detail}".format(
+            app=bindings["TEST_APP"],
+            stack=bindings["TEST_STACK"],
+            detail=self.__lb_detail,
+        )
+        self.__first_cert = "first-cert-%s" % (bindings["TEST_APP"])
+        self.__proto_hc = {
+            "name": "basic-" + self.TEST_APP,
+            "requestPath": "/",
+            "port": 80,
+            "checkIntervalSec": 2,
+            "timeoutSec": 1,
+            "healthyThreshold": 3,
+            "unhealthyThreshold": 4,
+            "healthCheckType": "HTTP",
+        }
+        self.__proto_delete = {
+            "type": "deleteLoadBalancer",
+            "cloudProvider": "gce",
+            "loadBalancerType": "HTTP",
+            "loadBalancerName": self.__lb_name,
+            "credentials": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+            "user": "[anonymous]",
+        }
+        self.__proto_upsert = {
+            "cloudProvider": "gce",
+            "provider": "gce",
+            "stack": bindings["TEST_STACK"],
+            "credentials": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+            "region": bindings["TEST_GCE_REGION"],
+            "loadBalancerType": "HTTP",
+            "loadBalancerName": self.__lb_name,
+            "urlMapName": self.__lb_name,
+            "listenersToDelete": [],
+            "portRange": "80",
+            "defaultService": {
+                "name": "default-" + self.TEST_APP,
+                "backends": [],
+                "healthCheck": self.__proto_hc,
+            },
+            "certificate": self.__first_cert,
+            "hostRules": [
+                {
+                    "hostPatterns": ["host1.com", "host2.com"],
+                    "pathMatcher": {
+                        "pathRules": [
+                            {
+                                "paths": ["/path", "/path2/more"],
+                                "backendService": {
+                                    "name": "bs-" + self.TEST_APP,
+                                    "backends": [],
+                                    "healthCheck": self.__proto_hc,
+                                },
+                            }
+                        ],
+                        "defaultService": {
+                            "name": "pm-" + self.TEST_APP,
+                            "backends": [],
+                            "healthCheck": self.__proto_hc,
+                        },
+                    },
                 }
-              }
             ],
-            'defaultService': {
-              'name': 'pm-' + self.TEST_APP,
-              'backends': [],
-              'healthCheck': self.__proto_hc,
+            "type": "upsertLoadBalancer",
+            "availabilityZones": {bindings["TEST_GCE_REGION"]: []},
+            "user": "[anonymous]",
+        }
+
+    def _get_bs_link(self, bs):
+        """Make a fully-formatted backend service link."""
+        return (
+            GCE_URL_PREFIX
+            + self.bindings["GOOGLE_PRIMARY_MANAGED_PROJECT_ID"]
+            + "/global/backendServices/"
+            + bs
+        )
+
+    def _get_hc_link(self, hc):
+        """Make a fully-formatted health check link."""
+        return (
+            GCE_URL_PREFIX
+            + self.bindings["GOOGLE_PRIMARY_MANAGED_PROJECT_ID"]
+            + "/global/healthChecks/"
+            + hc
+        )
+
+    def _set_all_hcs(self, upsert, hc):
+        """Set all health checks in upsert to hc."""
+        upsert["defaultService"]["healthCheck"] = hc
+        for host_rule in upsert["hostRules"]:
+            path_matcher = host_rule["pathMatcher"]
+            path_matcher["defaultService"]["healthCheck"] = hc
+            for path_rule in path_matcher["pathRules"]:
+                path_rule["backendService"]["healthCheck"] = hc
+
+    def _add_contract_clauses(self, contract_builder, upsert):
+        """Add the proper predicates to the contract builder for a given
+        upsert description.
+        """
+        host_rules = upsert["hostRules"]  # Host rules will be distinct.
+        backend_services = [upsert["defaultService"]]
+        for host_rule in host_rules:
+            path_matcher = host_rule["pathMatcher"]
+            backend_services.append(path_matcher["defaultService"])
+            for path_rule in path_matcher["pathRules"]:
+                backend_services.append(path_rule["backendService"])
+        health_checks = [service["healthCheck"] for service in backend_services]
+
+        hc_clause_builder = contract_builder.new_clause_builder(
+            "Health Checks Created", retryable_for_secs=30
+        ).list_resource("healthChecks")
+        for hc in health_checks:
+            hc_clause_builder.AND(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_EQ(hc["name"]),
+                            "httpHealthCheck": jp.DICT_MATCHES(
+                                {
+                                    "requestPath": jp.STR_EQ(hc["requestPath"]),
+                                    "port": jp.NUM_EQ(hc["port"]),
+                                }
+                            ),
+                        }
+                    )
+                )
+            )
+
+        bs_clause_builder = contract_builder.new_clause_builder(
+            "Backend Services Created", retryable_for_secs=30
+        ).list_resource("backendServices")
+        for bs in backend_services:
+            bs_clause_builder.AND(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_EQ(bs["name"]),
+                            "portName": jp.STR_EQ("http"),
+                            "healthChecks": jp.LIST_MATCHES(
+                                [
+                                    jp.STR_EQ(
+                                        self._get_hc_link(bs["healthCheck"]["name"])
+                                    )
+                                ]
+                            ),
+                        }
+                    )
+                )
+            )
+
+        url_map_clause_builder = contract_builder.new_clause_builder(
+            "Url Map Created", retryable_for_secs=30
+        ).list_resource("urlMaps")
+        for hr in host_rules:
+            pm = hr["pathMatcher"]
+
+            path_rules_spec = [
+                jp.DICT_MATCHES(
+                    {
+                        "service": jp.STR_EQ(
+                            self._get_bs_link(pr["backendService"]["name"])
+                        ),
+                        "paths": jp.LIST_MATCHES(
+                            [jp.STR_EQ(path) for path in pr["paths"]]
+                        ),
+                    }
+                )
+                for pr in pm["pathRules"]
+            ]
+
+            path_matchers_spec = {
+                "defaultService": jp.STR_EQ(
+                    self._get_bs_link(pm["defaultService"]["name"])
+                ),
+                "pathRules": jp.LIST_MATCHES(path_rules_spec),
             }
-          }
+
+            url_map_clause_builder.AND(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_EQ(self.__lb_name),
+                            "defaultService": jp.STR_EQ(
+                                self._get_bs_link(upsert["defaultService"]["name"])
+                            ),
+                            "hostRules/hosts": jp.LIST_MATCHES(
+                                [jp.STR_SUBSTR(host) for host in hr["hostPatterns"]]
+                            ),
+                            "pathMatchers": jp.LIST_MATCHES(
+                                [jp.DICT_MATCHES(path_matchers_spec)]
+                            ),
+                        }
+                    )
+                )
+            )
+
+        port_string = "443-443"
+        if upsert["certificate"] == "":
+            port_string = "%s-%s" % (upsert["portRange"], upsert["portRange"])
+
+        (
+            contract_builder.new_clause_builder(
+                "Forwarding Rule Created", retryable_for_secs=30
+            )
+            .list_resource("globalForwardingRules")
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_EQ(self.__lb_name),
+                            "portRange": jp.STR_EQ(port_string),
+                        }
+                    )
+                )
+            )
+        )
+
+        proxy_clause_builder = contract_builder.new_clause_builder(
+            "Target Proxy Created", retryable_for_secs=30
+        )
+        self._add_proxy_clause(upsert["certificate"], proxy_clause_builder)
+
+    def _add_proxy_clause(self, certificate, proxy_clause_builder):
+        target_proxy_name = "%s-target-%s-proxy"
+        if certificate:
+            target_proxy_name = target_proxy_name % (self.__lb_name, "https")
+            (
+                proxy_clause_builder.list_resource("targetHttpsProxies").EXPECT(
+                    ov_factory.value_list_path_contains(
+                        "name", jp.STR_EQ(target_proxy_name)
+                    )
+                )
+            )
+        else:
+            target_proxy_name = target_proxy_name % (self.__lb_name, "http")
+            (
+                proxy_clause_builder.list_resource("targetHttpProxies").EXPECT(
+                    ov_factory.value_list_path_contains(
+                        "name", jp.STR_EQ(target_proxy_name)
+                    )
+                )
+            )
+
+    def upsert_full_load_balancer(self):
+        """Upserts L7 LB with full hostRules, pathMatchers, etc.
+
+        Calls the upsertLoadBalancer operation with a payload, then verifies that
+        the expected resources are visible on GCP.
+        """
+        hc = copy.deepcopy(self.__proto_hc)
+        hc["requestPath"] = "/"
+        hc["port"] = 80
+        upsert = copy.deepcopy(self.__proto_upsert)
+        self._set_all_hcs(upsert, hc)
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[upsert],
+            description="Upsert L7 Load Balancer: " + self.__lb_name,
+            application=self.TEST_APP,
+        )
+
+        contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
+        self._add_contract_clauses(contract_builder, upsert)
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="upsert full http lb", data=payload, path="tasks"
+            ),
+            contract=contract_builder.build(),
+        )
+
+    def upsert_min_load_balancer(self):
+        """Upserts a L7 LB with the minimum description."""
+        upsert = copy.deepcopy(self.__proto_upsert)
+        upsert["hostRules"] = []
+        upsert["certificate"] = ""  # Test HTTP upsert, not HTTPS.
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[upsert],
+            description="Upsert L7 Load Balancer: " + self.__lb_name,
+            application=self.TEST_APP,
+        )
+
+        contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
+        self._add_contract_clauses(contract_builder, upsert)
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="upsert min http lb", data=payload, path="tasks"
+            ),
+            contract=contract_builder.build(),
+        )
+
+    def delete_http_load_balancer(self):
+        """Deletes the L7 LB."""
+        bindings = self.bindings
+        delete = copy.deepcopy(self.__proto_delete)
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[delete],
+            description="Delete L7 Load Balancer: {0} in {1}".format(
+                self.__lb_name,
+                bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+            ),
+            application=self.TEST_APP,
+        )
+        contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            contract_builder.new_clause_builder(
+                "Health Check Removed", retryable_for_secs=30
+            )
+            .list_resource("healthChecks")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__proto_hc["name"])
+                )
+            )
+        )
+        (
+            contract_builder.new_clause_builder(
+                "Url Map Removed", retryable_for_secs=30
+            )
+            .list_resource("urlMaps")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__lb_name)
+                )
+            )
+        )
+        (
+            contract_builder.new_clause_builder(
+                "Forwarding Rule Removed", retryable_for_secs=30
+            )
+            .list_resource("globalForwardingRules")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__lb_name)
+                )
+            )
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete_http_load_balancer", data=payload, path="tasks"
+            ),
+            contract=contract_builder.build(),
+        )
+
+    def change_health_check(self):
+        """Changes the health check associated with the LB."""
+        upsert = copy.deepcopy(self.__proto_upsert)
+        hc = copy.deepcopy(self.__proto_hc)
+        hc["requestPath"] = "/changedPath"
+        hc["port"] = 8080
+        self._set_all_hcs(upsert, hc)
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[upsert],
+            description="Upsert L7 Load Balancer: " + self.__lb_name,
+            application=self.TEST_APP,
+        )
+
+        contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
+        self._add_contract_clauses(contract_builder, upsert)
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="change health checks", data=payload, path="tasks"
+            ),
+            contract=contract_builder.build(),
+        )
+
+    def change_backend_service(self):
+        """Changes the default backend service associated with the LB."""
+        hc = copy.deepcopy(self.__proto_hc)
+        bs_upsert = copy.deepcopy(self.__proto_upsert)
+        hc["name"] = "updated-" + self.TEST_APP
+        hc["requestPath"] = "/changedPath1"
+        hc["port"] = 8080
+
+        bs_upsert["defaultService"]["healthCheck"] = hc
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[bs_upsert],
+            description="Upsert L7 Load Balancer: " + self.__lb_name,
+            application=self.TEST_APP,
+        )
+
+        contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
+        self._add_contract_clauses(contract_builder, bs_upsert)
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="change backend services", data=payload, path="tasks"
+            ),
+            contract=contract_builder.build(),
+        )
+
+    def add_host_rule(self):
+        """Adds a host rule to the url map."""
+        bs_upsert = copy.deepcopy(self.__proto_upsert)
+        hr = copy.deepcopy(bs_upsert["hostRules"][0])
+        hr["hostPatterns"] = ["added.host1.com", "added.host2.com"]
+        hr["pathMatcher"]["pathRules"][0]["paths"] = ["/added/path"]
+        bs_upsert["hostRules"].append(hr)
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[bs_upsert],
+            description="Upsert L7 Load Balancer: " + self.__lb_name,
+            application=self.TEST_APP,
+        )
+
+        contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
+        self._add_contract_clauses(contract_builder, bs_upsert)
+
+        return st.OperationContract(
+            self.new_post_operation(title="add host rule", data=payload, path="tasks"),
+            contract=contract_builder.build(),
+        )
+
+    def update_host_rule(self):
+        """Updates a host rule to the url map."""
+        bs_upsert = copy.deepcopy(self.__proto_upsert)
+        hr = copy.deepcopy(bs_upsert["hostRules"][0])
+        hr["hostPatterns"] = ["updated.host1.com"]
+        hr["pathMatcher"]["pathRules"][0]["paths"] = ["/updated/path"]
+        bs_upsert["hostRules"].append(hr)
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[bs_upsert],
+            description="Upsert L7 Load Balancer: " + self.__lb_name,
+            application=self.TEST_APP,
+        )
+
+        contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
+        self._add_contract_clauses(contract_builder, bs_upsert)
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="update host rule", data=payload, path="tasks"
+            ),
+            contract=contract_builder.build(),
+        )
+
+    def add_cert(self, certname, title):
+        """Add cert to targetHttpProxy to make it a targetHttpsProxy."""
+        bs_upsert = copy.deepcopy(self.__proto_upsert)
+        bs_upsert["certificate"] = certname
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[bs_upsert],
+            description="Upsert L7 Load Balancer: " + self.__lb_name,
+            application=self.TEST_APP,
+        )
+
+        contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
+        self._add_contract_clauses(contract_builder, bs_upsert)
+
+        return st.OperationContract(
+            self.new_post_operation(title=title, data=payload, path="tasks"),
+            contract=contract_builder.build(),
+        )
+
+    def add_security_group(self):
+        """Associates a security group with the L7 load balancer."""
+        bindings = self.bindings
+        sec_group_payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "allowed": [
+                        {"ipProtocol": "tcp", "portRanges": ["80-80"]},
+                        {"ipProtocol": "tcp", "portRanges": ["8080-8080"]},
+                        {"ipProtocol": "tcp", "portRanges": ["443-443"]},
+                    ],
+                    "backingData": {"networks": ["default"]},
+                    "cloudProvider": "gce",
+                    "application": self.TEST_APP,
+                    "credentials": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    "description": "",
+                    "detail": "http",
+                    "ipIngress": [
+                        {
+                            "type": "tcp",
+                            "startPort": 80,
+                            "endPort": 80,
+                        },
+                        {
+                            "type": "tcp",
+                            "startPort": 8080,
+                            "endPort": 8080,
+                        },
+                        {
+                            "type": "tcp",
+                            "startPort": 443,
+                            "endPort": 443,
+                        },
+                    ],
+                    "name": self.__lb_name + "-rule",
+                    "network": "default",
+                    "region": "global",
+                    "securityGroupName": self.__lb_name + "-rule",
+                    "sourceRanges": ["0.0.0.0/0"],
+                    "targetTags": [self.__lb_name + "-tag"],
+                    "type": "upsertSecurityGroup",
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Create a Security Group for L7 operations.",
+            application=self.TEST_APP,
+        )
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Security Group Created", retryable_for_secs=30)
+            .list_resource("firewalls")
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "name", jp.STR_SUBSTR(self.__lb_name + "-rule")
+                )
+            )
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create security group", data=sec_group_payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
+
+    def delete_security_group(self):
+        """Deletes a security group."""
+        bindings = self.bindings
+        sec_group_payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "gce",
+                    "credentials": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    "regions": ["global"],
+                    "securityGroupName": self.__lb_name + "-rule",
+                    "type": "deleteSecurityGroup",
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Delete a Security Group.",
+            application=self.TEST_APP,
+        )
+
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Security Group Deleted", retryable_for_secs=30)
+            .list_resource("firewalls")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__lb_name + "-rule")
+                )
+            )
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete security group", data=sec_group_payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
+
+    def add_server_group(self):
+        """Adds a server group to the L7 LB."""
+        time.sleep(60)  # Wait for the L7 LB to be ready.
+        bindings = self.bindings
+        group_name = "{app}-{stack}-v000".format(
+            app=self.TEST_APP, stack=bindings["TEST_STACK"]
+        )
+        policy = {
+            "balancingMode": "UTILIZATION",
+            "namedPorts": [{"name": "http", "port": 80}],
+            "maxUtilization": 0.8,
+            "capacityScaler": 0.8,
         }
-      ],
-      'type': 'upsertLoadBalancer',
-      'availabilityZones': {bindings['TEST_GCE_REGION']: []},
-      'user': '[anonymous]'
-    }
 
-
-  def _get_bs_link(self, bs):
-    '''Make a fully-formatted backend service link.
-    '''
-    return (GCE_URL_PREFIX
-            + self.bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID']
-            + '/global/backendServices/' + bs)
-
-
-  def _get_hc_link(self, hc):
-    '''Make a fully-formatted health check link.
-    '''
-    return (GCE_URL_PREFIX
-            + self.bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID']
-            + '/global/healthChecks/' + hc)
-
-
-  def _set_all_hcs(self, upsert, hc):
-    '''Set all health checks in upsert to hc.
-    '''
-    upsert['defaultService']['healthCheck'] = hc
-    for host_rule in upsert['hostRules']:
-      path_matcher = host_rule['pathMatcher']
-      path_matcher['defaultService']['healthCheck'] = hc
-      for path_rule in path_matcher['pathRules']:
-        path_rule['backendService']['healthCheck'] = hc
-
-
-  def _add_contract_clauses(self, contract_builder, upsert):
-    '''Add the proper predicates to the contract builder for a given
-    upsert description.
-    '''
-    host_rules = upsert['hostRules'] # Host rules will be distinct.
-    backend_services = [upsert['defaultService']]
-    for host_rule in host_rules:
-      path_matcher = host_rule['pathMatcher']
-      backend_services.append(path_matcher['defaultService'])
-      for path_rule in path_matcher['pathRules']:
-        backend_services.append(path_rule['backendService'])
-    health_checks = [service['healthCheck'] for service in backend_services]
-
-    hc_clause_builder = (contract_builder
-                         .new_clause_builder('Health Checks Created',
-                                             retryable_for_secs=30)
-                         .list_resource('healthChecks'))
-    for hc in health_checks:
-      hc_clause_builder.AND(
-          ov_factory.value_list_contains(jp.DICT_MATCHES({
-              'name': jp.STR_EQ(hc['name']),
-              'httpHealthCheck': jp.DICT_MATCHES({
-                  'requestPath': jp.STR_EQ(hc['requestPath']),
-                  'port': jp.NUM_EQ(hc['port']),
-              })
-          })))
-
-    bs_clause_builder = (contract_builder.
-                         new_clause_builder('Backend Services Created',
-                                            retryable_for_secs=30).
-                         list_resource('backendServices'))
-    for bs in backend_services:
-      bs_clause_builder.AND(ov_factory.value_list_contains(jp.DICT_MATCHES({
-          'name': jp.STR_EQ(bs['name']),
-          'portName': jp.STR_EQ('http'),
-          'healthChecks':
-              jp.LIST_MATCHES([
-                  jp.STR_EQ(self._get_hc_link(bs['healthCheck']['name']))])
-        })))
-
-    url_map_clause_builder = (contract_builder
-                              .new_clause_builder('Url Map Created',
-                                                  retryable_for_secs=30)
-                              .list_resource('urlMaps'))
-    for hr in host_rules:
-      pm = hr['pathMatcher']
-
-      path_rules_spec = [
-          jp.DICT_MATCHES({
-              'service': jp.STR_EQ(
-                  self._get_bs_link(pr['backendService']['name'])),
-              'paths':
-                  jp.LIST_MATCHES([jp.STR_EQ(path) for path in pr['paths']])
-              })
-          for pr in pm['pathRules']]
-
-      path_matchers_spec = {
-        'defaultService':
-            jp.STR_EQ(self._get_bs_link(pm['defaultService']['name'])),
-        'pathRules':  jp.LIST_MATCHES(path_rules_spec)
-        }
-
-      url_map_clause_builder.AND(
-          ov_factory.value_list_contains(jp.DICT_MATCHES({
-              'name': jp.STR_EQ(self.__lb_name),
-              'defaultService':
-                  jp.STR_EQ(self._get_bs_link(upsert['defaultService']['name'])),
-              'hostRules/hosts':
-                  jp.LIST_MATCHES([jp.STR_SUBSTR(host)
-                                   for host in hr['hostPatterns']]),
-              'pathMatchers':
-                  jp.LIST_MATCHES([jp.DICT_MATCHES(path_matchers_spec)]),
-          })))
-
-    port_string = '443-443'
-    if upsert['certificate'] == '':
-      port_string = '%s-%s' % (upsert['portRange'], upsert['portRange'])
-
-    (contract_builder.new_clause_builder('Forwarding Rule Created',
-                                         retryable_for_secs=30)
-     .list_resource('globalForwardingRules')
-     .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES({
-          'name': jp.STR_EQ(self.__lb_name),
-          'portRange': jp.STR_EQ(port_string)
-          }))))
-
-    proxy_clause_builder = contract_builder.new_clause_builder(
-      'Target Proxy Created', retryable_for_secs=30)
-    self._add_proxy_clause(upsert['certificate'], proxy_clause_builder)
-
-
-  def _add_proxy_clause(self, certificate, proxy_clause_builder):
-    target_proxy_name = '%s-target-%s-proxy'
-    if certificate:
-      target_proxy_name = target_proxy_name % (self.__lb_name, 'https')
-      (proxy_clause_builder.list_resource('targetHttpsProxies')
-       .EXPECT(ov_factory.value_list_path_contains(
-           'name', jp.STR_EQ(target_proxy_name))))
-    else:
-      target_proxy_name = target_proxy_name % (self.__lb_name, 'http')
-      (proxy_clause_builder.list_resource('targetHttpProxies')
-       .EXPECT(ov_factory.value_list_path_contains(
-           'name', jp.STR_EQ(target_proxy_name))))
-
-
-  def upsert_full_load_balancer(self):
-    '''Upserts L7 LB with full hostRules, pathMatchers, etc.
-
-    Calls the upsertLoadBalancer operation with a payload, then verifies that
-    the expected resources are visible on GCP.
-    '''
-    hc = copy.deepcopy(self.__proto_hc)
-    hc['requestPath'] = '/'
-    hc['port'] = 80
-    upsert = copy.deepcopy(self.__proto_upsert)
-    self._set_all_hcs(upsert, hc)
-
-    payload = self.agent.make_json_payload_from_kwargs(
-      job=[upsert],
-      description='Upsert L7 Load Balancer: ' + self.__lb_name,
-      application=self.TEST_APP
-    )
-
-    contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
-    self._add_contract_clauses(contract_builder, upsert)
-
-    return st.OperationContract(
-      self.new_post_operation(title='upsert full http lb',
-                              data=payload, path='tasks'),
-      contract=contract_builder.build()
-    )
-
-
-  def upsert_min_load_balancer(self):
-    '''Upserts a L7 LB with the minimum description.
-    '''
-    upsert = copy.deepcopy(self.__proto_upsert)
-    upsert['hostRules'] = []
-    upsert['certificate'] = '' # Test HTTP upsert, not HTTPS.
-
-    payload = self.agent.make_json_payload_from_kwargs(
-      job=[upsert],
-      description='Upsert L7 Load Balancer: ' + self.__lb_name,
-      application=self.TEST_APP
-    )
-
-    contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
-    self._add_contract_clauses(contract_builder, upsert)
-
-    return st.OperationContract(
-      self.new_post_operation(title='upsert min http lb',
-                              data=payload, path='tasks'),
-      contract=contract_builder.build()
-    )
-
-
-  def delete_http_load_balancer(self):
-    '''Deletes the L7 LB.
-    '''
-    bindings = self.bindings
-    delete = copy.deepcopy(self.__proto_delete)
-
-    payload = self.agent.make_json_payload_from_kwargs(
-      job=[delete],
-      description='Delete L7 Load Balancer: {0} in {1}'.format(
-        self.__lb_name,
-        bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      ),
-      application=self.TEST_APP
-    )
-    contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (contract_builder.new_clause_builder('Health Check Removed',
-                                         retryable_for_secs=30)
-     .list_resource('healthChecks')
-     .EXPECT(ov_factory.value_list_path_excludes(
-         'name', jp.STR_SUBSTR(self.__proto_hc['name'])))
-    )
-    (contract_builder.new_clause_builder('Url Map Removed',
-                                         retryable_for_secs=30)
-     .list_resource('urlMaps')
-     .EXPECT(ov_factory.value_list_path_excludes(
-         'name', jp.STR_SUBSTR(self.__lb_name)))
-    )
-    (contract_builder.new_clause_builder('Forwarding Rule Removed',
-                                         retryable_for_secs=30)
-     .list_resource('globalForwardingRules')
-     .EXPECT(ov_factory.value_list_path_excludes(
-         'name', jp.STR_SUBSTR(self.__lb_name)))
-    )
-
-    return st.OperationContract(
-      self.new_post_operation(
-        title='delete_http_load_balancer', data=payload, path='tasks'),
-      contract=contract_builder.build())
-
-
-  def change_health_check(self):
-    '''Changes the health check associated with the LB.
-    '''
-    upsert = copy.deepcopy(self.__proto_upsert)
-    hc = copy.deepcopy(self.__proto_hc)
-    hc['requestPath'] = '/changedPath'
-    hc['port'] = 8080
-    self._set_all_hcs(upsert, hc)
-
-    payload = self.agent.make_json_payload_from_kwargs(
-      job=[upsert],
-      description='Upsert L7 Load Balancer: ' + self.__lb_name,
-      application=self.TEST_APP
-    )
-
-    contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
-    self._add_contract_clauses(contract_builder, upsert)
-
-    return st.OperationContract(
-      self.new_post_operation(title='change health checks',
-                              data=payload, path='tasks'),
-      contract=contract_builder.build()
-    )
-
-
-  def change_backend_service(self):
-    '''Changes the default backend service associated with the LB.
-    '''
-    hc = copy.deepcopy(self.__proto_hc)
-    bs_upsert = copy.deepcopy(self.__proto_upsert)
-    hc['name'] = 'updated-' + self.TEST_APP
-    hc['requestPath'] = '/changedPath1'
-    hc['port'] = 8080
-
-    bs_upsert['defaultService']['healthCheck'] = hc
-    payload = self.agent.make_json_payload_from_kwargs(
-      job=[bs_upsert],
-      description='Upsert L7 Load Balancer: ' + self.__lb_name,
-      application=self.TEST_APP
-    )
-
-    contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
-    self._add_contract_clauses(contract_builder, bs_upsert)
-
-    return st.OperationContract(
-      self.new_post_operation(title='change backend services',
-                              data=payload, path='tasks'),
-      contract=contract_builder.build()
-    )
-
-
-  def add_host_rule(self):
-    '''Adds a host rule to the url map.
-    '''
-    bs_upsert = copy.deepcopy(self.__proto_upsert)
-    hr = copy.deepcopy(bs_upsert['hostRules'][0])
-    hr['hostPatterns'] = ['added.host1.com', 'added.host2.com']
-    hr['pathMatcher']['pathRules'][0]['paths'] = ['/added/path']
-    bs_upsert['hostRules'].append(hr)
-
-    payload = self.agent.make_json_payload_from_kwargs(
-      job=[bs_upsert],
-      description='Upsert L7 Load Balancer: ' + self.__lb_name,
-      application=self.TEST_APP
-    )
-
-    contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
-    self._add_contract_clauses(contract_builder, bs_upsert)
-
-    return st.OperationContract(
-      self.new_post_operation(title='add host rule',
-                              data=payload, path='tasks'),
-      contract=contract_builder.build()
-    )
-
-
-  def update_host_rule(self):
-    '''Updates a host rule to the url map.
-    '''
-    bs_upsert = copy.deepcopy(self.__proto_upsert)
-    hr = copy.deepcopy(bs_upsert['hostRules'][0])
-    hr['hostPatterns'] = ['updated.host1.com']
-    hr['pathMatcher']['pathRules'][0]['paths'] = ['/updated/path']
-    bs_upsert['hostRules'].append(hr)
-
-    payload = self.agent.make_json_payload_from_kwargs(
-      job=[bs_upsert],
-      description='Upsert L7 Load Balancer: ' + self.__lb_name,
-      application=self.TEST_APP
-    )
-
-    contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
-    self._add_contract_clauses(contract_builder, bs_upsert)
-
-    return st.OperationContract(
-      self.new_post_operation(title='update host rule',
-                              data=payload, path='tasks'),
-      contract=contract_builder.build()
-    )
-
-
-  def add_cert(self, certname, title):
-    '''Add cert to targetHttpProxy to make it a targetHttpsProxy.
-    '''
-    bs_upsert = copy.deepcopy(self.__proto_upsert)
-    bs_upsert['certificate'] = certname
-
-    payload = self.agent.make_json_payload_from_kwargs(
-      job=[bs_upsert],
-      description='Upsert L7 Load Balancer: ' + self.__lb_name,
-      application=self.TEST_APP
-    )
-
-    contract_builder = gcp.GcpContractBuilder(self.gcp_observer)
-    self._add_contract_clauses(contract_builder, bs_upsert)
-
-    return st.OperationContract(
-      self.new_post_operation(title=title,
-                              data=payload, path='tasks'),
-      contract=contract_builder.build()
-    )
-
-
-  def add_security_group(self):
-    '''Associates a security group with the L7 load balancer.
-    '''
-    bindings = self.bindings
-    sec_group_payload = self.agent.make_json_payload_from_kwargs(
-      job=[
-        {
-          'allowed': [
-            {
-              'ipProtocol': 'tcp',
-              'portRanges': ['80-80']
-            },
-            {
-              'ipProtocol': 'tcp',
-              'portRanges': ['8080-8080']
-            },
-            {
-              'ipProtocol': 'tcp',
-              'portRanges': ['443-443']
-            }
-          ],
-          'backingData': {'networks': ['default']},
-          'cloudProvider': 'gce',
-          'application': self.TEST_APP,
-          'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-          'description': '',
-          'detail': 'http',
-          'ipIngress': [
-            {
-              'type': 'tcp',
-              'startPort': 80,
-              'endPort': 80,
-            },
-            {
-              'type': 'tcp',
-              'startPort': 8080,
-              'endPort': 8080,
-            },
-            {
-              'type': 'tcp',
-              'startPort': 443,
-              'endPort': 443,
-            }
-          ],
-          'name': self.__lb_name + '-rule',
-          'network': 'default',
-          'region': 'global',
-          'securityGroupName': self.__lb_name + '-rule',
-          'sourceRanges': ['0.0.0.0/0'],
-          'targetTags': [self.__lb_name + '-tag'],
-          'type': 'upsertSecurityGroup',
-          'user': '[anonymous]'
-        }
-      ],
-      description='Create a Security Group for L7 operations.',
-      application=self.TEST_APP
-    )
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Security Group Created',
-                                retryable_for_secs=30)
-     .list_resource('firewalls')
-     .EXPECT(ov_factory.value_list_path_contains(
-         'name', jp.STR_SUBSTR(self.__lb_name + '-rule'))))
-
-    return st.OperationContract(
-      self.new_post_operation(title='create security group',
-                              data=sec_group_payload, path='tasks'),
-      contract=builder.build()
-    )
-
-  def delete_security_group(self):
-    '''Deletes a security group.
-    '''
-    bindings = self.bindings
-    sec_group_payload = self.agent.make_json_payload_from_kwargs(
-      job=[
-        {
-          'cloudProvider': 'gce',
-          'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-          'regions': ['global'],
-          'securityGroupName': self.__lb_name + '-rule',
-          'type': 'deleteSecurityGroup',
-          'user': '[anonymous]'
-        }
-      ],
-      description='Delete a Security Group.',
-      application=self.TEST_APP
-    )
-
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Security Group Deleted',
-                                retryable_for_secs=30)
-     .list_resource('firewalls')
-     .EXPECT(ov_factory.value_list_path_excludes(
-         'name', jp.STR_SUBSTR(self.__lb_name + '-rule'))))
-
-    return st.OperationContract(
-      self.new_post_operation(title='delete security group',
-                              data=sec_group_payload, path='tasks'),
-      contract=builder.build()
-    )
-
-  def add_server_group(self):
-    '''Adds a server group to the L7 LB.
-    '''
-    time.sleep(60) # Wait for the L7 LB to be ready.
-    bindings = self.bindings
-    group_name = '{app}-{stack}-v000'.format(app=self.TEST_APP,
-                                             stack=bindings['TEST_STACK'])
-    policy = {
-      'balancingMode': 'UTILIZATION',
-      'namedPorts': [{'name': 'http', 'port': 80}],
-      'maxUtilization': 0.8,
-      'capacityScaler': 0.8
-    }
-
-    payload = self.agent.make_json_payload_from_kwargs(
-      job=[{
-        'cloudProvider': 'gce',
-        'application': self.TEST_APP,
-        'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-        'strategy':'',
-        'capacity': {'min':1, 'max':1, 'desired':1},
-        'targetSize': 1,
-        'image': bindings['TEST_GCE_IMAGE_NAME'],
-        'zone': bindings['TEST_GCE_ZONE'],
-        'stack': bindings['TEST_STACK'],
-        'instanceType': 'f1-micro',
-        'type': 'createServerGroup',
-        'tags': [self.__lb_name + '-tag'],
-        'loadBalancers': [self.__lb_name],
-        'backendServices': {self.__lb_name: ['bs-' + self.TEST_APP]},
-        'disableTraffic': False,
-        'loadBalancingPolicy': {
-          'balancingMode': 'UTILIZATION',
-          'namedPorts': [{'name': 'http', 'port': 80}],
-          'maxUtilization': 0.8,
-          'capacityScaler': 0.8
-        },
-        'availabilityZones': {
-          bindings['TEST_GCE_REGION']: [bindings['TEST_GCE_ZONE']]
-        },
-        'instanceMetadata': {
-          'global-load-balancer-names': self.__lb_name,
-          'backend-service-names': 'bs-' + self.TEST_APP,
-          'load-balancing-policy': json.dumps(policy)
-        },
-        'account': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-        'authScopes': ['compute'],
-        'user': '[anonymous]'
-      }],
-      description='Create Server Group in ' + group_name,
-      application=self.TEST_APP
-    )
-
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Managed Instance Group Added',
-                                retryable_for_secs=30)
-     .inspect_resource('instanceGroupManagers', group_name)
-     .EXPECT(ov_factory.value_list_path_contains('targetSize', jp.NUM_EQ(1)))
-    )
-
-    return st.OperationContract(
-      self.new_post_operation(title='create server group',
-                              data=payload, path='tasks'),
-      contract=builder.build()
-    )
-
-
-  def delete_server_group(self):
-    """Creates OperationContract for deleteServerGroup.
-
-    To verify the operation, we just check that the GCP managed instance group
-    is no longer visible on GCP (or is in the process of terminating).
-    """
-    bindings = self.bindings
-    group_name = '{app}-{stack}-v000'.format(
-        app=self.TEST_APP, stack=bindings['TEST_STACK'])
-
-    payload = self.agent.make_json_payload_from_kwargs(
-      job=[{
-        'cloudProvider': 'gce',
-        'serverGroupName': group_name,
-        'region': bindings['TEST_GCE_REGION'],
-        'zone': bindings['TEST_GCE_ZONE'],
-        'type': 'destroyServerGroup',
-        'regions': [bindings['TEST_GCE_REGION']],
-        'zones': [bindings['TEST_GCE_ZONE']],
-        'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-        'user': '[anonymous]'
-      }],
-      application=self.TEST_APP,
-      description='DestroyServerGroup: ' + group_name
-    )
-
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Managed Instance Group Removed')
-     .inspect_resource('instanceGroupManagers', group_name)
-     .EXPECT(
-         ov_factory.error_list_contains(gcp.HttpErrorPredicate(http_code=404)))
-     .OR(ov_factory.value_list_path_contains('targetSize', jp.NUM_EQ(0))))
-
-    (builder.new_clause_builder('Instances Are Removed',
-                                retryable_for_secs=30)
-     .list_resource('instances')
-     .EXPECT(ov_factory.value_list_path_excludes(
-         'name', jp.STR_SUBSTR(group_name))))
-
-    return st.OperationContract(
-      self.new_post_operation(
-        title='delete server group', data=payload, path='tasks'),
-      contract=builder.build()
-    )
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "gce",
+                    "application": self.TEST_APP,
+                    "credentials": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    "strategy": "",
+                    "capacity": {"min": 1, "max": 1, "desired": 1},
+                    "targetSize": 1,
+                    "image": bindings["TEST_GCE_IMAGE_NAME"],
+                    "zone": bindings["TEST_GCE_ZONE"],
+                    "stack": bindings["TEST_STACK"],
+                    "instanceType": "f1-micro",
+                    "type": "createServerGroup",
+                    "tags": [self.__lb_name + "-tag"],
+                    "loadBalancers": [self.__lb_name],
+                    "backendServices": {self.__lb_name: ["bs-" + self.TEST_APP]},
+                    "disableTraffic": False,
+                    "loadBalancingPolicy": {
+                        "balancingMode": "UTILIZATION",
+                        "namedPorts": [{"name": "http", "port": 80}],
+                        "maxUtilization": 0.8,
+                        "capacityScaler": 0.8,
+                    },
+                    "availabilityZones": {
+                        bindings["TEST_GCE_REGION"]: [bindings["TEST_GCE_ZONE"]]
+                    },
+                    "instanceMetadata": {
+                        "global-load-balancer-names": self.__lb_name,
+                        "backend-service-names": "bs-" + self.TEST_APP,
+                        "load-balancing-policy": json.dumps(policy),
+                    },
+                    "account": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    "authScopes": ["compute"],
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Create Server Group in " + group_name,
+            application=self.TEST_APP,
+        )
+
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder(
+                "Managed Instance Group Added", retryable_for_secs=30
+            )
+            .inspect_resource("instanceGroupManagers", group_name)
+            .EXPECT(ov_factory.value_list_path_contains("targetSize", jp.NUM_EQ(1)))
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create server group", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
+
+    def delete_server_group(self):
+        """Creates OperationContract for deleteServerGroup.
+
+        To verify the operation, we just check that the GCP managed instance group
+        is no longer visible on GCP (or is in the process of terminating).
+        """
+        bindings = self.bindings
+        group_name = "{app}-{stack}-v000".format(
+            app=self.TEST_APP, stack=bindings["TEST_STACK"]
+        )
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "gce",
+                    "serverGroupName": group_name,
+                    "region": bindings["TEST_GCE_REGION"],
+                    "zone": bindings["TEST_GCE_ZONE"],
+                    "type": "destroyServerGroup",
+                    "regions": [bindings["TEST_GCE_REGION"]],
+                    "zones": [bindings["TEST_GCE_ZONE"]],
+                    "credentials": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    "user": "[anonymous]",
+                }
+            ],
+            application=self.TEST_APP,
+            description="DestroyServerGroup: " + group_name,
+        )
+
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Managed Instance Group Removed")
+            .inspect_resource("instanceGroupManagers", group_name)
+            .EXPECT(
+                ov_factory.error_list_contains(gcp.HttpErrorPredicate(http_code=404))
+            )
+            .OR(ov_factory.value_list_path_contains("targetSize", jp.NUM_EQ(0)))
+        )
+
+        (
+            builder.new_clause_builder("Instances Are Removed", retryable_for_secs=30)
+            .list_resource("instances")
+            .EXPECT(
+                ov_factory.value_list_path_excludes("name", jp.STR_SUBSTR(group_name))
+            )
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete server group", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )

--- a/testing/citest/tests/google_http_lb_upsert_server_test.py
+++ b/testing/citest/tests/google_http_lb_upsert_server_test.py
@@ -34,48 +34,45 @@ from google_http_lb_upsert_test import GoogleHttpLoadBalancerTest
 
 # pylint: disable=too-many-public-methods
 class GoogleHttpLoadBalancerServerTest(GoogleHttpLoadBalancerTest):
-  '''Test fixture for Http LB test.
-  '''
+    """Test fixture for Http LB test."""
 
+    @classmethod
+    def setUpClass(cls):
+        super(GoogleHttpLoadBalancerServerTest, cls).setUpClass()
 
-  @classmethod
-  def setUpClass(cls):
-    super(GoogleHttpLoadBalancerServerTest, cls).setUpClass()
+    @classmethod
+    def tearDownClass(cls):
+        super(GoogleHttpLoadBalancerServerTest, cls).tearDownClass()
 
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            GoogleHttpLoadBalancerTestScenario
+        )
 
-  @classmethod
-  def tearDownClass(cls):
-    super(GoogleHttpLoadBalancerServerTest, cls).tearDownClass()
+    def test_f_add_server_group(self):
+        self.run_test_case(self.scenario.add_server_group(), poll_every_secs=5)
 
-
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-      GoogleHttpLoadBalancerTestScenario)
-
-  def test_f_add_server_group(self):
-    self.run_test_case(self.scenario.add_server_group(),
-                       poll_every_secs=5)
-
-  def test_n_delete_server_group(self):
-    self.run_test_case(self.scenario.delete_server_group(),
-                       poll_every_secs=5)
+    def test_n_delete_server_group(self):
+        self.run_test_case(self.scenario.delete_server_group(), poll_every_secs=5)
 
 
 def main():
-  """Implements the main method running this http lb test."""
+    """Implements the main method running this http lb test."""
 
-  defaults = {
-      'TEST_STACK': str(GoogleHttpLoadBalancerTestScenario.DEFAULT_TEST_ID),
-      'TEST_APP': ('gcphttplbservertest' +
-                   GoogleHttpLoadBalancerTestScenario.DEFAULT_TEST_ID)
-  }
+    defaults = {
+        "TEST_STACK": str(GoogleHttpLoadBalancerTestScenario.DEFAULT_TEST_ID),
+        "TEST_APP": (
+            "gcphttplbservertest" + GoogleHttpLoadBalancerTestScenario.DEFAULT_TEST_ID
+        ),
+    }
 
-  return citest.base.TestRunner.main(
-      parser_inits=[GoogleHttpLoadBalancerTestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[GoogleHttpLoadBalancerServerTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[GoogleHttpLoadBalancerTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[GoogleHttpLoadBalancerServerTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/google_http_lb_upsert_test.py
+++ b/testing/citest/tests/google_http_lb_upsert_test.py
@@ -32,173 +32,184 @@ import citest.gcp_testing as gcp
 import citest.service_testing as st
 
 # Spinnaker modules.
-from google_http_lb_upsert_scenario import GoogleHttpLoadBalancerTestScenario, \
-  SCOPES
+from google_http_lb_upsert_scenario import GoogleHttpLoadBalancerTestScenario, SCOPES
 
 
 # pylint: disable=too-many-public-methods
 class GoogleHttpLoadBalancerTest(st.AgentTestCase):
-  '''Test fixture for Http LB test.
-  '''
+    """Test fixture for Http LB test."""
 
-  FIRST_CERT = ''
-  SECOND_CERT = ''
+    FIRST_CERT = ""
+    SECOND_CERT = ""
 
+    @staticmethod
+    def make_ssl_cert(name):
+        """Create and return an SslCertificate in dictionary format."""
+        key = crypto.PKey()
+        key.generate_key(crypto.TYPE_RSA, 2048)
+        cert = crypto.X509()
+        cert.get_subject().C = "US"
+        cert.get_subject().ST = "New York"
+        cert.get_subject().L = "New York City"
+        cert.get_subject().O = "Google"
+        cert.get_subject().OU = "Spinnaker"
+        cert.get_subject().CN = "localhost"
+        cert.set_serial_number(4096)
+        cert.gmtime_adj_notBefore(0)
+        cert.gmtime_adj_notAfter(24 * 60 * 60)
+        cert.set_issuer(cert.get_subject())
+        cert.set_pubkey(key)
+        cert.sign(key, "sha1")
 
-  @staticmethod
-  def make_ssl_cert(name):
-    '''Create and return an SslCertificate in dictionary format.
-    '''
-    key = crypto.PKey()
-    key.generate_key(crypto.TYPE_RSA, 2048)
-    cert = crypto.X509()
-    cert.get_subject().C = "US"
-    cert.get_subject().ST = "New York"
-    cert.get_subject().L = "New York City"
-    cert.get_subject().O = "Google"
-    cert.get_subject().OU = "Spinnaker"
-    cert.get_subject().CN = "localhost"
-    cert.set_serial_number(4096)
-    cert.gmtime_adj_notBefore(0)
-    cert.gmtime_adj_notAfter(24 * 60 * 60)
-    cert.set_issuer(cert.get_subject())
-    cert.set_pubkey(key)
-    cert.sign(key, 'sha1')
+        return {
+            "name": name,
+            "privateKey": bytes.decode(
+                crypto.dump_privatekey(crypto.FILETYPE_PEM, key)
+            ),
+            "certificate": bytes.decode(
+                crypto.dump_certificate(crypto.FILETYPE_PEM, cert)
+            ),
+        }
 
-    return {
-      'name': name,
-      'privateKey': bytes.decode(
-          crypto.dump_privatekey(crypto.FILETYPE_PEM, key)),
-      'certificate': bytes.decode(
-          crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
-    }
+    @classmethod
+    def setUpClass(cls):
+        runner = citest.base.TestRunner.global_runner()
+        scenario = runner.get_shared_data(GoogleHttpLoadBalancerTestScenario)
+        bindings = scenario.bindings
+        cls.FIRST_CERT = "first-cert-%s" % (bindings["TEST_APP"])
+        cls.SECOND_CERT = "second-cert-%s" % (bindings["TEST_APP"])
+        cls.UPDATED_HC = "updated-%s" % (bindings["TEST_APP"])
+        managed_region = bindings["TEST_GCE_REGION"]
+        title = "Check Quota for {0}".format(scenario.__class__.__name__)
 
+        verify_results = gcp.verify_quota(
+            title,
+            scenario.gcp_observer,
+            project_quota=GoogleHttpLoadBalancerTestScenario.MINIMUM_PROJECT_QUOTA,
+            regions=[
+                (
+                    managed_region,
+                    GoogleHttpLoadBalancerTestScenario.MINIMUM_REGION_QUOTA,
+                )
+            ],
+        )
+        if not verify_results:
+            raise RuntimeError("Insufficient Quota: {0}".format(verify_results))
 
-  @classmethod
-  def setUpClass(cls):
-    runner = citest.base.TestRunner.global_runner()
-    scenario = runner.get_shared_data(GoogleHttpLoadBalancerTestScenario)
-    bindings = scenario.bindings
-    cls.FIRST_CERT = 'first-cert-%s' % (bindings['TEST_APP'])
-    cls.SECOND_CERT = 'second-cert-%s'  % (bindings['TEST_APP'])
-    cls.UPDATED_HC = 'updated-%s' % (bindings['TEST_APP'])
-    managed_region = bindings['TEST_GCE_REGION']
-    title = 'Check Quota for {0}'.format(scenario.__class__.__name__)
+        # No predicates against this agent, context is empty.
+        context = ExecutionContext()
+        compute_agent = gcp.GcpComputeAgent.make_agent(
+            scopes=SCOPES, credentials_path=bindings["GCE_CREDENTIALS_PATH"]
+        )
+        compute_agent.invoke_resource(
+            context,
+            "insert",
+            resource_type="sslCertificates",
+            project=bindings["GOOGLE_PRIMARY_MANAGED_PROJECT_ID"],
+            body=cls.make_ssl_cert(cls.FIRST_CERT),
+        )
+        compute_agent.invoke_resource(
+            context,
+            "insert",
+            resource_type="sslCertificates",
+            project=bindings["GOOGLE_PRIMARY_MANAGED_PROJECT_ID"],
+            body=cls.make_ssl_cert(cls.SECOND_CERT),
+        )
 
-    verify_results = gcp.verify_quota(
-      title,
-      scenario.gcp_observer,
-      project_quota=GoogleHttpLoadBalancerTestScenario.MINIMUM_PROJECT_QUOTA,
-      regions=[(managed_region,
-                GoogleHttpLoadBalancerTestScenario.MINIMUM_REGION_QUOTA)]
-    )
-    if not verify_results:
-      raise RuntimeError('Insufficient Quota: {0}'.format(verify_results))
+    @classmethod
+    def tearDownClass(cls):
+        runner = citest.base.TestRunner.global_runner()
+        scenario = runner.get_shared_data(GoogleHttpLoadBalancerTestScenario)
+        bindings = scenario.bindings
+        context = ExecutionContext()
+        compute_agent = gcp.GcpComputeAgent.make_agent(
+            scopes=SCOPES, credentials_path=bindings["GCE_CREDENTIALS_PATH"]
+        )
+        compute_agent.invoke_resource(
+            context,
+            "delete",
+            resource_type="sslCertificates",
+            project=bindings["GOOGLE_PRIMARY_MANAGED_PROJECT_ID"],
+            sslCertificate=cls.FIRST_CERT,
+        )
+        compute_agent.invoke_resource(
+            context,
+            "delete",
+            resource_type="sslCertificates",
+            project=bindings["GOOGLE_PRIMARY_MANAGED_PROJECT_ID"],
+            sslCertificate=cls.SECOND_CERT,
+        )
+        # Delete the orphaned, updated health check.
+        compute_agent.invoke_resource(
+            context,
+            "delete",
+            resource_type="healthChecks",
+            project=bindings["GOOGLE_PRIMARY_MANAGED_PROJECT_ID"],
+            healthCheck=cls.UPDATED_HC,
+        )
 
-    # No predicates against this agent, context is empty.
-    context = ExecutionContext()
-    compute_agent = (
-      gcp.GcpComputeAgent
-      .make_agent(scopes=SCOPES,
-                  credentials_path=bindings['GCE_CREDENTIALS_PATH']))
-    compute_agent.invoke_resource(context,
-                                  'insert',
-                                  resource_type='sslCertificates',
-                                  project=bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID'],
-                                  body=cls.make_ssl_cert(cls.FIRST_CERT))
-    compute_agent.invoke_resource(context,
-                                  'insert',
-                                  resource_type='sslCertificates',
-                                  project=bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID'],
-                                  body=cls.make_ssl_cert(cls.SECOND_CERT))
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            GoogleHttpLoadBalancerTestScenario
+        )
 
+    def test_a_upsert_min_lb(self):
+        self.run_test_case(self.scenario.upsert_min_load_balancer())
 
-  @classmethod
-  def tearDownClass(cls):
-    runner = citest.base.TestRunner.global_runner()
-    scenario = runner.get_shared_data(GoogleHttpLoadBalancerTestScenario)
-    bindings = scenario.bindings
-    context = ExecutionContext()
-    compute_agent = (
-      gcp.GcpComputeAgent
-      .make_agent(scopes=SCOPES,
-                  credentials_path=bindings['GCE_CREDENTIALS_PATH']))
-    compute_agent.invoke_resource(context,
-                                  'delete',
-                                  resource_type='sslCertificates',
-                                  project=bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID'],
-                                  sslCertificate=cls.FIRST_CERT)
-    compute_agent.invoke_resource(context,
-                                  'delete',
-                                  resource_type='sslCertificates',
-                                  project=bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID'],
-                                  sslCertificate=cls.SECOND_CERT)
-    # Delete the orphaned, updated health check.
-    compute_agent.invoke_resource(context,
-                                  'delete',
-                                  resource_type='healthChecks',
-                                  project=bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID'],
-                                  healthCheck=cls.UPDATED_HC)
+    def test_b_delete_lb(self):
+        self.run_test_case(self.scenario.delete_http_load_balancer())
 
+    def test_d_upsert_full_lb(self):
+        self.run_test_case(self.scenario.upsert_full_load_balancer())
 
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-        GoogleHttpLoadBalancerTestScenario)
+    def test_e_add_security_group(self):
+        self.run_test_case(self.scenario.add_security_group())
 
-  def test_a_upsert_min_lb(self):
-    self.run_test_case(self.scenario.upsert_min_load_balancer())
+    # Test letters f and n are reserved for another test derived from this one.
 
-  def test_b_delete_lb(self):
-    self.run_test_case(self.scenario.delete_http_load_balancer())
+    def test_g_change_hc(self):
+        self.run_test_case(self.scenario.change_health_check())
 
-  def test_d_upsert_full_lb(self):
-    self.run_test_case(self.scenario.upsert_full_load_balancer())
+    def test_h_change_bs(self):
+        self.run_test_case(self.scenario.change_backend_service())
 
-  def test_e_add_security_group(self):
-    self.run_test_case(self.scenario.add_security_group())
+    def test_i_add_host_rule(self):
+        self.run_test_case(self.scenario.add_host_rule())
 
-  # Test letters f and n are reserved for another test derived from this one.
+    def test_j_update_host_rule(self):
+        self.run_test_case(self.scenario.update_host_rule())
 
-  def test_g_change_hc(self):
-    self.run_test_case(self.scenario.change_health_check())
+    def test_m_change_cert(self):
+        self.run_test_case(
+            self.scenario.add_cert(self.__class__.SECOND_CERT, "update cert")
+        )
 
-  def test_h_change_bs(self):
-    self.run_test_case(self.scenario.change_backend_service())
+    # Test letters f and n are reserved for another test derived from this one.
 
-  def test_i_add_host_rule(self):
-    self.run_test_case(self.scenario.add_host_rule())
+    def test_o_delete_lb(self):
+        self.run_test_case(self.scenario.delete_http_load_balancer())
 
-  def test_j_update_host_rule(self):
-    self.run_test_case(self.scenario.update_host_rule())
-
-  def test_m_change_cert(self):
-    self.run_test_case(self.scenario.add_cert(self.__class__.SECOND_CERT,
-                                              'update cert'))
-
-  # Test letters f and n are reserved for another test derived from this one.
-
-  def test_o_delete_lb(self):
-    self.run_test_case(self.scenario.delete_http_load_balancer())
-
-  def test_p_delete_security_group(self):
-    self.run_test_case(self.scenario.delete_security_group())
+    def test_p_delete_security_group(self):
+        self.run_test_case(self.scenario.delete_security_group())
 
 
 def main():
-  """Implements the main method running this http lb test."""
+    """Implements the main method running this http lb test."""
 
-  defaults = {
-      'TEST_STACK': str(GoogleHttpLoadBalancerTestScenario.DEFAULT_TEST_ID),
-      'TEST_APP': ('gcphttplbtest'
-                   + GoogleHttpLoadBalancerTestScenario.DEFAULT_TEST_ID)
-  }
+    defaults = {
+        "TEST_STACK": str(GoogleHttpLoadBalancerTestScenario.DEFAULT_TEST_ID),
+        "TEST_APP": (
+            "gcphttplbtest" + GoogleHttpLoadBalancerTestScenario.DEFAULT_TEST_ID
+        ),
+    }
 
-  return citest.base.TestRunner.main(
-      parser_inits=[GoogleHttpLoadBalancerTestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[GoogleHttpLoadBalancerTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[GoogleHttpLoadBalancerTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[GoogleHttpLoadBalancerTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/google_kato_test.py
+++ b/testing/citest/tests/google_kato_test.py
@@ -52,6 +52,7 @@ import citest.gcp_testing as gcp
 import citest.json_predicate as jp
 import citest.service_testing as st
 from citest.json_contract import ObservationPredicateFactory
+
 ov_factory = ObservationPredicateFactory()
 
 
@@ -60,620 +61,816 @@ import spinnaker_testing as sk
 import spinnaker_testing.kato as kato
 
 
-
 GCP_STANDARD_IMAGES = {
-  'centos-cloud': ['centos-7', 'centos-6'],
-  'coreos-cloud': ['coreos-stable', 'coreos-beta', 'coreos-alpha'],
-  'debian-cloud': ['debian-8'],
-  'opensuse-cloud': [''],
-  'rhel-cloud': ['rhel-7', 'rhel-6'],
-  'suse-cloud': [''],
-  'ubuntu-os-cloud': ['ubuntu-1604-lts', 'ubuntu-1404-lts',
-                      'ubuntu-1204-lts', 'ubuntu-1510'],
-  'windows-cloud': ['windows-2012-r2', 'windows-2008-r2']
+    "centos-cloud": ["centos-7", "centos-6"],
+    "coreos-cloud": ["coreos-stable", "coreos-beta", "coreos-alpha"],
+    "debian-cloud": ["debian-8"],
+    "opensuse-cloud": [""],
+    "rhel-cloud": ["rhel-7", "rhel-6"],
+    "suse-cloud": [""],
+    "ubuntu-os-cloud": [
+        "ubuntu-1604-lts",
+        "ubuntu-1404-lts",
+        "ubuntu-1204-lts",
+        "ubuntu-1510",
+    ],
+    "windows-cloud": ["windows-2012-r2", "windows-2008-r2"],
 }
 
 
 class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
-  # _instance_names and _instance_zones will be set in create_instances_.
-  # We're breaking them out so that they can be shared by other methods,
-  # especially terminate.
-  use_instance_names = []
-  use_instance_zones = []
-  __use_lb_name = ''     # The load balancer name.
-  __use_lb_tp_name = ''  # The load balancer's target pool name.
-  __use_lb_hc_name = ''  # The load balancer's health check name.
-  __use_lb_target = ''   # The load balancer's 'target' resource.
-  __use_http_lb_name = '' # The HTTP load balancer name.
-  __use_http_lb_proxy_name = '' # The HTTP load balancer target proxy name.
-  __use_http_lb_hc_name = '' # The HTTP load balancer health check name.
-  __use_http_lb_bs_name = '' # The HTTP load balancer backend service name.
-  __use_http_lb_fr_name = '' # The HTTP load balancer forwarding rule.
-  __use_http_lb_map_name = '' # The HTTP load balancer url map name.
-  __use_http_lb_http_proxy_name = '' # The HTTP load balancer target http proxy.
+    # _instance_names and _instance_zones will be set in create_instances_.
+    # We're breaking them out so that they can be shared by other methods,
+    # especially terminate.
+    use_instance_names = []
+    use_instance_zones = []
+    __use_lb_name = ""  # The load balancer name.
+    __use_lb_tp_name = ""  # The load balancer's target pool name.
+    __use_lb_hc_name = ""  # The load balancer's health check name.
+    __use_lb_target = ""  # The load balancer's 'target' resource.
+    __use_http_lb_name = ""  # The HTTP load balancer name.
+    __use_http_lb_proxy_name = ""  # The HTTP load balancer target proxy name.
+    __use_http_lb_hc_name = ""  # The HTTP load balancer health check name.
+    __use_http_lb_bs_name = ""  # The HTTP load balancer backend service name.
+    __use_http_lb_fr_name = ""  # The HTTP load balancer forwarding rule.
+    __use_http_lb_map_name = ""  # The HTTP load balancer url map name.
+    __use_http_lb_http_proxy_name = ""  # The HTTP load balancer target http proxy.
 
-  @classmethod
-  def new_agent(cls, bindings):
-    """Implements the base class interface to create a new agent.
+    @classmethod
+    def new_agent(cls, bindings):
+        """Implements the base class interface to create a new agent.
 
-    This method is called by the base classes during setup/initialization.
+        This method is called by the base classes during setup/initialization.
 
-    Args:
-      bindings: The bindings dictionary with configuration information
-        that this factory can draw from to initialize. If the factory would
-        like additional custom bindings it could add them to initArgumentParser.
+        Args:
+          bindings: The bindings dictionary with configuration information
+            that this factory can draw from to initialize. If the factory would
+            like additional custom bindings it could add them to initArgumentParser.
 
-    Returns:
-      A citest.service_testing.BaseAgent that can interact with Kato.
-      This is the agent that test operations will be posted to.
-    """
-    return kato.new_agent(bindings)
+        Returns:
+          A citest.service_testing.BaseAgent that can interact with Kato.
+          This is the agent that test operations will be posted to.
+        """
+        return kato.new_agent(bindings)
 
-  def create_instances(self):
-    """Creates test adding instances to GCE.
+    def create_instances(self):
+        """Creates test adding instances to GCE.
 
-     Create three instances.
-       * The first two are of different types and zones, which
-         we'll check. Future tests will also be using these
-         from different zones (but same region).
+         Create three instances.
+           * The first two are of different types and zones, which
+             we'll check. Future tests will also be using these
+             from different zones (but same region).
 
-       * The third is a duplicate in the same zone as another
-         so we can check duplicate deletes (which limit one zone per call).
+           * The third is a duplicate in the same zone as another
+             so we can check duplicate deletes (which limit one zone per call).
 
-     We'll set the class properties use_instance_names and use_instance_zones
-     so that they can be communicated to future tests to reference.
+         We'll set the class properties use_instance_names and use_instance_zones
+         so that they can be communicated to future tests to reference.
 
-    Returns:
-      st.OperationContract
-    """
-    # We're going to make specific instances so we can refer to them later
-    # in tests involving instances. The instances are decorated to trace back
-    # to this particular run so as not to conflict with other tests that may
-    # be running.
-    self.use_instance_names = [
-        'katotest%sa' % self.test_id,
-        'katotest%sb' % self.test_id,
-        'katotest%sc' % self.test_id]
+        Returns:
+          st.OperationContract
+        """
+        # We're going to make specific instances so we can refer to them later
+        # in tests involving instances. The instances are decorated to trace back
+        # to this particular run so as not to conflict with other tests that may
+        # be running.
+        self.use_instance_names = [
+            "katotest%sa" % self.test_id,
+            "katotest%sb" % self.test_id,
+            "katotest%sc" % self.test_id,
+        ]
 
-    # Put the instance in zones. Force one zone to be different
-    # to ensure we're testing zone placement. We arent bothering
-    # with different regions at this time.
-    test_zone = self.bindings['TEST_GCE_ZONE']
-    other_zone = self.bindings['TEST_GCE_REGION'] + (
-        '-b' if test_zone[-1] != 'b' else '-c')
+        # Put the instance in zones. Force one zone to be different
+        # to ensure we're testing zone placement. We arent bothering
+        # with different regions at this time.
+        test_zone = self.bindings["TEST_GCE_ZONE"]
+        other_zone = self.bindings["TEST_GCE_REGION"] + (
+            "-b" if test_zone[-1] != "b" else "-c"
+        )
 
-    self.use_instance_zones = [test_zone, other_zone, test_zone]
+        self.use_instance_zones = [test_zone, other_zone, test_zone]
 
-    # Give the instances images and machine types. Again we're forcing
-    # one to be different to ensure that we're using the values.
-    image_name = [self.bindings['TEST_GCE_IMAGE_NAME'],
-                  'debian-9-stretch-v20190116',
-                  self.bindings['TEST_GCE_IMAGE_NAME']]
-    if image_name[0] == image_name[1]:
-      image_name[1] = 'ubuntu-minimal-1604-xenial-v20190122'
-    machine_type = ['f1-micro', 'g1-small', 'f1-micro']
+        # Give the instances images and machine types. Again we're forcing
+        # one to be different to ensure that we're using the values.
+        image_name = [
+            self.bindings["TEST_GCE_IMAGE_NAME"],
+            "debian-9-stretch-v20190116",
+            self.bindings["TEST_GCE_IMAGE_NAME"],
+        ]
+        if image_name[0] == image_name[1]:
+            image_name[1] = "ubuntu-minimal-1604-xenial-v20190122"
+        machine_type = ["f1-micro", "g1-small", "f1-micro"]
 
-    # The instance_spec will turn into the payload of instances we request.
-    instance_spec = []
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    for i in range(3):
-      # pylint: disable=bad-continuation
-      instance_spec.append(
-        {
-          'createGoogleInstanceDescription': {
-            'instanceName': self.use_instance_names[i],
-            'image': image_name[i],
-            'instanceType': machine_type[i],
-            'zone': self.use_instance_zones[i],
-            'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
-            }
-        })
+        # The instance_spec will turn into the payload of instances we request.
+        instance_spec = []
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        for i in range(3):
+            # pylint: disable=bad-continuation
+            instance_spec.append(
+                {
+                    "createGoogleInstanceDescription": {
+                        "instanceName": self.use_instance_names[i],
+                        "image": image_name[i],
+                        "instanceType": machine_type[i],
+                        "zone": self.use_instance_zones[i],
+                        "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    }
+                }
+            )
 
-      # Verify we created an instance, whether or not it boots.
-      (builder.new_clause_builder(
-          'Instance %d Created' % i, retryable_for_secs=90)
-            .aggregated_list_resource('instances')
-            .EXPECT(ov_factory.value_list_path_contains(
-                'name', jp.STR_SUBSTR(self.use_instance_names[i]))))
-      if i < 2:
-        # Verify the details are what we asked for.
-        # Since we've finished the created clause, this already exists.
-        # Note we're only checking the first two since they are different
-        # from one another. Anything after that isnt necessary for the test.
-        # The clause above already checked that they were all created so we
-        # can assume from this test that the details are ok as well.
-        (builder.new_clause_builder('Instance %d Details' % i)
-            .inspect_resource('instances', self.use_instance_names[i],
-                              zone=self.use_instance_zones[i])
-            .contains_path_value('machineType', machine_type[i]))
-        # Verify the instance eventually boots up.
-        # We can combine this with above, but we'll probably need
-        # to retry this, but not the above, so this way if the
-        # above is broken (wrong), we wont retry thinking it isnt there yet.
-        (builder.new_clause_builder('Instance %d Is Running' % i,
-                             retryable_for_secs=360)
-            .inspect_resource('instances', self.use_instance_names[i],
-                              zone=self.use_instance_zones[i])
-            .EXPECT(ov_factory.value_list_path_contains(
-                'status', jp.STR_EQ('RUNNING'))))
+            # Verify we created an instance, whether or not it boots.
+            (
+                builder.new_clause_builder(
+                    "Instance %d Created" % i, retryable_for_secs=90
+                )
+                .aggregated_list_resource("instances")
+                .EXPECT(
+                    ov_factory.value_list_path_contains(
+                        "name", jp.STR_SUBSTR(self.use_instance_names[i])
+                    )
+                )
+            )
+            if i < 2:
+                # Verify the details are what we asked for.
+                # Since we've finished the created clause, this already exists.
+                # Note we're only checking the first two since they are different
+                # from one another. Anything after that isnt necessary for the test.
+                # The clause above already checked that they were all created so we
+                # can assume from this test that the details are ok as well.
+                (
+                    builder.new_clause_builder("Instance %d Details" % i)
+                    .inspect_resource(
+                        "instances",
+                        self.use_instance_names[i],
+                        zone=self.use_instance_zones[i],
+                    )
+                    .contains_path_value("machineType", machine_type[i])
+                )
+                # Verify the instance eventually boots up.
+                # We can combine this with above, but we'll probably need
+                # to retry this, but not the above, so this way if the
+                # above is broken (wrong), we wont retry thinking it isnt there yet.
+                (
+                    builder.new_clause_builder(
+                        "Instance %d Is Running" % i, retryable_for_secs=360
+                    )
+                    .inspect_resource(
+                        "instances",
+                        self.use_instance_names[i],
+                        zone=self.use_instance_zones[i],
+                    )
+                    .EXPECT(
+                        ov_factory.value_list_path_contains(
+                            "status", jp.STR_EQ("RUNNING")
+                        )
+                    )
+                )
 
-    payload = self.agent.make_json_payload_from_object(instance_spec)
+        payload = self.agent.make_json_payload_from_object(instance_spec)
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='create_instances', data=payload, path='ops'),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(title="create_instances", data=payload, path="ops"),
+            contract=builder.build(),
+        )
 
-  def terminate_instances(self, names, zone):
-    """Creates test for removing specific instances.
+    def terminate_instances(self, names, zone):
+        """Creates test for removing specific instances.
 
-    Args:
-      names: A list of instance names to be removed.
-      zone: The zone containing the instances.
+        Args:
+          names: A list of instance names to be removed.
+          zone: The zone containing the instances.
 
-    Returns:
-      st.OperationContract
-    """
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    clause = (builder.new_clause_builder('Instances Deleted',
-                                         retryable_for_secs=30,
-                                         strict=True)
-              .aggregated_list_resource('instances'))
-    for name in names:
-      # If one of our instances still exists, it should be STOPPING.
-      name_matches_pred = jp.PathContainsPredicate('name', name)
-      is_stopping_pred = jp.PathEqPredicate('status', 'STOPPING')
+        Returns:
+          st.OperationContract
+        """
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        clause = builder.new_clause_builder(
+            "Instances Deleted", retryable_for_secs=30, strict=True
+        ).aggregated_list_resource("instances")
+        for name in names:
+            # If one of our instances still exists, it should be STOPPING.
+            name_matches_pred = jp.PathContainsPredicate("name", name)
+            is_stopping_pred = jp.PathEqPredicate("status", "STOPPING")
 
-      # We want the condition to apply to all the observed objects so we'll
-      # map the constraint over the observation. Otherwise, if dont map it,
-      # then we'd expect the constraint to hold somewhere among the observed
-      # objects, but not necessarily all of them.
-      clause.AND(
-          ov_factory.value_list_matches(
-              [jp.IF(name_matches_pred, is_stopping_pred)],
-              strict=True))
+            # We want the condition to apply to all the observed objects so we'll
+            # map the constraint over the observation. Otherwise, if dont map it,
+            # then we'd expect the constraint to hold somewhere among the observed
+            # objects, but not necessarily all of them.
+            clause.AND(
+                ov_factory.value_list_matches(
+                    [jp.IF(name_matches_pred, is_stopping_pred)], strict=True
+                )
+            )
 
-    # pylint: disable=bad-continuation
-    payload = self.agent.type_to_payload(
-          'terminateInstances',
-          {
-            'instanceIds': names,
-            'zone': zone,
-            'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
-          })
+        # pylint: disable=bad-continuation
+        payload = self.agent.type_to_payload(
+            "terminateInstances",
+            {
+                "instanceIds": names,
+                "zone": zone,
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+            },
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='terminate_instances', data=payload, path='gce/ops'),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="terminate_instances", data=payload, path="gce/ops"
+            ),
+            contract=builder.build(),
+        )
 
-  def upsert_google_server_group_tags(self):
-    # pylint: disable=bad-continuation
-    server_group_name = 'katotest-server-group'
-    payload = self.agent.type_to_payload(
-        'upsertGoogleServerGroupTagsDescription',
-        {
-          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-          'zone': self.bindings['TEST_GCE_ZONE'],
-          'serverGroupName': 'katotest-server-group',
-          'tags': ['test-tag-1', 'test-tag-2']
-        })
+    def upsert_google_server_group_tags(self):
+        # pylint: disable=bad-continuation
+        server_group_name = "katotest-server-group"
+        payload = self.agent.type_to_payload(
+            "upsertGoogleServerGroupTagsDescription",
+            {
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                "zone": self.bindings["TEST_GCE_ZONE"],
+                "serverGroupName": "katotest-server-group",
+                "tags": ["test-tag-1", "test-tag-2"],
+            },
+        )
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Server Group Tags Added')
-        .inspect_resource('instanceGroupManagers', server_group_name)
-        .EXPECT(
-            ov_factory.value_list_contains(
-                jp.DICT_MATCHES({
-                    'name': jp.STR_SUBSTR(server_group_name),
-                    jp.build_path('tags', 'items'):
-                        jp.LIST_MATCHES(['test-tag-1', 'test-tag-2'])
-                }))))
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Server Group Tags Added")
+            .inspect_resource("instanceGroupManagers", server_group_name)
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_SUBSTR(server_group_name),
+                            jp.build_path("tags", "items"): jp.LIST_MATCHES(
+                                ["test-tag-1", "test-tag-2"]
+                            ),
+                        }
+                    )
+                )
+            )
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='upsert_server_group_tags', data=payload, path='ops'),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="upsert_server_group_tags", data=payload, path="ops"
+            ),
+            contract=builder.build(),
+        )
 
-  def create_http_load_balancer(self):
-    logical_http_lb_name = 'katotest-httplb-' + self.test_id
-    self.__use_http_lb_name = logical_http_lb_name
+    def create_http_load_balancer(self):
+        logical_http_lb_name = "katotest-httplb-" + self.test_id
+        self.__use_http_lb_name = logical_http_lb_name
 
-    self.__use_http_lb_hc_name = logical_http_lb_name + '-health-check'
-    self.__use_http_lb_bs_name = logical_http_lb_name + '-backend-service'
-    self.__use_http_lb_fr_name = logical_http_lb_name
-    self.__use_http_lb_map_name = logical_http_lb_name + '-url-map'
-    self.__use_http_lb_proxy_name = logical_http_lb_name + '-target-http-proxy'
+        self.__use_http_lb_hc_name = logical_http_lb_name + "-health-check"
+        self.__use_http_lb_bs_name = logical_http_lb_name + "-backend-service"
+        self.__use_http_lb_fr_name = logical_http_lb_name
+        self.__use_http_lb_map_name = logical_http_lb_name + "-url-map"
+        self.__use_http_lb_proxy_name = logical_http_lb_name + "-target-http-proxy"
 
-    interval = 231
-    healthy = 8
-    unhealthy = 9
-    timeout = 65
-    path = '/hello/world'
-    port_range = "123-456"
+        interval = 231
+        healthy = 8
+        unhealthy = 9
+        timeout = 65
+        path = "/hello/world"
+        port_range = "123-456"
 
-    health_check = {
-        'checkIntervalSec': interval,
-        'healthyThreshold': healthy,
-        'unhealthyThreshold': unhealthy,
-        'timeoutSec': timeout,
-        'requestPath': path
+        health_check = {
+            "checkIntervalSec": interval,
+            "healthyThreshold": healthy,
+            "unhealthyThreshold": unhealthy,
+            "timeoutSec": timeout,
+            "requestPath": path,
         }
 
-    # pylint: disable=bad-continuation
-    payload = self.agent.type_to_payload(
-        'createGoogleHttpLoadBalancerDescription',
-        {
-          'healthCheck': health_check,
-          'portRange': port_range,
-          'loadBalancerName': logical_http_lb_name,
-          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
-        })
+        # pylint: disable=bad-continuation
+        payload = self.agent.type_to_payload(
+            "createGoogleHttpLoadBalancerDescription",
+            {
+                "healthCheck": health_check,
+                "portRange": port_range,
+                "loadBalancerName": logical_http_lb_name,
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+            },
+        )
 
-    hc_dict = dict(health_check)
-    del hc_dict['requestPath']
-    hc_match = {name: jp.NUM_EQ(value)
-                for name, value in health_check.items()}
-    hc_match['requestPath'] = jp.STR_EQ(path)
-    hc_match['name'] = jp.STR_SUBSTR(self.__use_http_lb_hc_name),
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Http Health Check Added')
-        .list_resource('httpHealthChecks')
-        .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES(hc_match))))
-    (builder.new_clause_builder('Global Forwarding Rule Added',
-                                retryable_for_secs=15)
-       .list_resource('globalForwardingRules')
-       .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES({
-          'name': jp.STR_SUBSTR(self.__use_http_lb_fr_name),
-          'portRange': jp.STR_EQ(port_range)}))))
-    (builder.new_clause_builder('Backend Service Added')
-       .list_resource('backendServices')
-       .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES({
-           'name': jp.STR_SUBSTR(self.__use_http_lb_bs_name),
-           'healthChecks': jp.STR_SUBSTR(self.__use_http_lb_hc_name)}))))
-    (builder.new_clause_builder('Url Map Added')
-       .list_resource('urlMaps')
-       .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES({
-          'name': jp.STR_SUBSTR(self.__use_http_lb_map_name),
-          'defaultService': jp.STR_SUBSTR(self.__use_http_lb_bs_name)}))))
-    (builder.new_clause_builder('Target Http Proxy Added')
-       .list_resource('targetHttpProxies')
-       .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES({
-          'name': jp.STR_SUBSTR(self.__use_http_lb_proxy_name),
-          'urlMap': jp.STR_SUBSTR(self.__use_http_lb_map_name)}))))
+        hc_dict = dict(health_check)
+        del hc_dict["requestPath"]
+        hc_match = {name: jp.NUM_EQ(value) for name, value in health_check.items()}
+        hc_match["requestPath"] = jp.STR_EQ(path)
+        hc_match["name"] = (jp.STR_SUBSTR(self.__use_http_lb_hc_name),)
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Http Health Check Added")
+            .list_resource("httpHealthChecks")
+            .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES(hc_match)))
+        )
+        (
+            builder.new_clause_builder(
+                "Global Forwarding Rule Added", retryable_for_secs=15
+            )
+            .list_resource("globalForwardingRules")
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_SUBSTR(self.__use_http_lb_fr_name),
+                            "portRange": jp.STR_EQ(port_range),
+                        }
+                    )
+                )
+            )
+        )
+        (
+            builder.new_clause_builder("Backend Service Added")
+            .list_resource("backendServices")
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_SUBSTR(self.__use_http_lb_bs_name),
+                            "healthChecks": jp.STR_SUBSTR(self.__use_http_lb_hc_name),
+                        }
+                    )
+                )
+            )
+        )
+        (
+            builder.new_clause_builder("Url Map Added")
+            .list_resource("urlMaps")
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_SUBSTR(self.__use_http_lb_map_name),
+                            "defaultService": jp.STR_SUBSTR(self.__use_http_lb_bs_name),
+                        }
+                    )
+                )
+            )
+        )
+        (
+            builder.new_clause_builder("Target Http Proxy Added")
+            .list_resource("targetHttpProxies")
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_SUBSTR(self.__use_http_lb_proxy_name),
+                            "urlMap": jp.STR_SUBSTR(self.__use_http_lb_map_name),
+                        }
+                    )
+                )
+            )
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='create_http_load_balancer', data=payload, path='ops'),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_http_load_balancer", data=payload, path="ops"
+            ),
+            contract=builder.build(),
+        )
 
-  def delete_http_load_balancer(self):
-    # pylint: disable=bad-continuation
-    payload = self.agent.type_to_payload(
-        'deleteGoogleHttpLoadBalancerDescription',
-        {
-          'loadBalancerName': self.__use_http_lb_name,
-          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
-        })
+    def delete_http_load_balancer(self):
+        # pylint: disable=bad-continuation
+        payload = self.agent.type_to_payload(
+            "deleteGoogleHttpLoadBalancerDescription",
+            {
+                "loadBalancerName": self.__use_http_lb_name,
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+            },
+        )
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Health Check Removed')
-       .list_resource('httpHealthChecks')
-       .EXPECT(ov_factory.value_list_path_excludes(
-           'name', jp.STR_SUBSTR(self.__use_http_lb_hc_name))))
-    (builder.new_clause_builder('Global Forwarding Rules Removed')
-       .list_resource('globalForwardingRules')
-       .EXPECT(ov_factory.value_list_path_excludes(
-           'name', jp.STR_SUBSTR(self.__use_http_lb_fr_name))))
-    (builder.new_clause_builder('Backend Service Removed')
-       .list_resource('backendServices')
-       .EXPECT(ov_factory.value_list_path_excludes(
-           'name', jp.STR_SUBSTR(self.__use_http_lb_bs_name))))
-    (builder.new_clause_builder('Url Map Removed')
-       .list_resource('urlMaps')
-       .EXPECT(ov_factory.value_list_path_excludes(
-           'name', jp.STR_SUBSTR(self.__use_http_lb_map_name))))
-    (builder.new_clause_builder('Target Http Proxy Removed')
-       .list_resource('targetHttpProxies')
-       .EXPECT(ov_factory.value_list_path_excludes(
-           'name', jp.STR_SUBSTR(self.__use_http_lb_proxy_name))))
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Health Check Removed")
+            .list_resource("httpHealthChecks")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__use_http_lb_hc_name)
+                )
+            )
+        )
+        (
+            builder.new_clause_builder("Global Forwarding Rules Removed")
+            .list_resource("globalForwardingRules")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__use_http_lb_fr_name)
+                )
+            )
+        )
+        (
+            builder.new_clause_builder("Backend Service Removed")
+            .list_resource("backendServices")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__use_http_lb_bs_name)
+                )
+            )
+        )
+        (
+            builder.new_clause_builder("Url Map Removed")
+            .list_resource("urlMaps")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__use_http_lb_map_name)
+                )
+            )
+        )
+        (
+            builder.new_clause_builder("Target Http Proxy Removed")
+            .list_resource("targetHttpProxies")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__use_http_lb_proxy_name)
+                )
+            )
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_http_load_balancer', data=payload, path='ops'),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete_http_load_balancer", data=payload, path="ops"
+            ),
+            contract=builder.build(),
+        )
 
+    def upsert_load_balancer(self):
+        self.__use_lb_name = "katotest-lb-" + self.test_id
+        self.__use_lb_hc_name = "%s-hc" % self.__use_lb_name
+        self.__use_lb_tp_name = "%s-tp" % self.__use_lb_name
+        self.__use_lb_target = "{0}/targetPools/{1}".format(
+            self.bindings["TEST_GCE_REGION"], self.__use_lb_tp_name
+        )
 
-  def upsert_load_balancer(self):
-    self.__use_lb_name = 'katotest-lb-' + self.test_id
-    self.__use_lb_hc_name = '%s-hc' % self.__use_lb_name
-    self.__use_lb_tp_name = '%s-tp' % self.__use_lb_name
-    self.__use_lb_target = '{0}/targetPools/{1}'.format(
-        self.bindings['TEST_GCE_REGION'], self.__use_lb_tp_name)
+        interval = 123
+        healthy = 4
+        unhealthy = 5
+        timeout = 78
+        path = "/" + self.__use_lb_target
 
-    interval = 123
-    healthy = 4
-    unhealthy = 5
-    timeout = 78
-    path = '/' + self.__use_lb_target
-
-    health_check = {
-        'checkIntervalSec': interval,
-        'healthyThreshold': healthy,
-        'unhealthyThreshold': unhealthy,
-        'timeoutSec': timeout,
-        'requestPath': path
+        health_check = {
+            "checkIntervalSec": interval,
+            "healthyThreshold": healthy,
+            "unhealthyThreshold": unhealthy,
+            "timeoutSec": timeout,
+            "requestPath": path,
         }
 
-    # pylint: disable=bad-continuation
-    payload = self.agent.type_to_payload(
-        'upsertGoogleLoadBalancerDescription',
-        {
-          'healthCheck': health_check,
-          'region': self.bindings['TEST_GCE_REGION'],
-          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-          'loadBalancerName': self.__use_lb_name
-        })
+        # pylint: disable=bad-continuation
+        payload = self.agent.type_to_payload(
+            "upsertGoogleLoadBalancerDescription",
+            {
+                "healthCheck": health_check,
+                "region": self.bindings["TEST_GCE_REGION"],
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                "loadBalancerName": self.__use_lb_name,
+            },
+        )
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Forwarding Rules Added',
-                                retryable_for_secs=30)
-       .list_resource('forwardingRules')
-       .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES({
-           'name': jp.STR_SUBSTR(self.__use_lb_name),
-           'target': jp.STR_SUBSTR(self.__use_lb_target)}))))
-    (builder.new_clause_builder('Target Pool Added', retryable_for_secs=15)
-       .list_resource('targetPools')
-       .EXPECT(ov_factory.value_list_path_contains(
-           'name', jp.STR_SUBSTR(self.__use_lb_tp_name))))
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Forwarding Rules Added", retryable_for_secs=30)
+            .list_resource("forwardingRules")
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_SUBSTR(self.__use_lb_name),
+                            "target": jp.STR_SUBSTR(self.__use_lb_target),
+                        }
+                    )
+                )
+            )
+        )
+        (
+            builder.new_clause_builder("Target Pool Added", retryable_for_secs=15)
+            .list_resource("targetPools")
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "name", jp.STR_SUBSTR(self.__use_lb_tp_name)
+                )
+            )
+        )
 
-     # We list the resources here because the name isnt exact
-     # and the list also returns the details we need.
-    hc_dict = dict(health_check)
-    del hc_dict['requestPath']
+        # We list the resources here because the name isnt exact
+        # and the list also returns the details we need.
+        hc_dict = dict(health_check)
+        del hc_dict["requestPath"]
 
-    hc_match = {name: jp.NUM_EQ(value) for name, value in hc_dict.items()}
-    hc_match['requestPath'] = jp.STR_EQ(path)
-    hc_match['name'] = jp.STR_SUBSTR(self.__use_http_lb_hc_name)
-    (builder.new_clause_builder('Health Check Added', retryable_for_secs=15)
-       .list_resource('httpHealthChecks')
-       .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES(hc_match))))
+        hc_match = {name: jp.NUM_EQ(value) for name, value in hc_dict.items()}
+        hc_match["requestPath"] = jp.STR_EQ(path)
+        hc_match["name"] = jp.STR_SUBSTR(self.__use_http_lb_hc_name)
+        (
+            builder.new_clause_builder("Health Check Added", retryable_for_secs=15)
+            .list_resource("httpHealthChecks")
+            .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES(hc_match)))
+        )
 
-    return st.OperationContract(
-      self.new_post_operation(
-          title='upsert_load_balancer', data=payload, path='ops'),
-      contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="upsert_load_balancer", data=payload, path="ops"
+            ),
+            contract=builder.build(),
+        )
 
-  def delete_load_balancer(self):
-    # pylint: disable=bad-continuation
-    payload = self.agent.type_to_payload(
-        'deleteGoogleLoadBalancerDescription',
-        {
-          'region': self.bindings['TEST_GCE_REGION'],
-          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-          'loadBalancerName': self.__use_lb_name
-        })
+    def delete_load_balancer(self):
+        # pylint: disable=bad-continuation
+        payload = self.agent.type_to_payload(
+            "deleteGoogleLoadBalancerDescription",
+            {
+                "region": self.bindings["TEST_GCE_REGION"],
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                "loadBalancerName": self.__use_lb_name,
+            },
+        )
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Health Check Removed')
-       .list_resource('httpHealthChecks')
-       .EXPECT(ov_factory.value_list_path_excludes(
-           'name', jp.STR_SUBSTR(self.__use_lb_hc_name))))
-    (builder.new_clause_builder('Target Pool Removed')
-       .list_resource('targetPools')
-       .EXPECT(ov_factory.value_list_path_excludes(
-           'name', jp.STR_SUBSTR(self.__use_lb_tp_name))))
-    (builder.new_clause_builder('Forwarding Rule Removed')
-       .list_resource('forwardingRules')
-       .EXPECT(ov_factory.value_list_path_excludes(
-           'name', jp.STR_SUBSTR(self.__use_lb_name))))
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Health Check Removed")
+            .list_resource("httpHealthChecks")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__use_lb_hc_name)
+                )
+            )
+        )
+        (
+            builder.new_clause_builder("Target Pool Removed")
+            .list_resource("targetPools")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__use_lb_tp_name)
+                )
+            )
+        )
+        (
+            builder.new_clause_builder("Forwarding Rule Removed")
+            .list_resource("forwardingRules")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__use_lb_name)
+                )
+            )
+        )
 
-    return st.OperationContract(
-      self.new_post_operation(
-          title='delete_load_balancer', data=payload, path='ops'),
-      contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete_load_balancer", data=payload, path="ops"
+            ),
+            contract=builder.build(),
+        )
 
-  def register_load_balancer_instances(self):
-    """Creates test registering the first two instances with a load balancer.
+    def register_load_balancer_instances(self):
+        """Creates test registering the first two instances with a load balancer.
 
-       Assumes that create_instances test has been run to add
-       the instances. Note by design these were in two different zones
-       but same region as required by the API this is testing.
+           Assumes that create_instances test has been run to add
+           the instances. Note by design these were in two different zones
+           but same region as required by the API this is testing.
 
-       Assumes that upsert_load_balancer has been run to
-       create the load balancer itself.
-    Returns:
-      st.OperationContract
-    """
-    # pylint: disable=bad-continuation
-    payload = self.agent.type_to_payload(
-        'registerInstancesWithGoogleLoadBalancerDescription',
-        {
-          'loadBalancerNames': [self.__use_lb_name],
-          'instanceIds': self.use_instance_names[:2],
-          'region': self.bindings['TEST_GCE_REGION'],
-          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
-        })
+           Assumes that upsert_load_balancer has been run to
+           create the load balancer itself.
+        Returns:
+          st.OperationContract
+        """
+        # pylint: disable=bad-continuation
+        payload = self.agent.type_to_payload(
+            "registerInstancesWithGoogleLoadBalancerDescription",
+            {
+                "loadBalancerNames": [self.__use_lb_name],
+                "instanceIds": self.use_instance_names[:2],
+                "region": self.bindings["TEST_GCE_REGION"],
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+            },
+        )
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Instances in Target Pool',
-                                retryable_for_secs=15)
-       .list_resource('targetPools')
-       .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES({
-          'name': jp.STR_SUBSTR(self.__use_lb_tp_name),
-          'instances': jp.LIST_MATCHES([
-              jp.STR_SUBSTR(self.use_instance_names[0]),
-              jp.STR_SUBSTR(self.use_instance_names[1])])
-          })))
-       .AND(
-           ov_factory.value_list_excludes(jp.DICT_MATCHES({
-              'name': jp.STR_SUBSTR(self.__use_lb_tp_name),
-              'instances': jp.LIST_MATCHES(
-                  [jp.STR_SUBSTR(self.use_instance_names[2])])
-           }))))
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder(
+                "Instances in Target Pool", retryable_for_secs=15
+            )
+            .list_resource("targetPools")
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_SUBSTR(self.__use_lb_tp_name),
+                            "instances": jp.LIST_MATCHES(
+                                [
+                                    jp.STR_SUBSTR(self.use_instance_names[0]),
+                                    jp.STR_SUBSTR(self.use_instance_names[1]),
+                                ]
+                            ),
+                        }
+                    )
+                )
+            )
+            .AND(
+                ov_factory.value_list_excludes(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_SUBSTR(self.__use_lb_tp_name),
+                            "instances": jp.LIST_MATCHES(
+                                [jp.STR_SUBSTR(self.use_instance_names[2])]
+                            ),
+                        }
+                    )
+                )
+            )
+        )
 
-    return st.OperationContract(
-      self.new_post_operation(
-          title='register_load_balancer_instances', data=payload, path='ops'),
-      contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="register_load_balancer_instances", data=payload, path="ops"
+            ),
+            contract=builder.build(),
+        )
 
+    def deregister_load_balancer_instances(self):
+        """Creates a test unregistering instances from load balancer.
 
-  def deregister_load_balancer_instances(self):
-    """Creates a test unregistering instances from load balancer.
+        Returns:
+          st.OperationContract
+        """
+        # pylint: disable=bad-continuation
+        payload = self.agent.type_to_payload(
+            "deregisterInstancesFromGoogleLoadBalancerDescription",
+            {
+                "loadBalancerNames": [self.__use_lb_name],
+                "instanceIds": self.use_instance_names[:2],
+                "region": self.bindings["TEST_GCE_REGION"],
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+            },
+        )
 
-    Returns:
-      st.OperationContract
-    """
-    # pylint: disable=bad-continuation
-    payload = self.agent.type_to_payload(
-       'deregisterInstancesFromGoogleLoadBalancerDescription',
-        {
-          'loadBalancerNames': [self.__use_lb_name],
-          'instanceIds': self.use_instance_names[:2],
-          'region': self.bindings['TEST_GCE_REGION'],
-          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
-        })
+        # NOTE(ewiseblatt): 20150530
+        # This displays an error that 'instances' field doesnt exist.
+        # That's because it was removed because all the instances are gone.
+        # I dont have a way to express that the field itself is optional,
+        # just the record. Leaving it as is because displaying this type of
+        # error is usually helpful for development.
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder(
+                "Instances not in Target Pool", retryable_for_secs=30
+            )
+            .list_resource("targetPools", region=self.bindings["TEST_GCE_REGION"])
+            .EXPECT(
+                ov_factory.value_list_excludes(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_SUBSTR(self.__use_lb_tp_name),
+                            "instances": jp.LIST_MATCHES(
+                                [
+                                    jp.STR_SUBSTR(self.use_instance_names[0]),
+                                    jp.STR_SUBSTR(self.use_instance_names[1]),
+                                ]
+                            ),
+                        }
+                    )
+                )
+            )
+        )
 
-    # NOTE(ewiseblatt): 20150530
-    # This displays an error that 'instances' field doesnt exist.
-    # That's because it was removed because all the instances are gone.
-    # I dont have a way to express that the field itself is optional,
-    # just the record. Leaving it as is because displaying this type of
-    # error is usually helpful for development.
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Instances not in Target Pool',
-                                retryable_for_secs=30)
-       .list_resource(
-          'targetPools', region=self.bindings['TEST_GCE_REGION'])
-       .EXPECT(ov_factory.value_list_excludes(jp.DICT_MATCHES({
-          'name': jp.STR_SUBSTR(self.__use_lb_tp_name),
-          'instances': jp.LIST_MATCHES([
-              jp.STR_SUBSTR(self.use_instance_names[0]),
-              jp.STR_SUBSTR(self.use_instance_names[1])])
-          }))))
+        return st.OperationContract(
+            self.new_post_operation(
+                title="deregister_load_balancer_instances", data=payload, path="ops"
+            ),
+            contract=builder.build(),
+        )
 
-    return st.OperationContract(
-      self.new_post_operation(
-          title='deregister_load_balancer_instances', data=payload, path='ops'),
-      contract=builder.build())
+    def list_available_images(self):
+        """Creates a test that confirms expected available images.
 
-  def list_available_images(self):
-    """Creates a test that confirms expected available images.
+        Returns:
+          st.OperationContract
+        """
+        logger = logging.getLogger(__name__)
 
-    Returns:
-      st.OperationContract
-    """
-    logger = logging.getLogger(__name__)
+        # Get the list of images available (to the service account we are using).
+        context = citest.base.ExecutionContext()
+        gcp_agent = self.gcp_observer
+        JournalLogger.begin_context("Collecting expected available images")
+        relation_context = "ERROR"
+        try:
+            logger.debug("Looking up available images.")
 
-    # Get the list of images available (to the service account we are using).
-    context = citest.base.ExecutionContext()
-    gcp_agent = self.gcp_observer
-    JournalLogger.begin_context('Collecting expected available images')
-    relation_context = 'ERROR'
-    try:
-      logger.debug('Looking up available images.')
+            json_doc = gcp_agent.list_resource(context, "images")
+            for project in GCP_STANDARD_IMAGES.keys():
+                logger.info("Looking for images from project=%s", project)
+                found = gcp_agent.list_resource(context, "images", project=project)
+                for image in found:
+                    if not image.get("deprecated", None):
+                        json_doc.append(image)
 
-      json_doc = gcp_agent.list_resource(context, 'images')
-      for project in GCP_STANDARD_IMAGES.keys():
-        logger.info('Looking for images from project=%s', project)
-        found = gcp_agent.list_resource(context, 'images', project=project)
-        for image in found:
-          if not image.get('deprecated', None):
-            json_doc.append(image)
+            # Produce the list of images that we expect to receive from spinnaker
+            # (visible to the primary service account).
+            spinnaker_account = self.bindings["SPINNAKER_GOOGLE_ACCOUNT"]
 
-      # Produce the list of images that we expect to receive from spinnaker
-      # (visible to the primary service account).
-      spinnaker_account = self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
+            logger.debug('Configured with Spinnaker account "%s"', spinnaker_account)
+            expect_images = [
+                {"account": spinnaker_account, "imageName": image["name"]}
+                for image in json_doc
+            ]
+            expect_images = sorted(expect_images, key=lambda k: k["imageName"])
+            relation_context = "VALID"
+        finally:
+            JournalLogger.end_context(relation=relation_context)
 
-      logger.debug('Configured with Spinnaker account "%s"', spinnaker_account)
-      expect_images = [{'account': spinnaker_account, 'imageName': image['name']}
-                       for image in json_doc]
-      expect_images = sorted(expect_images, key=lambda k: k['imageName'])
-      relation_context = 'VALID'
-    finally:
-      JournalLogger.end_context(relation=relation_context)
+        # pylint: disable=bad-continuation
+        builder = HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder("Has Expected Images")
+            .get_url_path("/gce/images/find")
+            .EXPECT(
+                ov_factory.value_list_matches(
+                    [jp.DICT_SUBSET(image_entry) for image_entry in expect_images],
+                    strict=True,
+                    unique=True,
+                )
+            )
+        )
 
-    # pylint: disable=bad-continuation
-    builder = HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Expected Images')
-       .get_url_path('/gce/images/find')
-       .EXPECT(
-           ov_factory.value_list_matches(
-               [jp.DICT_SUBSET(image_entry) for image_entry in expect_images],
-               strict=True,
-               unique=True)))
-
-    return st.OperationContract(
-        NoOpOperation('List Available Images'),
-        contract=builder.build())
+        return st.OperationContract(
+            NoOpOperation("List Available Images"), contract=builder.build()
+        )
 
 
 class GoogleKatoIntegrationTest(st.AgentTestCase):
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-        GoogleKatoTestScenario)
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            GoogleKatoTestScenario
+        )
 
-  def Xtest_a_upsert_server_group_tags(self):
-    self.run_test_case(self.scenario.upsert_google_server_group_tags())
+    def Xtest_a_upsert_server_group_tags(self):
+        self.run_test_case(self.scenario.upsert_google_server_group_tags())
 
-  def test_a_upsert_load_balancer(self):
-    self.run_test_case(self.scenario.upsert_load_balancer())
+    def test_a_upsert_load_balancer(self):
+        self.run_test_case(self.scenario.upsert_load_balancer())
 
-  def test_b_create_instances(self):
-    self.run_test_case(self.scenario.create_instances())
+    def test_b_create_instances(self):
+        self.run_test_case(self.scenario.create_instances())
 
-  def test_c_register_load_balancer_instances(self):
-    self.run_test_case(self.scenario.register_load_balancer_instances())
+    def test_c_register_load_balancer_instances(self):
+        self.run_test_case(self.scenario.register_load_balancer_instances())
 
-  def Xtest_d_create_http_load_balancer(self):
-    self.run_test_case(self.scenario.create_http_load_balancer())
+    def Xtest_d_create_http_load_balancer(self):
+        self.run_test_case(self.scenario.create_http_load_balancer())
 
-  def Xtest_v_delete_http_load_balancer(self):
-    self.run_test_case(
-        self.scenario.delete_http_load_balancer(), timeout_ok=True,
-        retry_interval_secs=10, max_retries=9)
+    def Xtest_v_delete_http_load_balancer(self):
+        self.run_test_case(
+            self.scenario.delete_http_load_balancer(),
+            timeout_ok=True,
+            retry_interval_secs=10,
+            max_retries=9,
+        )
 
-  def test_w_deregister_load_balancer_instances(self):
-    self.run_test_case(self.scenario.deregister_load_balancer_instances())
+    def test_w_deregister_load_balancer_instances(self):
+        self.run_test_case(self.scenario.deregister_load_balancer_instances())
 
-  def test_x_terminate_instances(self):
-    # delete 1 which was in a different zone than the other two.
-    # Then delete [0,2] together, which were in the same zone.
-    try:
-      self.run_test_case(
-          self.scenario.terminate_instances(
-              [self.scenario.use_instance_names[1]],
-              self.scenario.use_instance_zones[1]))
-    finally:
-      # Always give this a try, even if the first test fails.
-      # that increases our chances of cleaning everything up.
-      self.run_test_case(
-          self.scenario.terminate_instances(
-              [self.scenario.use_instance_names[0],
-               self.scenario.use_instance_names[2]],
-              self.scenario.use_instance_zones[0]))
+    def test_x_terminate_instances(self):
+        # delete 1 which was in a different zone than the other two.
+        # Then delete [0,2] together, which were in the same zone.
+        try:
+            self.run_test_case(
+                self.scenario.terminate_instances(
+                    [self.scenario.use_instance_names[1]],
+                    self.scenario.use_instance_zones[1],
+                )
+            )
+        finally:
+            # Always give this a try, even if the first test fails.
+            # that increases our chances of cleaning everything up.
+            self.run_test_case(
+                self.scenario.terminate_instances(
+                    [
+                        self.scenario.use_instance_names[0],
+                        self.scenario.use_instance_names[2],
+                    ],
+                    self.scenario.use_instance_zones[0],
+                )
+            )
 
+    def test_z_delete_load_balancer(self):
+        # TODO(ewiseblatt): 20151220
+        # The retry here is really due to the 400 "not ready" race condition
+        # within GCP. Would be better to couple this to the agent and not the
+        # test so that it is easier to maintain. Need to add a generalization
+        # so the agent can see this is a delete test, got a 400, and only
+        # in that condition override the default retry parameters, then stick
+        # with the defaults here.
+        self.run_test_case(self.scenario.delete_load_balancer(), max_retries=5)
 
-  def test_z_delete_load_balancer(self):
-    # TODO(ewiseblatt): 20151220
-    # The retry here is really due to the 400 "not ready" race condition
-    # within GCP. Would be better to couple this to the agent and not the
-    # test so that it is easier to maintain. Need to add a generalization
-    # so the agent can see this is a delete test, got a 400, and only
-    # in that condition override the default retry parameters, then stick
-    # with the defaults here.
-    self.run_test_case(self.scenario.delete_load_balancer(), max_retries=5)
-
-  def Xtest_available_images(self):
-    self.run_test_case(self.scenario.list_available_images())
+    def Xtest_available_images(self):
+        self.run_test_case(self.scenario.list_available_images())
 
 
 def main():
-  return citest.base.TestRunner.main(
-      parser_inits=[GoogleKatoTestScenario.initArgumentParser],
-      test_case_list=[GoogleKatoIntegrationTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[GoogleKatoTestScenario.initArgumentParser],
+        test_case_list=[GoogleKatoIntegrationTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/google_server_group_test.py
+++ b/testing/citest/tests/google_server_group_test.py
@@ -20,528 +20,652 @@ import citest.base
 
 class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
 
-  MINIMUM_PROJECT_QUOTA = {
-      'INSTANCE_TEMPLATES': 1,
-      'HEALTH_CHECKS': 1,
-      'FORWARDING_RULES': 1,
-      'IN_USE_ADDRESSES': 3,
-      'TARGET_POOLS': 1,
-  }
+    MINIMUM_PROJECT_QUOTA = {
+        "INSTANCE_TEMPLATES": 1,
+        "HEALTH_CHECKS": 1,
+        "FORWARDING_RULES": 1,
+        "IN_USE_ADDRESSES": 3,
+        "TARGET_POOLS": 1,
+    }
 
-  MINIMUM_REGION_QUOTA = {
-      'CPUS': 3,
-      'IN_USE_ADDRESSES': 3,
-      'INSTANCE_GROUP_MANAGERS': 2,
-      'INSTANCES': 3,
-  }
+    MINIMUM_REGION_QUOTA = {
+        "CPUS": 3,
+        "IN_USE_ADDRESSES": 3,
+        "INSTANCE_GROUP_MANAGERS": 2,
+        "INSTANCES": 3,
+    }
 
-  @classmethod
-  def initArgumentParser(cls, parser, defaults=None):
-    """Initialize command line argument parser."""
-    super(GoogleServerGroupTestScenario, cls).initArgumentParser(
-        parser, defaults=defaults)
-    parser.add_argument('--regional', default=False, action='store_true',
-                        help='Test regional server groups rather than zonal.')
+    @classmethod
+    def initArgumentParser(cls, parser, defaults=None):
+        """Initialize command line argument parser."""
+        super(GoogleServerGroupTestScenario, cls).initArgumentParser(
+            parser, defaults=defaults
+        )
+        parser.add_argument(
+            "--regional",
+            default=False,
+            action="store_true",
+            help="Test regional server groups rather than zonal.",
+        )
 
-  @classmethod
-  def new_agent(cls, bindings):
-    """Implements the base class interface to create a new agent.
+    @classmethod
+    def new_agent(cls, bindings):
+        """Implements the base class interface to create a new agent.
 
-    This method is called by the base classes during setup/initialization.
+        This method is called by the base classes during setup/initialization.
 
-    Args:
-      bindings: The bindings dictionary with configuration information
-        that this factory can draw from to initialize. If the factory would
-        like additional custom bindings it could add them to initArgumentParser.
+        Args:
+          bindings: The bindings dictionary with configuration information
+            that this factory can draw from to initialize. If the factory would
+            like additional custom bindings it could add them to initArgumentParser.
 
-    Returns:
-      A citest.service_testing.BaseAgent that can interact with Gate.
-      This is the agent that test operations will be posted to.
-    """
-    return gate.new_agent(bindings)
+        Returns:
+          A citest.service_testing.BaseAgent that can interact with Gate.
+          This is the agent that test operations will be posted to.
+        """
+        return gate.new_agent(bindings)
 
-  def __init__(self, bindings, agent=None):
-    super(GoogleServerGroupTestScenario, self).__init__(bindings, agent)
+    def __init__(self, bindings, agent=None):
+        super(GoogleServerGroupTestScenario, self).__init__(bindings, agent)
 
-    if bindings['REGIONAL']:
-      app_decorator = 'r'
-      self.__mig_title = 'Regional Instance Group'
-      self.__mig_resource_name = 'regionInstanceGroups'
-      self.__mig_resource_kwargs = {'region': bindings['TEST_GCE_REGION']}
-      self.__mig_manager_name = 'regionInstanceGroupManagers'
-      self.__mig_manager_kwargs = {'region': bindings['TEST_GCE_REGION']}
-      self.__mig_payload_extra = {
-          'regional': True, 'region': bindings['TEST_GCE_REGION']
-      }
-    else:
-      app_decorator = 'z'
-      self.__mig_title = 'Zonal Instance Group'
-      self.__mig_resource_name = 'instanceGroups'
-      self.__mig_resource_kwargs = {}  # all zones
-      self.__mig_manager_name = 'instanceGroupManagers'
-      self.__mig_manager_kwargs = {}  # all zones
-      self.__mig_payload_extra = {
-          'zone': bindings['TEST_GCE_ZONE']
-      }
+        if bindings["REGIONAL"]:
+            app_decorator = "r"
+            self.__mig_title = "Regional Instance Group"
+            self.__mig_resource_name = "regionInstanceGroups"
+            self.__mig_resource_kwargs = {"region": bindings["TEST_GCE_REGION"]}
+            self.__mig_manager_name = "regionInstanceGroupManagers"
+            self.__mig_manager_kwargs = {"region": bindings["TEST_GCE_REGION"]}
+            self.__mig_payload_extra = {
+                "regional": True,
+                "region": bindings["TEST_GCE_REGION"],
+            }
+        else:
+            app_decorator = "z"
+            self.__mig_title = "Zonal Instance Group"
+            self.__mig_resource_name = "instanceGroups"
+            self.__mig_resource_kwargs = {}  # all zones
+            self.__mig_manager_name = "instanceGroupManagers"
+            self.__mig_manager_kwargs = {}  # all zones
+            self.__mig_payload_extra = {"zone": bindings["TEST_GCE_ZONE"]}
 
-    logging.info('Running tests against %s', self.__mig_title)
+        logging.info("Running tests against %s", self.__mig_title)
 
-    if not bindings['TEST_APP']:
-      bindings['TEST_APP'] = app_decorator + 'svrgrptest' + bindings['TEST_ID']
+        if not bindings["TEST_APP"]:
+            bindings["TEST_APP"] = app_decorator + "svrgrptest" + bindings["TEST_ID"]
 
-    # Our application name and path to post events to.
-    self.TEST_APP = bindings['TEST_APP']
-    self.__path = 'applications/%s/tasks' % self.TEST_APP
+        # Our application name and path to post events to.
+        self.TEST_APP = bindings["TEST_APP"]
+        self.__path = "applications/%s/tasks" % self.TEST_APP
 
-    # Custom userdata.
-    self.__custom_user_data_key = 'customUserData'
-    self.__custom_user_data_value = 'testCustomUserData'
+        # Custom userdata.
+        self.__custom_user_data_key = "customUserData"
+        self.__custom_user_data_value = "testCustomUserData"
 
-    # The spinnaker stack decorator for our resources.
-    self.TEST_STACK = bindings['TEST_STACK']
+        # The spinnaker stack decorator for our resources.
+        self.TEST_STACK = bindings["TEST_STACK"]
 
-    self.TEST_REGION = bindings['TEST_GCE_REGION']
-    self.TEST_ZONE = bindings['TEST_GCE_ZONE']
+        self.TEST_REGION = bindings["TEST_GCE_REGION"]
+        self.TEST_ZONE = bindings["TEST_GCE_ZONE"]
 
-    # Resource names used among tests.
-    self.__cluster_name = frigga.Naming.cluster(
-        app=self.TEST_APP, stack=self.TEST_STACK)
-    self.__server_group_name = frigga.Naming.server_group(
-        app=self.TEST_APP, stack=self.TEST_STACK, version='v000')
-    self.__cloned_server_group_name = frigga.Naming.server_group(
-        app=self.TEST_APP, stack=self.TEST_STACK, version='v001')
-    self.__lb_name = frigga.Naming.cluster(
-        app=self.TEST_APP, stack=self.TEST_STACK, detail='fe')
+        # Resource names used among tests.
+        self.__cluster_name = frigga.Naming.cluster(
+            app=self.TEST_APP, stack=self.TEST_STACK
+        )
+        self.__server_group_name = frigga.Naming.server_group(
+            app=self.TEST_APP, stack=self.TEST_STACK, version="v000"
+        )
+        self.__cloned_server_group_name = frigga.Naming.server_group(
+            app=self.TEST_APP, stack=self.TEST_STACK, version="v001"
+        )
+        self.__lb_name = frigga.Naming.cluster(
+            app=self.TEST_APP, stack=self.TEST_STACK, detail="fe"
+        )
 
-  def create_app(self):
-    """Creates OperationContract that creates a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_create_app_operation(
-            bindings=self.bindings, application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-            cloud_providers="gce"),
-        contract=contract)
+    def create_app(self):
+        """Creates OperationContract that creates a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_create_app_operation(
+                bindings=self.bindings,
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                cloud_providers="gce",
+            ),
+            contract=contract,
+        )
 
-  def delete_app(self):
-    """Creates OperationContract that deletes a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_delete_app_operation(
+    def delete_app(self):
+        """Creates OperationContract that deletes a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_delete_app_operation(
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+            ),
+            contract=contract,
+        )
+
+    def create_load_balancer(self):
+        job = [
+            {
+                "cloudProvider": "gce",
+                "loadBalancerName": self.__lb_name,
+                "ipProtocol": "TCP",
+                "portRange": "8080",
+                "provider": "gce",
+                "stack": self.TEST_STACK,
+                "detail": "frontend",
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                "region": self.TEST_REGION,
+                "listeners": [
+                    {"protocol": "TCP", "portRange": "8080", "healthCheck": False}
+                ],
+                "name": self.__lb_name,
+                "type": "upsertLoadBalancer",
+                "availabilityZones": {self.TEST_REGION: []},
+                "user": "integration-tests",
+            }
+        ]
+
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Load Balancer Created", retryable_for_secs=30)
+            .list_resource("forwardingRules")
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "name", jp.STR_SUBSTR(self.__lb_name)
+                )
+            )
+        )
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=job,
+            description=self.__mig_title + " Test - create load balancer",
             application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_GOOGLE_ACCOUNT']),
-        contract=contract)
+        )
 
-  def create_load_balancer(self):
-    job = [{
-      'cloudProvider': 'gce',
-      'loadBalancerName': self.__lb_name,
-      'ipProtocol': 'TCP',
-      'portRange': '8080',
-      'provider': 'gce',
-      'stack': self.TEST_STACK,
-      'detail': 'frontend',
-      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      'region': self.TEST_REGION,
-      'listeners': [{
-        'protocol': 'TCP',
-        'portRange': '8080',
-        'healthCheck': False
-      }],
-      'name': self.__lb_name,
-      'type': 'upsertLoadBalancer',
-      'availabilityZones': {self.TEST_REGION: []},
-      'user': 'integration-tests'
-    }]
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_load_balancer", data=payload, path=self.__path
+            ),
+            contract=builder.build(),
+        )
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Load Balancer Created', retryable_for_secs=30)
-     .list_resource('forwardingRules')
-     .EXPECT(ov_factory.value_list_path_contains(
-         'name', jp.STR_SUBSTR(self.__lb_name))))
+    def create_server_group(self):
+        job = [
+            {
+                "application": self.TEST_APP,
+                "stack": self.TEST_STACK,
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                "network": "default",
+                "targetSize": 1,
+                "capacity": {"min": 1, "max": 1, "desired": 1},
+                "availabilityZones": {self.TEST_REGION: [self.TEST_ZONE]},
+                "loadBalancers": [self.__lb_name],
+                "instanceMetadata": {"load-balancer-names": self.__lb_name},
+                "userData": self.__custom_user_data_key
+                + "="
+                + self.__custom_user_data_value,
+                "cloudProvider": "gce",
+                "image": self.bindings["TEST_GCE_IMAGE_NAME"],
+                "instanceType": "f1-micro",
+                "initialNumReplicas": 1,
+                "type": "createServerGroup",
+                "account": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                "user": "integration-tests",
+            }
+        ]
+        job[0].update(self.__mig_payload_extra)
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=job, description=self.__mig_title + ' Test - create load balancer',
-        application=self.TEST_APP)
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder(
+                self.__mig_title + "Created", retryable_for_secs=150
+            )
+            .list_resource(self.__mig_manager_name, **self.__mig_manager_kwargs)
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "name", jp.EQUIVALENT(self.__server_group_name)
+                )
+            )
+        )
 
-    return st.OperationContract(
-      self.new_post_operation(
-          title='create_load_balancer', data=payload, path=self.__path),
-      contract=builder.build())
+        (
+            builder.new_clause_builder(
+                "Instance template created", retryable_for_secs=150
+            )
+            .list_resource("instanceTemplates")
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "properties/metadata/items",
+                    jp.LIST_MATCHES(
+                        [
+                            jp.DICT_MATCHES(
+                                {
+                                    "key": jp.EQUIVALENT(self.__custom_user_data_key),
+                                    "value": jp.EQUIVALENT(
+                                        self.__custom_user_data_value
+                                    ),
+                                }
+                            )
+                        ]
+                    ),
+                )
+            )
+        )
 
-  def create_server_group(self):
-    job = [{
-      'application': self.TEST_APP,
-      'stack': self.TEST_STACK,
-      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      'network': 'default',
-      'targetSize': 1,
-      'capacity': {
-        'min': 1,
-        'max': 1,
-        'desired': 1
-      },
-      'availabilityZones': {
-        self.TEST_REGION: [self.TEST_ZONE]
-      },
-      'loadBalancers': [self.__lb_name],
-      'instanceMetadata': {
-        'load-balancer-names': self.__lb_name
-      },
-      'userData': self.__custom_user_data_key + '=' +  self.__custom_user_data_value,
-      'cloudProvider': 'gce',
-      'image': self.bindings['TEST_GCE_IMAGE_NAME'],
-      'instanceType': 'f1-micro',
-      'initialNumReplicas': 1,
-      'type': 'createServerGroup',
-      'account': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      'user': 'integration-tests'
-    }]
-    job[0].update(self.__mig_payload_extra)
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=job,
+            description=self.__mig_title + " Test - create initial",
+            application=self.TEST_APP,
+        )
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder(self.__mig_title + 'Created',
-                                retryable_for_secs=150)
-     .list_resource(self.__mig_manager_name, **self.__mig_manager_kwargs)
-     .EXPECT(ov_factory.value_list_path_contains(
-         'name', jp.EQUIVALENT(self.__server_group_name))))
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_server_group", data=payload, path=self.__path
+            ),
+            contract=builder.build(),
+        )
 
-    (builder.new_clause_builder('Instance template created',
-                                retryable_for_secs=150)
-     .list_resource('instanceTemplates')
-     .EXPECT(ov_factory.value_list_path_contains(
-         'properties/metadata/items',
-         jp.LIST_MATCHES([
-             jp.DICT_MATCHES({
-                 'key': jp.EQUIVALENT(self.__custom_user_data_key),
-                 'value': jp.EQUIVALENT(self.__custom_user_data_value)})
-         ])
-     )))
+    def resize_server_group(self):
+        job = [
+            {
+                "targetSize": 2,
+                "capacity": {"min": 2, "max": 2, "desired": 2},
+                "replicaPoolName": self.__server_group_name,
+                "numReplicas": 2,
+                "region": self.TEST_REGION,
+                "zone": self.TEST_ZONE,
+                "asgName": self.__server_group_name,
+                "serverGroupName": self.__server_group_name,
+                "type": "resizeServerGroup",
+                "regions": [self.TEST_REGION],
+                "zones": [self.TEST_ZONE],
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                "cloudProvider": "gce",
+                "user": "integration-tests",
+            }
+        ]
+        job[0].update(self.__mig_payload_extra)
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=job,
-        description=self.__mig_title + ' Test - create initial',
-        application=self.TEST_APP)
+        # We set the timeout to 10 minutes, as Spinnaker is returning success once
+        # it has seen the new instance appear, but the contract is waiting for the
+        # instance group's self-reported size to be the new size. There is sometimes a
+        # delay of several minutes between the instance first appearing and the instance
+        # group manager reporting the new size. In order to avoid intermittently failing
+        # tests, we set a reasonably long timeout to wait for consistency between the
+        # Spinnaker internal contract and the contract this test is measuring.
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder(
+                self.__mig_title + " Resized", retryable_for_secs=600
+            )
+            .inspect_resource(
+                self.__mig_resource_name,
+                self.__server_group_name,
+                **self.__mig_resource_kwargs
+            )
+            .EXPECT(ov_factory.value_list_path_contains("size", jp.NUM_EQ(2)))
+        )
 
-    return st.OperationContract(
-      self.new_post_operation(
-          title='create_server_group', data=payload, path=self.__path),
-      contract=builder.build())
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=job,
+            description=self.__mig_title + " Test - resize to 2 instances",
+            application=self.TEST_APP,
+        )
 
-  def resize_server_group(self):
-    job = [{
-      'targetSize': 2,
-      'capacity': {
-        'min': 2,
-        'max': 2,
-        'desired': 2
-      },
-      'replicaPoolName': self.__server_group_name,
-      'numReplicas': 2,
-      'region': self.TEST_REGION,
-      'zone': self.TEST_ZONE,
-      'asgName': self.__server_group_name,
-      'serverGroupName': self.__server_group_name,
-      'type': 'resizeServerGroup',
-      'regions': [self.TEST_REGION],
-      'zones': [self.TEST_ZONE],
-      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      'cloudProvider': 'gce',
-      'user': 'integration-tests'
-    }]
-    job[0].update(self.__mig_payload_extra)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="resize_instances", data=payload, path=self.__path
+            ),
+            contract=builder.build(),
+        )
 
-    # We set the timeout to 10 minutes, as Spinnaker is returning success once
-    # it has seen the new instance appear, but the contract is waiting for the
-    # instance group's self-reported size to be the new size. There is sometimes a
-    # delay of several minutes between the instance first appearing and the instance
-    # group manager reporting the new size. In order to avoid intermittently failing
-    # tests, we set a reasonably long timeout to wait for consistency between the
-    # Spinnaker internal contract and the contract this test is measuring.
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder(
-        self.__mig_title + ' Resized', retryable_for_secs=600)
-     .inspect_resource(self.__mig_resource_name, self.__server_group_name,
-                       **self.__mig_resource_kwargs)
-     .EXPECT(ov_factory.value_list_path_contains('size', jp.NUM_EQ(2))))
+    def clone_server_group(self):
+        job = [
+            {
+                "application": self.TEST_APP,
+                "stack": self.TEST_STACK,
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                "loadBalancers": [self.__lb_name],
+                "targetSize": 1,
+                "capacity": {"min": 1, "max": 1, "desired": 1},
+                "zone": self.TEST_ZONE,
+                "network": "default",
+                "instanceMetadata": {"load-balancer-names": self.__lb_name},
+                "availabilityZones": {self.TEST_REGION: [self.TEST_ZONE]},
+                "cloudProvider": "gce",
+                "source": {
+                    "account": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    "region": self.TEST_REGION,
+                    "zone": self.TEST_ZONE,
+                    "serverGroupName": self.__server_group_name,
+                    "asgName": self.__server_group_name,
+                },
+                "instanceType": "f1-micro",
+                "image": self.bindings["TEST_GCE_IMAGE_NAME"],
+                "initialNumReplicas": 1,
+                "loadBalancers": [self.__lb_name],
+                "type": "cloneServerGroup",
+                "account": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                "user": "integration-tests",
+            }
+        ]
+        job[0].update(self.__mig_payload_extra)
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=job, description=self.__mig_title + ' Test - resize to 2 instances',
-        application=self.TEST_APP)
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder(
+                self.__mig_title + " Cloned", retryable_for_secs=90
+            )
+            .list_resource(self.__mig_manager_name, **self.__mig_manager_kwargs)
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "baseInstanceName", jp.STR_SUBSTR(self.__cloned_server_group_name)
+                )
+            )
+        )
+        (
+            builder.new_clause_builder(
+                "Instance template preserved", retryable_for_secs=150
+            )
+            .list_resource("instanceTemplates")
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "properties/metadata/items",
+                    jp.LIST_MATCHES(
+                        [
+                            jp.DICT_MATCHES(
+                                {
+                                    "key": jp.EQUIVALENT(self.__custom_user_data_key),
+                                    "value": jp.EQUIVALENT(
+                                        self.__custom_user_data_value
+                                    ),
+                                }
+                            )
+                        ]
+                    ),
+                )
+            )
+        )
 
-    return st.OperationContract(
-      self.new_post_operation(
-          title='resize_instances', data=payload, path=self.__path),
-      contract=builder.build())
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=job,
+            description=self.__mig_title + " Test - clone server group",
+            application=self.TEST_APP,
+        )
 
-  def clone_server_group(self):
-    job = [{
-      'application': self.TEST_APP,
-      'stack': self.TEST_STACK,
-      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      'loadBalancers': [self.__lb_name],
-      'targetSize': 1,
-      'capacity': {
-        'min': 1,
-        'max': 1,
-        'desired': 1
-      },
-      'zone': self.TEST_ZONE,
-      'network': 'default',
-      'instanceMetadata': {'load-balancer-names': self.__lb_name},
-      'availabilityZones': {self.TEST_REGION: [self.TEST_ZONE]},
-      'cloudProvider': 'gce',
-      'source': {
-        'account': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-        'region': self.TEST_REGION,
-        'zone': self.TEST_ZONE,
-        'serverGroupName': self.__server_group_name,
-        'asgName': self.__server_group_name
-      },
-      'instanceType': 'f1-micro',
-      'image': self.bindings['TEST_GCE_IMAGE_NAME'],
-      'initialNumReplicas': 1,
-      'loadBalancers': [self.__lb_name],
-      'type': 'cloneServerGroup',
-      'account': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      'user': 'integration-tests'
-    }]
-    job[0].update(self.__mig_payload_extra)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="clone_server_group", data=payload, path=self.__path
+            ),
+            contract=builder.build(),
+        )
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder(self.__mig_title + ' Cloned',
-                                retryable_for_secs=90)
-       .list_resource(self.__mig_manager_name, **self.__mig_manager_kwargs)
-       .EXPECT(ov_factory.value_list_path_contains(
-           'baseInstanceName', jp.STR_SUBSTR(self.__cloned_server_group_name))))
-    (builder.new_clause_builder('Instance template preserved',
-                                retryable_for_secs=150)
-       .list_resource('instanceTemplates')
-       .EXPECT(ov_factory.value_list_path_contains(
-           'properties/metadata/items',
-           jp.LIST_MATCHES([
-               jp.DICT_MATCHES({
-                   'key': jp.EQUIVALENT(self.__custom_user_data_key),
-                   'value': jp.EQUIVALENT(self.__custom_user_data_value)})
-           ])))
-    )
+    def disable_server_group(self):
+        job = [
+            {
+                "cloudProvider": "gce",
+                "asgName": self.__server_group_name,
+                "serverGroupName": self.__server_group_name,
+                "region": self.TEST_REGION,
+                "zone": self.TEST_ZONE,
+                "type": "disableServerGroup",
+                "regions": [self.TEST_REGION],
+                "zones": [self.TEST_ZONE],
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                "user": "integration-tests",
+            }
+        ]
+        job[0].update(self.__mig_payload_extra)
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=job, description=self.__mig_title + ' Test - clone server group',
-        application=self.TEST_APP)
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder(
+                self.__mig_title + " Disabled", retryable_for_secs=90
+            )
+            .list_resource(self.__mig_manager_name, **self.__mig_manager_kwargs)
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "baseInstanceName", jp.STR_SUBSTR(self.__server_group_name)
+                )
+            )
+            .AND(
+                ov_factory.value_list_excludes(
+                    jp.DICT_MATCHES(
+                        {
+                            "baseInstanceName": jp.STR_SUBSTR(self.__server_group_name),
+                            "targetPools": jp.LIST_MATCHES([jp.STR_SUBSTR("https")]),
+                        }
+                    )
+                )
+            )
+        )
 
-    return st.OperationContract(
-      self.new_post_operation(
-          title='clone_server_group', data=payload, path=self.__path),
-      contract=builder.build())
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=job,
+            description=self.__mig_title + " Test - disable server group",
+            application=self.TEST_APP,
+        )
 
-  def disable_server_group(self):
-    job = [{
-      'cloudProvider': 'gce',
-      'asgName': self.__server_group_name,
-      'serverGroupName': self.__server_group_name,
-      'region': self.TEST_REGION,
-      'zone': self.TEST_ZONE,
-      'type': 'disableServerGroup',
-      'regions': [self.TEST_REGION],
-      'zones': [self.TEST_ZONE],
-      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      'user': 'integration-tests'
-    }]
-    job[0].update(self.__mig_payload_extra)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="disable_server_group", data=payload, path=self.__path
+            ),
+            contract=builder.build(),
+        )
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder(self.__mig_title + ' Disabled',
-                                retryable_for_secs=90)
-     .list_resource(self.__mig_manager_name, **self.__mig_manager_kwargs)
-     .EXPECT(ov_factory.value_list_path_contains(
-         'baseInstanceName', jp.STR_SUBSTR(self.__server_group_name)))
-     .AND(ov_factory.value_list_excludes(
-         jp.DICT_MATCHES({
-            'baseInstanceName': jp.STR_SUBSTR(self.__server_group_name),
-            'targetPools': jp.LIST_MATCHES([jp.STR_SUBSTR('https')])
-            }))))
+    def enable_server_group(self):
+        job = [
+            {
+                "cloudProvider": "gce",
+                "asgName": self.__server_group_name,
+                "serverGroupName": self.__server_group_name,
+                "region": self.TEST_REGION,
+                "zone": self.TEST_ZONE,
+                "type": "enableServerGroup",
+                "regions": [self.TEST_REGION],
+                "zones": [self.TEST_ZONE],
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                "user": "integration-tests",
+            }
+        ]
+        job[0].update(self.__mig_payload_extra)
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=job, description=self.__mig_title + ' Test - disable server group',
-        application=self.TEST_APP)
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder(
+                self.__mig_title + " Enabled", retryable_for_secs=90
+            )
+            .list_resource(self.__mig_manager_name, **self.__mig_manager_kwargs)
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "baseInstanceName": jp.STR_SUBSTR(self.__server_group_name),
+                            "targetPools": jp.LIST_MATCHES([jp.STR_SUBSTR("https")]),
+                        }
+                    )
+                )
+            )
+        )
 
-    return st.OperationContract(
-      self.new_post_operation(
-          title='disable_server_group', data=payload, path=self.__path),
-      contract=builder.build())
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=job,
+            description=self.__mig_title + " Test - enable server group",
+            application=self.TEST_APP,
+        )
 
-  def enable_server_group(self):
-    job = [{
-      'cloudProvider': 'gce',
-      'asgName': self.__server_group_name,
-      'serverGroupName': self.__server_group_name,
-      'region': self.TEST_REGION,
-      'zone': self.TEST_ZONE,
-      'type': 'enableServerGroup',
-      'regions': [self.TEST_REGION],
-      'zones': [self.TEST_ZONE],
-      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      'user': 'integration-tests'
-    }]
-    job[0].update(self.__mig_payload_extra)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="enable_server_group", data=payload, path=self.__path
+            ),
+            contract=builder.build(),
+        )
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder(self.__mig_title + ' Enabled',
-                                retryable_for_secs=90)
-     .list_resource(self.__mig_manager_name, **self.__mig_manager_kwargs)
-     .EXPECT(ov_factory.value_list_contains(
-         jp.DICT_MATCHES({
-            'baseInstanceName': jp.STR_SUBSTR(self.__server_group_name),
-            'targetPools': jp.LIST_MATCHES([jp.STR_SUBSTR( 'https')])
-            }))))
+    def destroy_server_group(self, version):
+        serverGroupName = "%s-%s" % (self.__cluster_name, version)
+        job = [
+            {
+                "cloudProvider": "gce",
+                "asgName": serverGroupName,
+                "serverGroupName": serverGroupName,
+                "region": self.TEST_REGION,
+                "zone": self.TEST_ZONE,
+                "type": "destroyServerGroup",
+                "regions": [self.TEST_REGION],
+                "zones": [self.TEST_ZONE],
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                "user": "integration-tests",
+            }
+        ]
+        job[0].update(self.__mig_payload_extra)
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=job, description=self.__mig_title + ' Test - enable server group',
-        application=self.TEST_APP)
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder(
+                self.__mig_title + " Destroyed", retryable_for_secs=90
+            )
+            .list_resource(self.__mig_manager_name, **self.__mig_manager_kwargs)
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "baseInstanceName", jp.STR_SUBSTR(serverGroupName)
+                )
+            )
+        )
 
-    return st.OperationContract(
-      self.new_post_operation(
-          title='enable_server_group', data=payload, path=self.__path),
-      contract=builder.build())
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=job,
+            description=self.__mig_title + " Test - destroy server group",
+            application=self.TEST_APP,
+        )
 
-  def destroy_server_group(self, version):
-    serverGroupName = '%s-%s' % (self.__cluster_name, version)
-    job = [{
-      'cloudProvider': 'gce',
-      'asgName': serverGroupName,
-      'serverGroupName': serverGroupName,
-      'region': self.TEST_REGION,
-      'zone': self.TEST_ZONE,
-      'type': 'destroyServerGroup',
-      'regions': [self.TEST_REGION],
-      'zones': [self.TEST_ZONE],
-      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      'user': 'integration-tests'
-    }]
-    job[0].update(self.__mig_payload_extra)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="destroy_server_group", data=payload, path=self.__path
+            ),
+            contract=builder.build(),
+        )
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder(self.__mig_title + ' Destroyed',
-                                retryable_for_secs=90)
-     .list_resource(self.__mig_manager_name, **self.__mig_manager_kwargs)
-     .EXPECT(ov_factory.value_list_path_excludes(
-         'baseInstanceName', jp.STR_SUBSTR(serverGroupName))))
+    def delete_load_balancer(self):
+        job = [
+            {
+                "loadBalancerName": self.__lb_name,
+                "networkLoadBalancerName": self.__lb_name,
+                "region": self.TEST_REGION,
+                "type": "deleteLoadBalancer",
+                "regions": [self.TEST_REGION],
+                "credentials": self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                "cloudProvider": "gce",
+                "user": "integration-tests",
+            }
+        ]
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=job, description=self.__mig_title + ' Test - destroy server group',
-        application=self.TEST_APP)
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Load Balancer Created", retryable_for_secs=30)
+            .list_resource("forwardingRules")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__lb_name)
+                )
+            )
+        )
 
-    return st.OperationContract(
-      self.new_post_operation(
-          title='destroy_server_group', data=payload, path=self.__path),
-      contract=builder.build())
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=job,
+            description=self.__mig_title + " Test - delete load balancer",
+            application=self.TEST_APP,
+        )
 
-  def delete_load_balancer(self):
-    job = [{
-      "loadBalancerName": self.__lb_name,
-      "networkLoadBalancerName": self.__lb_name,
-      "region": self.TEST_REGION,
-      "type": "deleteLoadBalancer",
-      "regions": [self.TEST_REGION],
-      "credentials": self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-      "cloudProvider": "gce",
-      "user": "integration-tests"
-    }]
-
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Load Balancer Created', retryable_for_secs=30)
-     .list_resource('forwardingRules')
-     .EXPECT(ov_factory.value_list_path_excludes(
-         'name', jp.STR_SUBSTR(self.__lb_name))))
-
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=job, description=self.__mig_title + ' Test - delete load balancer',
-        application=self.TEST_APP)
-
-    return st.OperationContract(
-      self.new_post_operation(
-          title='delete_load_balancer', data=payload, path=self.__path),
-      contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete_load_balancer", data=payload, path=self.__path
+            ),
+            contract=builder.build(),
+        )
 
 
 class GoogleServerGroupTest(st.AgentTestCase):
+    @staticmethod
+    def setUpClass():
+        runner = citest.base.TestRunner.global_runner()
+        scenario = runner.get_shared_data(GoogleServerGroupTestScenario)
+        managed_region = scenario.bindings["TEST_GCE_REGION"]
+        title = "Check Quota for {0}".format(scenario.__class__.__name__)
 
-  @staticmethod
-  def setUpClass():
-    runner = citest.base.TestRunner.global_runner()
-    scenario = runner.get_shared_data(GoogleServerGroupTestScenario)
-    managed_region = scenario.bindings['TEST_GCE_REGION']
-    title = 'Check Quota for {0}'.format(scenario.__class__.__name__)
+        verify_results = gcp.verify_quota(
+            title,
+            scenario.gcp_observer,
+            project_quota=GoogleServerGroupTestScenario.MINIMUM_PROJECT_QUOTA,
+            regions=[
+                (managed_region, GoogleServerGroupTestScenario.MINIMUM_REGION_QUOTA)
+            ],
+        )
+        if not verify_results:
+            raise RuntimeError("Insufficient Quota: {0}".format(verify_results))
 
-    verify_results = gcp.verify_quota(
-        title,
-        scenario.gcp_observer,
-        project_quota=GoogleServerGroupTestScenario.MINIMUM_PROJECT_QUOTA,
-        regions=[(managed_region,
-                  GoogleServerGroupTestScenario.MINIMUM_REGION_QUOTA)])
-    if not verify_results:
-      raise RuntimeError('Insufficient Quota: {0}'.format(verify_results))
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            GoogleServerGroupTestScenario
+        )
 
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-        GoogleServerGroupTestScenario)
+    def test_a_create_app(self):
+        self.run_test_case(self.scenario.create_app())
 
-  def test_a_create_app(self):
-    self.run_test_case(self.scenario.create_app())
+    def test_b_create_load_balancer(self):
+        self.run_test_case(self.scenario.create_load_balancer())
 
-  def test_b_create_load_balancer(self):
-    self.run_test_case(self.scenario.create_load_balancer())
+    def test_c_create_server_group(self):
+        self.run_test_case(self.scenario.create_server_group(), poll_every_secs=3)
 
-  def test_c_create_server_group(self):
-    self.run_test_case(self.scenario.create_server_group(),
-                       poll_every_secs=3)
+    def test_d_resize_server_group(self):
+        self.run_test_case(self.scenario.resize_server_group())
 
-  def test_d_resize_server_group(self):
-    self.run_test_case(self.scenario.resize_server_group())
+    def test_e_clone_server_group(self):
+        self.run_test_case(self.scenario.clone_server_group(), poll_every_secs=3)
 
-  def test_e_clone_server_group(self):
-    self.run_test_case(self.scenario.clone_server_group(),
-                       poll_every_secs=3)
+    def test_f_disable_server_group(self):
+        self.run_test_case(self.scenario.disable_server_group())
 
-  def test_f_disable_server_group(self):
-    self.run_test_case(self.scenario.disable_server_group())
+    def test_g_enable_server_group(self):
+        self.run_test_case(self.scenario.enable_server_group())
 
-  def test_g_enable_server_group(self):
-    self.run_test_case(self.scenario.enable_server_group())
+    def test_w_destroy_server_group_v000(self):
+        self.run_test_case(
+            self.scenario.destroy_server_group("v000"), poll_every_secs=5
+        )
 
-  def test_w_destroy_server_group_v000(self):
-    self.run_test_case(self.scenario.destroy_server_group('v000'),
-                       poll_every_secs=5)
+    def test_x_destroy_server_group_v001(self):
+        self.run_test_case(
+            self.scenario.destroy_server_group("v001"), poll_every_secs=5
+        )
 
-  def test_x_destroy_server_group_v001(self):
-    self.run_test_case(self.scenario.destroy_server_group('v001'),
-                       poll_every_secs=5)
+    def test_y_delete_load_balancer(self):
+        self.run_test_case(self.scenario.delete_load_balancer(), poll_every_secs=5)
 
-  def test_y_delete_load_balancer(self):
-    self.run_test_case(self.scenario.delete_load_balancer(),
-                       poll_every_secs=5)
-
-  def test_z_delete_app(self):
-    self.run_test_case(self.scenario.delete_app(),
-                       retry_interval_secs=8, max_retries=8)
+    def test_z_delete_app(self):
+        self.run_test_case(
+            self.scenario.delete_app(), retry_interval_secs=8, max_retries=8
+        )
 
 
 def main():
 
-  # These are only used by our scenario.
-  # We'll rebind them in the constructor so we can consider command-line args.
-  defaults = {
-    'TEST_STACK': '',
-    'TEST_APP': '',
-  }
+    # These are only used by our scenario.
+    # We'll rebind them in the constructor so we can consider command-line args.
+    defaults = {
+        "TEST_STACK": "",
+        "TEST_APP": "",
+    }
 
-  return citest.base.TestRunner.main(
-      parser_inits=[GoogleServerGroupTestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[GoogleServerGroupTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[GoogleServerGroupTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[GoogleServerGroupTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/google_smoke_test.py
+++ b/testing/citest/tests/google_smoke_test.py
@@ -49,6 +49,7 @@ import citest.gcp_testing as gcp
 import citest.json_contract as jc
 import citest.json_predicate as jp
 import citest.service_testing as st
+
 ov_factory = jc.ObservationPredicateFactory()
 
 # Spinnaker modules.
@@ -60,376 +61,451 @@ import citest.base
 
 
 class GoogleSmokeTestScenario(sk.SpinnakerTestScenario):
-  """Defines the scenario for the smoke test.
+    """Defines the scenario for the smoke test.
 
-  This scenario defines the different test operations.
-  We're going to:
-    Create a Spinnaker Application
-    Create a Load Balancer
-    Create a Server Group
-    Delete each of the above (in reverse order)
-  """
-
-  MINIMUM_PROJECT_QUOTA = {
-      'INSTANCE_TEMPLATES': 1,
-      'HEALTH_CHECKS': 1,
-      'FORWARDING_RULES': 1,
-      'IN_USE_ADDRESSES': 2,
-      'TARGET_POOLS': 1,
-  }
-
-  MINIMUM_REGION_QUOTA = {
-      'CPUS': 2,
-      'IN_USE_ADDRESSES': 2,
-      'INSTANCE_GROUP_MANAGERS': 1,
-      'INSTANCES': 2,
-  }
-
-  @classmethod
-  def new_agent(cls, bindings):
-    """Implements citest.service_testing.AgentTestScenario.new_agent."""
-    return gate.new_agent(bindings)
-
-  @classmethod
-  def initArgumentParser(cls, parser, defaults=None):
-    """Initialize command line argument parser.
-
-    Args:
-      parser: argparse.ArgumentParser
+    This scenario defines the different test operations.
+    We're going to:
+      Create a Spinnaker Application
+      Create a Load Balancer
+      Create a Server Group
+      Delete each of the above (in reverse order)
     """
-    super(GoogleSmokeTestScenario, cls).initArgumentParser(
-        parser, defaults=defaults)
 
-  def __init__(self, bindings, agent=None):
-    """Constructor.
-
-    Args:
-      bindings: [dict] The data bindings to use to configure the scenario.
-      agent: [GateAgent] The agent for invoking the test operations on Gate.
-    """
-    super(GoogleSmokeTestScenario, self).__init__(bindings, agent)
-
-    bindings = self.bindings
-
-    self.__lb_detail = 'lb'
-    self.__lb_name = '{app}-{stack}-{detail}'.format(
-        app=bindings['TEST_APP'], stack=bindings['TEST_STACK'],
-        detail=self.__lb_detail)
-
-    # We'll call out the app name because it is widely used
-    # because it scopes the context of our activities.
-    # pylint: disable=invalid-name
-    self.TEST_APP = bindings['TEST_APP']
-
-  def create_app(self):
-    """Creates OperationContract that creates a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_create_app_operation(
-            bindings=self.bindings, application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-            cloud_providers="gce"),
-        contract=contract)
-
-  def delete_app(self):
-    """Creates OperationContract that deletes a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_delete_app_operation(
-            application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_GOOGLE_ACCOUNT']),
-        contract=contract)
-
-  def upsert_load_balancer(self):
-    """Creates OperationContract for upsertLoadBalancer.
-
-    Calls Spinnaker's upsertLoadBalancer with a configuration, then verifies
-    that the expected resources and configurations are visible on GCE. See
-    the contract builder for more info on what the expectations are.
-    """
-    bindings = self.bindings
-    target_pool_name = '{0}/targetPools/{1}-tp'.format(
-        bindings['TEST_GCE_REGION'], self.__lb_name)
-
-    spec = {
-        'checkIntervalSec': 9,
-        'healthyThreshold': 3,
-        'unhealthyThreshold': 5,
-        'timeoutSec': 2,
-        'port': 80
+    MINIMUM_PROJECT_QUOTA = {
+        "INSTANCE_TEMPLATES": 1,
+        "HEALTH_CHECKS": 1,
+        "FORWARDING_RULES": 1,
+        "IN_USE_ADDRESSES": 2,
+        "TARGET_POOLS": 1,
     }
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'gce',
-            'provider': 'gce',
-            'stack': bindings['TEST_STACK'],
-            'detail': self.__lb_detail,
-            'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-            'region': bindings['TEST_GCE_REGION'],
-            'ipProtocol': 'TCP',
-            'portRange': spec['port'],
-            'loadBalancerName': self.__lb_name,
-            'name': self.__lb_name,
-            'healthCheck': {
-                'port': spec['port'],
-                'timeoutSec': spec['timeoutSec'],
-                'checkIntervalSec': spec['checkIntervalSec'],
-                'healthyThreshold': spec['healthyThreshold'],
-                'unhealthyThreshold': spec['unhealthyThreshold'],
-            },
-            'type': 'upsertLoadBalancer',
-            'availabilityZones': {bindings['TEST_GCE_REGION']: []},
-            'user': '[anonymous]'
-        }],
-        description='Create Load Balancer: ' + self.__lb_name,
-        application=self.TEST_APP)
+    MINIMUM_REGION_QUOTA = {
+        "CPUS": 2,
+        "IN_USE_ADDRESSES": 2,
+        "INSTANCE_GROUP_MANAGERS": 1,
+        "INSTANCES": 2,
+    }
 
-    hc_match_spec = {key: jp.NUM_EQ(value) for key, value in spec.items()}
-    hc_match_spec['name'] = jp.STR_SUBSTR('%s-hc' % self.__lb_name)
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Health Check Added',
-                                retryable_for_secs=30)
-     .list_resource('httpHealthChecks')
-     .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES(hc_match_spec))))
-    (builder.new_clause_builder('Target Pool Added',
-                                retryable_for_secs=30)
-     .list_resource('targetPools')
-     .EXPECT(ov_factory.value_list_path_contains(
-         'name', jp.STR_SUBSTR('%s-tp' % self.__lb_name))))
-    (builder.new_clause_builder('Forwarding Rules Added',
-                                retryable_for_secs=30)
-     .list_resource('forwardingRules')
-     .EXPECT(ov_factory.value_list_contains(
-        jp.DICT_MATCHES({
-          'name': jp.STR_SUBSTR(self.__lb_name),
-          'target': jp.STR_SUBSTR(target_pool_name)}))))
+    @classmethod
+    def new_agent(cls, bindings):
+        """Implements citest.service_testing.AgentTestScenario.new_agent."""
+        return gate.new_agent(bindings)
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='upsert_load_balancer', data=payload, path='tasks'),
-        contract=builder.build())
+    @classmethod
+    def initArgumentParser(cls, parser, defaults=None):
+        """Initialize command line argument parser.
 
-  def delete_load_balancer(self):
-    """Creates OperationContract for deleteLoadBalancer.
+        Args:
+          parser: argparse.ArgumentParser
+        """
+        super(GoogleSmokeTestScenario, cls).initArgumentParser(
+            parser, defaults=defaults
+        )
 
-    To verify the operation, we just check that the GCP resources
-    created by upsert_load_balancer are no longer visible on GCP.
-    """
-    bindings = self.bindings
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'type': 'deleteLoadBalancer',
-            'cloudProvider': 'gce',
-            'loadBalancerName': self.__lb_name,
-            'region': bindings['TEST_GCE_REGION'],
-            'regions': [bindings['TEST_GCE_REGION']],
-            'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-            'user': '[anonymous]'
-        }],
-        description='Delete Load Balancer: {0} in {1}:{2}'.format(
-            self.__lb_name,
-            bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-            bindings['TEST_GCE_REGION']),
-        application=self.TEST_APP)
+    def __init__(self, bindings, agent=None):
+        """Constructor.
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Health Check Removed', retryable_for_secs=30)
-     .list_resource('httpHealthChecks')
-     .EXPECT(ov_factory.value_list_path_excludes(
-         'name', jp.STR_SUBSTR('%s-hc' % self.__lb_name))))
-    (builder.new_clause_builder('TargetPool Removed')
-     .list_resource('targetPools')
-     .EXPECT(ov_factory.value_list_path_excludes(
-         'name', jp.STR_SUBSTR('%s-tp' % self.__lb_name))))
-    (builder.new_clause_builder('Forwarding Rule Removed')
-     .list_resource('forwardingRules')
-     .EXPECT(ov_factory.value_list_path_excludes(
-         'name', jp.STR_SUBSTR(self.__lb_name))))
+        Args:
+          bindings: [dict] The data bindings to use to configure the scenario.
+          agent: [GateAgent] The agent for invoking the test operations on Gate.
+        """
+        super(GoogleSmokeTestScenario, self).__init__(bindings, agent)
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_load_balancer', data=payload, path='tasks'),
-        contract=builder.build())
+        bindings = self.bindings
 
-  def create_server_group(self):
-    """Creates OperationContract for createServerGroup.
+        self.__lb_detail = "lb"
+        self.__lb_name = "{app}-{stack}-{detail}".format(
+            app=bindings["TEST_APP"],
+            stack=bindings["TEST_STACK"],
+            detail=self.__lb_detail,
+        )
 
-    To verify the operation, we just check that Managed Instance Group
-    for the server was created.
-    """
-    bindings = self.bindings
+        # We'll call out the app name because it is widely used
+        # because it scopes the context of our activities.
+        # pylint: disable=invalid-name
+        self.TEST_APP = bindings["TEST_APP"]
 
-    # Spinnaker determines the group name created,
-    # which will be the following:
-    group_name = '{app}-{stack}-v000'.format(
-        app=self.TEST_APP, stack=bindings['TEST_STACK'])
+    def create_app(self):
+        """Creates OperationContract that creates a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_create_app_operation(
+                bindings=self.bindings,
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                cloud_providers="gce",
+            ),
+            contract=contract,
+        )
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'gce',
-            'application': self.TEST_APP,
-            'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-            'strategy':'',
-            'capacity': {'min':2, 'max':2, 'desired':2},
-            'targetSize': 2,
-            'image': bindings['TEST_GCE_IMAGE_NAME'],
-            'zone': bindings['TEST_GCE_ZONE'],
-            'stack': bindings['TEST_STACK'],
-            'instanceType': 'f1-micro',
-            'type': 'createServerGroup',
-            'loadBalancers': [self.__lb_name],
-            'availabilityZones': {
-                bindings['TEST_GCE_REGION']: [bindings['TEST_GCE_ZONE']]
-            },
-            'instanceMetadata': {
-                'load-balancer-names': self.__lb_name
-            },
-            'account': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-            'authScopes': ['compute'],
-            'user': '[anonymous]'
-        }],
-        description='Create Server Group in ' + group_name,
-        application=self.TEST_APP)
+    def delete_app(self):
+        """Creates OperationContract that deletes a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_delete_app_operation(
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+            ),
+            contract=contract,
+        )
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Managed Instance Group Added',
-                                retryable_for_secs=30)
-     .inspect_resource('instanceGroupManagers', group_name)
-     .EXPECT(ov_factory.value_list_path_contains('targetSize', jp.NUM_EQ(2))))
+    def upsert_load_balancer(self):
+        """Creates OperationContract for upsertLoadBalancer.
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='create_server_group', data=payload, path='tasks'),
-        contract=builder.build())
+        Calls Spinnaker's upsertLoadBalancer with a configuration, then verifies
+        that the expected resources and configurations are visible on GCE. See
+        the contract builder for more info on what the expectations are.
+        """
+        bindings = self.bindings
+        target_pool_name = "{0}/targetPools/{1}-tp".format(
+            bindings["TEST_GCE_REGION"], self.__lb_name
+        )
 
-  def delete_server_group(self):
-    """Creates OperationContract for deleteServerGroup.
+        spec = {
+            "checkIntervalSec": 9,
+            "healthyThreshold": 3,
+            "unhealthyThreshold": 5,
+            "timeoutSec": 2,
+            "port": 80,
+        }
 
-    To verify the operation, we just check that the GCP managed instance group
-    is no longer visible on GCP (or is in the process of terminating).
-    """
-    bindings = self.bindings
-    group_name = '{app}-{stack}-v000'.format(
-        app=self.TEST_APP, stack=bindings['TEST_STACK'])
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "gce",
+                    "provider": "gce",
+                    "stack": bindings["TEST_STACK"],
+                    "detail": self.__lb_detail,
+                    "credentials": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    "region": bindings["TEST_GCE_REGION"],
+                    "ipProtocol": "TCP",
+                    "portRange": spec["port"],
+                    "loadBalancerName": self.__lb_name,
+                    "name": self.__lb_name,
+                    "healthCheck": {
+                        "port": spec["port"],
+                        "timeoutSec": spec["timeoutSec"],
+                        "checkIntervalSec": spec["checkIntervalSec"],
+                        "healthyThreshold": spec["healthyThreshold"],
+                        "unhealthyThreshold": spec["unhealthyThreshold"],
+                    },
+                    "type": "upsertLoadBalancer",
+                    "availabilityZones": {bindings["TEST_GCE_REGION"]: []},
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Create Load Balancer: " + self.__lb_name,
+            application=self.TEST_APP,
+        )
 
-    # TODO(ttomsu): Change this back from asgName to serverGroupName
-    #               once it is fixed in orca.
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'gce',
-            'serverGroupName': group_name,
-            'region': bindings['TEST_GCE_REGION'],
-            'zone': bindings['TEST_GCE_ZONE'],
-            'asgName': group_name,
-            'type': 'destroyServerGroup',
-            'regions': [bindings['TEST_GCE_REGION']],
-            'zones': [bindings['TEST_GCE_ZONE']],
-            'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
-            'user': '[anonymous]'
-        }],
-        application=self.TEST_APP,
-        description='DestroyServerGroup: ' + group_name)
+        hc_match_spec = {key: jp.NUM_EQ(value) for key, value in spec.items()}
+        hc_match_spec["name"] = jp.STR_SUBSTR("%s-hc" % self.__lb_name)
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Health Check Added", retryable_for_secs=30)
+            .list_resource("httpHealthChecks")
+            .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES(hc_match_spec)))
+        )
+        (
+            builder.new_clause_builder("Target Pool Added", retryable_for_secs=30)
+            .list_resource("targetPools")
+            .EXPECT(
+                ov_factory.value_list_path_contains(
+                    "name", jp.STR_SUBSTR("%s-tp" % self.__lb_name)
+                )
+            )
+        )
+        (
+            builder.new_clause_builder("Forwarding Rules Added", retryable_for_secs=30)
+            .list_resource("forwardingRules")
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_SUBSTR(self.__lb_name),
+                            "target": jp.STR_SUBSTR(target_pool_name),
+                        }
+                    )
+                )
+            )
+        )
 
-    builder = gcp.GcpContractBuilder(self.gcp_observer)
-    (builder.new_clause_builder('Managed Instance Group Removed')
-     .inspect_resource('instanceGroupManagers', group_name)
-     .EXPECT(ov_factory.error_list_contains(
-         gcp.HttpErrorPredicate(http_code=404)))
-     .OR(ov_factory.value_list_path_contains('targetSize', jp.NUM_EQ(0))))
+        return st.OperationContract(
+            self.new_post_operation(
+                title="upsert_load_balancer", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
-    (builder.new_clause_builder('Instances Are Removed',
-                                retryable_for_secs=30)
-     .list_resource('instances')
-     .EXPECT(
-         ov_factory.value_list_path_excludes(
-             'name', jp.STR_SUBSTR(group_name))))
+    def delete_load_balancer(self):
+        """Creates OperationContract for deleteLoadBalancer.
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_server_group', data=payload, path='tasks'),
-        contract=builder.build())
+        To verify the operation, we just check that the GCP resources
+        created by upsert_load_balancer are no longer visible on GCP.
+        """
+        bindings = self.bindings
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "type": "deleteLoadBalancer",
+                    "cloudProvider": "gce",
+                    "loadBalancerName": self.__lb_name,
+                    "region": bindings["TEST_GCE_REGION"],
+                    "regions": [bindings["TEST_GCE_REGION"]],
+                    "credentials": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Delete Load Balancer: {0} in {1}:{2}".format(
+                self.__lb_name,
+                bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                bindings["TEST_GCE_REGION"],
+            ),
+            application=self.TEST_APP,
+        )
+
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Health Check Removed", retryable_for_secs=30)
+            .list_resource("httpHealthChecks")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR("%s-hc" % self.__lb_name)
+                )
+            )
+        )
+        (
+            builder.new_clause_builder("TargetPool Removed")
+            .list_resource("targetPools")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR("%s-tp" % self.__lb_name)
+                )
+            )
+        )
+        (
+            builder.new_clause_builder("Forwarding Rule Removed")
+            .list_resource("forwardingRules")
+            .EXPECT(
+                ov_factory.value_list_path_excludes(
+                    "name", jp.STR_SUBSTR(self.__lb_name)
+                )
+            )
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete_load_balancer", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
+
+    def create_server_group(self):
+        """Creates OperationContract for createServerGroup.
+
+        To verify the operation, we just check that Managed Instance Group
+        for the server was created.
+        """
+        bindings = self.bindings
+
+        # Spinnaker determines the group name created,
+        # which will be the following:
+        group_name = "{app}-{stack}-v000".format(
+            app=self.TEST_APP, stack=bindings["TEST_STACK"]
+        )
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "gce",
+                    "application": self.TEST_APP,
+                    "credentials": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    "strategy": "",
+                    "capacity": {"min": 2, "max": 2, "desired": 2},
+                    "targetSize": 2,
+                    "image": bindings["TEST_GCE_IMAGE_NAME"],
+                    "zone": bindings["TEST_GCE_ZONE"],
+                    "stack": bindings["TEST_STACK"],
+                    "instanceType": "f1-micro",
+                    "type": "createServerGroup",
+                    "loadBalancers": [self.__lb_name],
+                    "availabilityZones": {
+                        bindings["TEST_GCE_REGION"]: [bindings["TEST_GCE_ZONE"]]
+                    },
+                    "instanceMetadata": {"load-balancer-names": self.__lb_name},
+                    "account": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    "authScopes": ["compute"],
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Create Server Group in " + group_name,
+            application=self.TEST_APP,
+        )
+
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder(
+                "Managed Instance Group Added", retryable_for_secs=30
+            )
+            .inspect_resource("instanceGroupManagers", group_name)
+            .EXPECT(ov_factory.value_list_path_contains("targetSize", jp.NUM_EQ(2)))
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="create_server_group", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
+
+    def delete_server_group(self):
+        """Creates OperationContract for deleteServerGroup.
+
+        To verify the operation, we just check that the GCP managed instance group
+        is no longer visible on GCP (or is in the process of terminating).
+        """
+        bindings = self.bindings
+        group_name = "{app}-{stack}-v000".format(
+            app=self.TEST_APP, stack=bindings["TEST_STACK"]
+        )
+
+        # TODO(ttomsu): Change this back from asgName to serverGroupName
+        #               once it is fixed in orca.
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "gce",
+                    "serverGroupName": group_name,
+                    "region": bindings["TEST_GCE_REGION"],
+                    "zone": bindings["TEST_GCE_ZONE"],
+                    "asgName": group_name,
+                    "type": "destroyServerGroup",
+                    "regions": [bindings["TEST_GCE_REGION"]],
+                    "zones": [bindings["TEST_GCE_ZONE"]],
+                    "credentials": bindings["SPINNAKER_GOOGLE_ACCOUNT"],
+                    "user": "[anonymous]",
+                }
+            ],
+            application=self.TEST_APP,
+            description="DestroyServerGroup: " + group_name,
+        )
+
+        builder = gcp.GcpContractBuilder(self.gcp_observer)
+        (
+            builder.new_clause_builder("Managed Instance Group Removed")
+            .inspect_resource("instanceGroupManagers", group_name)
+            .EXPECT(
+                ov_factory.error_list_contains(gcp.HttpErrorPredicate(http_code=404))
+            )
+            .OR(ov_factory.value_list_path_contains("targetSize", jp.NUM_EQ(0)))
+        )
+
+        (
+            builder.new_clause_builder("Instances Are Removed", retryable_for_secs=30)
+            .list_resource("instances")
+            .EXPECT(
+                ov_factory.value_list_path_excludes("name", jp.STR_SUBSTR(group_name))
+            )
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete_server_group", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
 
 class GoogleSmokeTest(st.AgentTestCase):
-  """The test fixture for the SmokeTest.
+    """The test fixture for the SmokeTest.
 
-  This is implemented using citest OperationContract instances that are
-  created by the GoogleSmokeTestScenario.
-  """
-  # pylint: disable=missing-docstring
+    This is implemented using citest OperationContract instances that are
+    created by the GoogleSmokeTestScenario.
+    """
 
-  @staticmethod
-  def setUpClass():
-    runner = citest.base.TestRunner.global_runner()
-    scenario = runner.get_shared_data(GoogleSmokeTestScenario)
-    managed_region = scenario.bindings['TEST_GCE_REGION']
-    title = 'Check Quota for {0}'.format(scenario.__class__.__name__)
+    # pylint: disable=missing-docstring
 
-    verify_results = gcp.verify_quota(
-        title,
-        scenario.gcp_observer,
-        project_quota=GoogleSmokeTestScenario.MINIMUM_PROJECT_QUOTA,
-        regions=[(managed_region,
-                  GoogleSmokeTestScenario.MINIMUM_REGION_QUOTA)])
-    if not verify_results:
-      raise RuntimeError('Insufficient Quota: {0}'.format(verify_results))
+    @staticmethod
+    def setUpClass():
+        runner = citest.base.TestRunner.global_runner()
+        scenario = runner.get_shared_data(GoogleSmokeTestScenario)
+        managed_region = scenario.bindings["TEST_GCE_REGION"]
+        title = "Check Quota for {0}".format(scenario.__class__.__name__)
 
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-        GoogleSmokeTestScenario)
+        verify_results = gcp.verify_quota(
+            title,
+            scenario.gcp_observer,
+            project_quota=GoogleSmokeTestScenario.MINIMUM_PROJECT_QUOTA,
+            regions=[(managed_region, GoogleSmokeTestScenario.MINIMUM_REGION_QUOTA)],
+        )
+        if not verify_results:
+            raise RuntimeError("Insufficient Quota: {0}".format(verify_results))
 
-  def test_a_create_app(self):
-    self.run_test_case(self.scenario.create_app())
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            GoogleSmokeTestScenario
+        )
 
-  def test_b_upsert_load_balancer(self):
-    self.run_test_case(self.scenario.upsert_load_balancer())
+    def test_a_create_app(self):
+        self.run_test_case(self.scenario.create_app())
 
-  def test_c_create_server_group(self):
-    # We'll permit this to timeout for now
-    # because it might be waiting on confirmation
-    # but we'll continue anyway because side effects
-    # should have still taken place.
-    self.run_test_case(self.scenario.create_server_group(), timeout_ok=True,
-                       poll_every_secs=3)
+    def test_b_upsert_load_balancer(self):
+        self.run_test_case(self.scenario.upsert_load_balancer())
 
-  def test_d_upsert_http_load_balancer(self):
-    self.run_test_case(GoogleHttpLoadBalancerTestScenario(self.scenario.bindings)
-                       .upsert_min_load_balancer())
+    def test_c_create_server_group(self):
+        # We'll permit this to timeout for now
+        # because it might be waiting on confirmation
+        # but we'll continue anyway because side effects
+        # should have still taken place.
+        self.run_test_case(
+            self.scenario.create_server_group(), timeout_ok=True, poll_every_secs=3
+        )
 
-  def test_e_delete_http_load_balancer(self):
-    self.run_test_case(GoogleHttpLoadBalancerTestScenario(self.scenario.bindings)
-                       .delete_http_load_balancer())
+    def test_d_upsert_http_load_balancer(self):
+        self.run_test_case(
+            GoogleHttpLoadBalancerTestScenario(
+                self.scenario.bindings
+            ).upsert_min_load_balancer()
+        )
 
-  def test_x_delete_server_group(self):
-    self.run_test_case(self.scenario.delete_server_group(),
-                       poll_every_secs=3, max_retries=5)
+    def test_e_delete_http_load_balancer(self):
+        self.run_test_case(
+            GoogleHttpLoadBalancerTestScenario(
+                self.scenario.bindings
+            ).delete_http_load_balancer()
+        )
 
-  def test_y_delete_load_balancer(self):
-    self.run_test_case(self.scenario.delete_load_balancer(),
-                       max_retries=5)
+    def test_x_delete_server_group(self):
+        self.run_test_case(
+            self.scenario.delete_server_group(), poll_every_secs=3, max_retries=5
+        )
 
-  def test_z_delete_app(self):
-    # Give a total of a minute because it might also need
-    # an internal cache update
-    self.run_test_case(self.scenario.delete_app(),
-                       retry_interval_secs=8, max_retries=8)
+    def test_y_delete_load_balancer(self):
+        self.run_test_case(self.scenario.delete_load_balancer(), max_retries=5)
+
+    def test_z_delete_app(self):
+        # Give a total of a minute because it might also need
+        # an internal cache update
+        self.run_test_case(
+            self.scenario.delete_app(), retry_interval_secs=8, max_retries=8
+        )
 
 
 def main():
-  """Implements the main method running this smoke test."""
+    """Implements the main method running this smoke test."""
 
-  defaults = {
-      'TEST_STACK': str(GoogleSmokeTestScenario.DEFAULT_TEST_ID),
-      'TEST_APP': 'gcpsmoketest' + GoogleSmokeTestScenario.DEFAULT_TEST_ID
-  }
+    defaults = {
+        "TEST_STACK": str(GoogleSmokeTestScenario.DEFAULT_TEST_ID),
+        "TEST_APP": "gcpsmoketest" + GoogleSmokeTestScenario.DEFAULT_TEST_ID,
+    }
 
-  return citest.base.TestRunner.main(
-      parser_inits=[GoogleSmokeTestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[GoogleSmokeTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[GoogleSmokeTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[GoogleSmokeTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/kube_v2_artifact_test.py
+++ b/testing/citest/tests/kube_v2_artifact_test.py
@@ -36,440 +36,491 @@ import citest.base
 
 ov_factory = jc.ObservationPredicateFactory()
 
+
 class KubeV2ArtifactTestScenario(sk.SpinnakerTestScenario):
-  """Defines the scenario for the kube v2 artifact test.
-  """
+    """Defines the scenario for the kube v2 artifact test."""
 
-  @classmethod
-  def new_agent(cls, bindings):
-    """Implements citest.service_testing.AgentTestScenario.new_agent."""
-    agent = gate.new_agent(bindings)
-    agent.default_max_wait_secs = 180
-    return agent
+    @classmethod
+    def new_agent(cls, bindings):
+        """Implements citest.service_testing.AgentTestScenario.new_agent."""
+        agent = gate.new_agent(bindings)
+        agent.default_max_wait_secs = 180
+        return agent
 
-  @classmethod
-  def initArgumentParser(cls, parser, defaults=None):
-    """Initialize command line argument parser.
+    @classmethod
+    def initArgumentParser(cls, parser, defaults=None):
+        """Initialize command line argument parser.
 
-    Args:
-      parser: argparse.ArgumentParser
-    """
-    super(KubeV2ArtifactTestScenario, cls).initArgumentParser(
-        parser, defaults=defaults)
+        Args:
+          parser: argparse.ArgumentParser
+        """
+        super(KubeV2ArtifactTestScenario, cls).initArgumentParser(
+            parser, defaults=defaults
+        )
 
-    defaults = defaults or {}
-    parser.add_argument(
-      '--test_namespace', default='default',
-      help='The namespace to manage within the tests.')
+        defaults = defaults or {}
+        parser.add_argument(
+            "--test_namespace",
+            default="default",
+            help="The namespace to manage within the tests.",
+        )
 
-  def __init__(self, bindings, agent=None):
-    """Constructor.
+    def __init__(self, bindings, agent=None):
+        """Constructor.
 
-    Args:
-      bindings: [dict] The data bindings to use to configure the scenario.
-      agent: [GateAgent] The agent for invoking the test operations on Gate.
-    """
-    super(KubeV2ArtifactTestScenario, self).__init__(bindings, agent)
-    bindings = self.bindings
+        Args:
+          bindings: [dict] The data bindings to use to configure the scenario.
+          agent: [GateAgent] The agent for invoking the test operations on Gate.
+        """
+        super(KubeV2ArtifactTestScenario, self).__init__(bindings, agent)
+        bindings = self.bindings
 
-    # We'll call out the app name because it is widely used
-    # because it scopes the context of our activities.
-    # pylint: disable=invalid-name
-    self.TEST_APP = bindings['TEST_APP']
-    self.TEST_USER = bindings['TEST_USER']
+        # We'll call out the app name because it is widely used
+        # because it scopes the context of our activities.
+        # pylint: disable=invalid-name
+        self.TEST_APP = bindings["TEST_APP"]
+        self.TEST_USER = bindings["TEST_USER"]
 
-    # Take just the first if there are multiple
-    # because some uses below assume just one.
-    self.TEST_NAMESPACE = bindings['TEST_NAMESPACE'].split(',')[0]
+        # Take just the first if there are multiple
+        # because some uses below assume just one.
+        self.TEST_NAMESPACE = bindings["TEST_NAMESPACE"].split(",")[0]
 
-    self.mf = sk.KubernetesManifestFactory(self)
-    self.mp = sk.KubernetesManifestPredicateFactory()
-    self.ps = sk.PipelineSupport(self)
+        self.mf = sk.KubernetesManifestFactory(self)
+        self.mp = sk.KubernetesManifestPredicateFactory()
+        self.ps = sk.PipelineSupport(self)
 
-  def create_app(self):
-    """Creates OperationContract that creates a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_create_app_operation(
-            bindings=self.bindings, application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            cloud_providers="kubernetes"),
-        contract=contract)
+    def create_app(self):
+        """Creates OperationContract that creates a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_create_app_operation(
+                bindings=self.bindings,
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                cloud_providers="kubernetes",
+            ),
+            contract=contract,
+        )
 
-  def delete_app(self):
-    """Creates OperationContract that deletes a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_delete_app_operation(
+    def delete_app(self):
+        """Creates OperationContract that deletes a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_delete_app_operation(
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+            ),
+            contract=contract,
+        )
+
+    def __docker_image_artifact(self, name, image):
+        id_ = "".join(
+            random.choice(string.ascii_uppercase + string.digits) for _ in range(10)
+        )
+        return {"type": "docker/image", "name": name, "reference": image, "uuid": id_}
+
+    def deploy_unversioned_config_map(self, value):
+        """Creates OperationContract for deploying an unversioned configmap
+
+        To verify the operation, we just check that the configmap was created with
+        the correct 'value'.
+        """
+        name = self.TEST_APP + "-configmap"
+        manifest = self.mf.config_map(name, {"value": value})
+        manifest["metadata"]["annotations"] = {
+            "strategy.spinnaker.io/versioned": "false"
+        }
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "moniker": {"app": self.TEST_APP},
+                    "account": self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "source": "text",
+                    "type": "deployManifest",
+                    "user": "[anonymous]",
+                    "manifests": [manifest],
+                }
+            ],
+            description="Deploy manifest",
             application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']),
-        contract=contract)
+        )
 
-  def __docker_image_artifact(self, name, image):
-    id_ = ''.join(random.choice(string.ascii_uppercase + string.digits)
-                  for _ in range(10))
-    return {
-      'type': 'docker/image',
-      'name': name,
-      'reference': image,
-      'uuid': id_
-    }
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("ConfigMap created", retryable_for_secs=15)
+            .get_resources(
+                "configmap", extra_args=[name, "--namespace", self.TEST_NAMESPACE]
+            )
+            .EXPECT(self.mp.config_map_key_value_predicate("value", value))
+        )
 
-  def deploy_unversioned_config_map(self, value):
-    """Creates OperationContract for deploying an unversioned configmap
+        return st.OperationContract(
+            self.new_post_operation(
+                title="deploy_manifest", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
-    To verify the operation, we just check that the configmap was created with
-    the correct 'value'.
-    """
-    name = self.TEST_APP + '-configmap'
-    manifest = self.mf.config_map(name, {'value': value})
-    manifest['metadata']['annotations'] = {'strategy.spinnaker.io/versioned': 'false'}
+    def deploy_deployment_with_config_map(self, versioned):
+        """Creates OperationContract for deploying a configmap along with a deployment
+        mounting this configmap.
 
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'moniker': {
-                'app': self.TEST_APP
-            },
-            'account': self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'source': 'text',
-            'type': 'deployManifest',
-            'user': '[anonymous]',
-            'manifests': [manifest],
-        }],
-        description='Deploy manifest',
-        application=self.TEST_APP)
+        To verify the operation, we just check that the deployment was created with
+        the correct configmap mounted
+        """
+        deployment_name = self.TEST_APP + "-deployment"
+        deployment = self.mf.deployment(deployment_name, "library/nginx")
+        configmap_name = self.TEST_APP + "-configmap"
+        configmap = self.mf.config_map(configmap_name, {"key": "value"})
 
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('ConfigMap created',
-                                retryable_for_secs=15)
-     .get_resources(
-         'configmap',
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.config_map_key_value_predicate('value', value)))
-
-    return st.OperationContract(
-        self.new_post_operation(
-            title='deploy_manifest', data=payload, path='tasks'),
-        contract=builder.build())
-
-  def deploy_deployment_with_config_map(self, versioned):
-    """Creates OperationContract for deploying a configmap along with a deployment
-    mounting this configmap.
-
-    To verify the operation, we just check that the deployment was created with
-    the correct configmap mounted
-    """
-    deployment_name = self.TEST_APP + '-deployment'
-    deployment = self.mf.deployment(deployment_name, 'library/nginx')
-    configmap_name = self.TEST_APP + '-configmap'
-    configmap = self.mf.config_map(configmap_name, {'key': 'value'})
-
-    if not versioned:
-      configmap['metadata']['annotations'] = {'strategy.spinnaker.io/versioned': 'false'}
-
-    self.mf.add_configmap_volume(deployment, configmap_name)
-
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'moniker': {
-                'app': self.TEST_APP
-            },
-            'account': self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'source': 'text',
-            'type': 'deployManifest',
-            'user': '[anonymous]',
-            'manifests': [deployment, configmap],
-        }],
-        description='Deploy manifest',
-        application=self.TEST_APP)
-
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Deployment created',
-                                retryable_for_secs=15)
-     .get_resources(
-         'deploy',
-         extra_args=[deployment_name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.deployment_configmap_mounted_predicate(configmap_name)))
-
-    return st.OperationContract(
-        self.new_post_operation(
-            title='deploy_manifest', data=payload, path='tasks'),
-        contract=builder.build())
-
-  def deploy_config_map(self, version):
-    """Creates OperationContract for deploying a versioned configmap
-
-    To verify the operation, we just check that the deployment was created with
-    the correct image.
-    """
-    bindings = self.bindings
-    name = self.TEST_APP + '-configmap'
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'moniker': {
-                'app': self.TEST_APP
-            },
-            'account': bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'source': 'text',
-            'type': 'deployManifest',
-            'user': '[anonymous]',
-            'manifests': [self.mf.config_map(name, {'version': version})],
-        }],
-        description='Deploy manifest',
-        application=self.TEST_APP)
-
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('ConfigMap created',
-                                retryable_for_secs=15)
-     .get_resources(
-         'configmap',
-         extra_args=[name + '-' + version, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.config_map_key_value_predicate('version', version)))
-
-    return st.OperationContract(
-        self.new_post_operation(
-            title='deploy_manifest', data=payload, path='tasks'),
-        contract=builder.build())
-
-  def save_configmap_deployment_pipeline(self, pipeline_name, versioned=True):
-    deployment_name = self.TEST_APP + '-deployment'
-    deployment = self.mf.deployment(deployment_name, 'library/nginx')
-    configmap_name = self.TEST_APP + '-configmap'
-    configmap = self.mf.config_map(configmap_name, {'key': 'value'})
-
-    if not versioned:
-      configmap['metadata']['annotations'] = {'strategy.spinnaker.io/versioned': 'false'}
-
-    self.mf.add_configmap_volume(deployment, configmap_name)
-    configmap_stage = {
-        'refId': 'configmap',
-        'name': 'Deploy configmap',
-        'type': 'deployManifest',
-        'cloudProvider': 'kubernetes',
-        'moniker': {
-            'app': self.TEST_APP
-        },
-        'account': self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-        'source': 'text',
-        'manifests': [configmap],
-    }
-
-    deployment_stage = {
-        'refId': 'deployment',
-        'name': 'Deploy deployment',
-        'requisiteStageRefIds': ['configmap'],
-        'type': 'deployManifest',
-        'cloudProvider': 'kubernetes',
-        'moniker': {
-            'app': self.TEST_APP
-        },
-        'account': self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-        'source': 'text',
-        'manifests': [deployment],
-    }
-
-    return self.ps.submit_pipeline_contract(pipeline_name,
-            [configmap_stage, deployment_stage],
-            user=self.TEST_USER)
-
-  def execute_deploy_manifest_pipeline(self, pipeline_name):
-    deployment_name = self.TEST_APP + '-deployment'
-    configmap_name = self.TEST_APP + '-configmap'
-    bindings = self.bindings
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'type': 'manual',
-            'user': '[anonymous]'
-        }],
-        description='Deploy manifest in ' + self.TEST_APP,
-        application=self.TEST_APP)
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Deployment created',
-                                retryable_for_secs=60)
-     .get_resources(
-         'deploy',
-         extra_args=[deployment_name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.deployment_configmap_mounted_predicate(configmap_name)))
-
-    return st.OperationContract(
-        self.new_post_operation(
-            title='Deploy manifest', data=payload,
-            path='pipelines/' + self.TEST_APP + '/' + pipeline_name),
-        contract=builder.build())
-
-  def deploy_deployment_with_docker_artifact(self, image):
-    """Creates OperationContract for deploying and substituting one image into
-    a Deployment object
-
-    To verify the operation, we just check that the deployment was created with
-    the correct image.
-    """
-    bindings = self.bindings
-    name = self.TEST_APP + '-deployment'
-    image_name = 'placeholder'
-    docker_artifact = self.__docker_image_artifact(image_name, image)
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'moniker': {
-                'app': self.TEST_APP
-            },
-            'account': bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'source': 'text',
-            'type': 'deployManifest',
-            'user': '[anonymous]',
-            'manifests': [self.mf.deployment(name, image_name)],
-            'artifacts': [docker_artifact]
-        }],
-        description='Deploy manifest',
-        application=self.TEST_APP)
-
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Deployment created',
-                                retryable_for_secs=15)
-     .get_resources(
-         'deploy',
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.deployment_image_predicate(image)))
-
-    return st.OperationContract(
-        self.new_post_operation(
-            title='deploy_manifest', data=payload, path='tasks'),
-        contract=builder.build())
-
-  def delete_kind(self, kind, version=None):
-    """Creates OperationContract for deleteManifest
-
-    To verify the operation, we just check that the Kubernetes deployment
-    is no longer visible (or is in the process of terminating).
-    """
-    bindings = self.bindings
-    name = self.TEST_APP + '-' + kind
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'type': 'deleteManifest',
-            'account': bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'user': '[anonymous]',
-            'kinds': [ kind ],
-            'location': self.TEST_NAMESPACE,
-            'options': { },
-            'labelSelectors': {
-                'selectors': [{
-                    'kind': 'EQUALS',
-                    'key': 'app',
-                    'values': [ self.TEST_APP ]
-                }]
+        if not versioned:
+            configmap["metadata"]["annotations"] = {
+                "strategy.spinnaker.io/versioned": "false"
             }
-        }],
-        application=self.TEST_APP,
-        description='Destroy Manifest')
 
-    if version is not None:
-      name = name + '-' + version
+        self.mf.add_configmap_volume(deployment, configmap_name)
 
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Manifest Removed')
-     .get_resources(
-         kind,
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.not_found_observation_predicate()))
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "moniker": {"app": self.TEST_APP},
+                    "account": self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "source": "text",
+                    "type": "deployManifest",
+                    "user": "[anonymous]",
+                    "manifests": [deployment, configmap],
+                }
+            ],
+            description="Deploy manifest",
+            application=self.TEST_APP,
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_kind', data=payload, path='tasks'),
-        contract=builder.build())
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Deployment created", retryable_for_secs=15)
+            .get_resources(
+                "deploy",
+                extra_args=[deployment_name, "--namespace", self.TEST_NAMESPACE],
+            )
+            .EXPECT(self.mp.deployment_configmap_mounted_predicate(configmap_name))
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="deploy_manifest", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
+
+    def deploy_config_map(self, version):
+        """Creates OperationContract for deploying a versioned configmap
+
+        To verify the operation, we just check that the deployment was created with
+        the correct image.
+        """
+        bindings = self.bindings
+        name = self.TEST_APP + "-configmap"
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "moniker": {"app": self.TEST_APP},
+                    "account": bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "source": "text",
+                    "type": "deployManifest",
+                    "user": "[anonymous]",
+                    "manifests": [self.mf.config_map(name, {"version": version})],
+                }
+            ],
+            description="Deploy manifest",
+            application=self.TEST_APP,
+        )
+
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("ConfigMap created", retryable_for_secs=15)
+            .get_resources(
+                "configmap",
+                extra_args=[name + "-" + version, "--namespace", self.TEST_NAMESPACE],
+            )
+            .EXPECT(self.mp.config_map_key_value_predicate("version", version))
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="deploy_manifest", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
+
+    def save_configmap_deployment_pipeline(self, pipeline_name, versioned=True):
+        deployment_name = self.TEST_APP + "-deployment"
+        deployment = self.mf.deployment(deployment_name, "library/nginx")
+        configmap_name = self.TEST_APP + "-configmap"
+        configmap = self.mf.config_map(configmap_name, {"key": "value"})
+
+        if not versioned:
+            configmap["metadata"]["annotations"] = {
+                "strategy.spinnaker.io/versioned": "false"
+            }
+
+        self.mf.add_configmap_volume(deployment, configmap_name)
+        configmap_stage = {
+            "refId": "configmap",
+            "name": "Deploy configmap",
+            "type": "deployManifest",
+            "cloudProvider": "kubernetes",
+            "moniker": {"app": self.TEST_APP},
+            "account": self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+            "source": "text",
+            "manifests": [configmap],
+        }
+
+        deployment_stage = {
+            "refId": "deployment",
+            "name": "Deploy deployment",
+            "requisiteStageRefIds": ["configmap"],
+            "type": "deployManifest",
+            "cloudProvider": "kubernetes",
+            "moniker": {"app": self.TEST_APP},
+            "account": self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+            "source": "text",
+            "manifests": [deployment],
+        }
+
+        return self.ps.submit_pipeline_contract(
+            pipeline_name, [configmap_stage, deployment_stage], user=self.TEST_USER
+        )
+
+    def execute_deploy_manifest_pipeline(self, pipeline_name):
+        deployment_name = self.TEST_APP + "-deployment"
+        configmap_name = self.TEST_APP + "-configmap"
+        bindings = self.bindings
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[{"type": "manual", "user": "[anonymous]"}],
+            description="Deploy manifest in " + self.TEST_APP,
+            application=self.TEST_APP,
+        )
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Deployment created", retryable_for_secs=60)
+            .get_resources(
+                "deploy",
+                extra_args=[deployment_name, "--namespace", self.TEST_NAMESPACE],
+            )
+            .EXPECT(self.mp.deployment_configmap_mounted_predicate(configmap_name))
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="Deploy manifest",
+                data=payload,
+                path="pipelines/" + self.TEST_APP + "/" + pipeline_name,
+            ),
+            contract=builder.build(),
+        )
+
+    def deploy_deployment_with_docker_artifact(self, image):
+        """Creates OperationContract for deploying and substituting one image into
+        a Deployment object
+
+        To verify the operation, we just check that the deployment was created with
+        the correct image.
+        """
+        bindings = self.bindings
+        name = self.TEST_APP + "-deployment"
+        image_name = "placeholder"
+        docker_artifact = self.__docker_image_artifact(image_name, image)
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "moniker": {"app": self.TEST_APP},
+                    "account": bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "source": "text",
+                    "type": "deployManifest",
+                    "user": "[anonymous]",
+                    "manifests": [self.mf.deployment(name, image_name)],
+                    "artifacts": [docker_artifact],
+                }
+            ],
+            description="Deploy manifest",
+            application=self.TEST_APP,
+        )
+
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Deployment created", retryable_for_secs=15)
+            .get_resources(
+                "deploy", extra_args=[name, "--namespace", self.TEST_NAMESPACE]
+            )
+            .EXPECT(self.mp.deployment_image_predicate(image))
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title="deploy_manifest", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
+
+    def delete_kind(self, kind, version=None):
+        """Creates OperationContract for deleteManifest
+
+        To verify the operation, we just check that the Kubernetes deployment
+        is no longer visible (or is in the process of terminating).
+        """
+        bindings = self.bindings
+        name = self.TEST_APP + "-" + kind
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "type": "deleteManifest",
+                    "account": bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "user": "[anonymous]",
+                    "kinds": [kind],
+                    "location": self.TEST_NAMESPACE,
+                    "options": {},
+                    "labelSelectors": {
+                        "selectors": [
+                            {"kind": "EQUALS", "key": "app", "values": [self.TEST_APP]}
+                        ]
+                    },
+                }
+            ],
+            application=self.TEST_APP,
+            description="Destroy Manifest",
+        )
+
+        if version is not None:
+            name = name + "-" + version
+
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Manifest Removed")
+            .get_resources(kind, extra_args=[name, "--namespace", self.TEST_NAMESPACE])
+            .EXPECT(self.mp.not_found_observation_predicate())
+        )
+
+        return st.OperationContract(
+            self.new_post_operation(title="delete_kind", data=payload, path="tasks"),
+            contract=builder.build(),
+        )
+
 
 class KubeV2ArtifactTest(st.AgentTestCase):
-  """The test fixture for the KubeV2ArtifactTest.
+    """The test fixture for the KubeV2ArtifactTest.
 
-  This is implemented using citest OperationContract instances that are
-  created by the KubeV2ArtifactTestScenario.
-  """
-  # pylint: disable=missing-docstring
+    This is implemented using citest OperationContract instances that are
+    created by the KubeV2ArtifactTestScenario.
+    """
 
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-        KubeV2ArtifactTestScenario)
+    # pylint: disable=missing-docstring
 
-  def test_a_create_app(self):
-    self.run_test_case(self.scenario.create_app())
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            KubeV2ArtifactTestScenario
+        )
 
-  def test_b1_deploy_deployment_with_docker_artifact(self):
-    self.run_test_case(self.scenario.deploy_deployment_with_docker_artifact('library/nginx'))
+    def test_a_create_app(self):
+        self.run_test_case(self.scenario.create_app())
 
-  def test_b2_update_deployment_with_docker_artifact(self):
-    self.run_test_case(self.scenario.deploy_deployment_with_docker_artifact('library/redis'))
+    def test_b1_deploy_deployment_with_docker_artifact(self):
+        self.run_test_case(
+            self.scenario.deploy_deployment_with_docker_artifact("library/nginx")
+        )
 
-  def test_b3_delete_deployment(self):
-    self.run_test_case(self.scenario.delete_kind('deployment'), max_retries=2)
+    def test_b2_update_deployment_with_docker_artifact(self):
+        self.run_test_case(
+            self.scenario.deploy_deployment_with_docker_artifact("library/redis")
+        )
 
-  def test_c1_create_config_map(self):
-    self.run_test_case(self.scenario.deploy_config_map('v000'))
+    def test_b3_delete_deployment(self):
+        self.run_test_case(self.scenario.delete_kind("deployment"), max_retries=2)
 
-  def test_c2_noop_update_config_map(self):
-    self.run_test_case(self.scenario.deploy_config_map('v000'))
+    def test_c1_create_config_map(self):
+        self.run_test_case(self.scenario.deploy_config_map("v000"))
 
-  def test_c3_update_config_map(self):
-    self.run_test_case(self.scenario.deploy_config_map('v001'))
+    def test_c2_noop_update_config_map(self):
+        self.run_test_case(self.scenario.deploy_config_map("v000"))
 
-  def test_c4_delete_configmap(self):
-    self.run_test_case(self.scenario.delete_kind('configmap', version='v001'), max_retries=2)
+    def test_c3_update_config_map(self):
+        self.run_test_case(self.scenario.deploy_config_map("v001"))
 
-  def test_d1_create_unversioned_configmap(self):
-    self.run_test_case(self.scenario.deploy_unversioned_config_map('1'))
+    def test_c4_delete_configmap(self):
+        self.run_test_case(
+            self.scenario.delete_kind("configmap", version="v001"), max_retries=2
+        )
 
-  def test_d2_update_unversioned_configmap(self):
-    self.run_test_case(self.scenario.deploy_unversioned_config_map('2'))
+    def test_d1_create_unversioned_configmap(self):
+        self.run_test_case(self.scenario.deploy_unversioned_config_map("1"))
 
-  def test_d3_delete_unversioned_configmap(self):
-    self.run_test_case(self.scenario.delete_kind('configmap'), max_retries=2)
+    def test_d2_update_unversioned_configmap(self):
+        self.run_test_case(self.scenario.deploy_unversioned_config_map("2"))
 
-  def test_e1_create_deployment_with_versioned_configmap(self):
-    self.run_test_case(self.scenario.deploy_deployment_with_config_map(True))
+    def test_d3_delete_unversioned_configmap(self):
+        self.run_test_case(self.scenario.delete_kind("configmap"), max_retries=2)
 
-  def test_e2_delete_deployment(self):
-    self.run_test_case(self.scenario.delete_kind('deployment'), max_retries=2)
+    def test_e1_create_deployment_with_versioned_configmap(self):
+        self.run_test_case(self.scenario.deploy_deployment_with_config_map(True))
 
-  def test_e3_delete_configmap(self):
-    self.run_test_case(self.scenario.delete_kind('configmap', version='v000'), max_retries=2)
+    def test_e2_delete_deployment(self):
+        self.run_test_case(self.scenario.delete_kind("deployment"), max_retries=2)
 
-  def test_f1_create_configmap_deployment_pipeline(self):
-    self.run_test_case(self.scenario.save_configmap_deployment_pipeline('deploy-configmap-deployment'))
+    def test_e3_delete_configmap(self):
+        self.run_test_case(
+            self.scenario.delete_kind("configmap", version="v000"), max_retries=2
+        )
 
-  def test_f2_execute_configmap_deployment_pipeline(self):
-    self.run_test_case(self.scenario.execute_deploy_manifest_pipeline('deploy-configmap-deployment'))
+    def test_f1_create_configmap_deployment_pipeline(self):
+        self.run_test_case(
+            self.scenario.save_configmap_deployment_pipeline(
+                "deploy-configmap-deployment"
+            )
+        )
 
-  def test_f3_delete_deployment(self):
-    self.run_test_case(self.scenario.delete_kind('deployment'), max_retries=2)
+    def test_f2_execute_configmap_deployment_pipeline(self):
+        self.run_test_case(
+            self.scenario.execute_deploy_manifest_pipeline(
+                "deploy-configmap-deployment"
+            )
+        )
 
-  def test_f4_delete_configmap(self):
-    self.run_test_case(self.scenario.delete_kind('configmap', version='v000'), max_retries=2)
+    def test_f3_delete_deployment(self):
+        self.run_test_case(self.scenario.delete_kind("deployment"), max_retries=2)
 
-  def test_z_delete_app(self):
-    # Give a total of 2 minutes because it might also need
-    # an internal cache update
-    self.run_test_case(self.scenario.delete_app(),
-                       retry_interval_secs=8, max_retries=15)
+    def test_f4_delete_configmap(self):
+        self.run_test_case(
+            self.scenario.delete_kind("configmap", version="v000"), max_retries=2
+        )
+
+    def test_z_delete_app(self):
+        # Give a total of 2 minutes because it might also need
+        # an internal cache update
+        self.run_test_case(
+            self.scenario.delete_app(), retry_interval_secs=8, max_retries=15
+        )
 
 
 def main():
-  """Implements the main method running this artifact test."""
+    """Implements the main method running this artifact test."""
 
-  defaults = {
-      'TEST_STACK': 'tst',
-      'TEST_APP': 'kubv2arti' + KubeV2ArtifactTestScenario.DEFAULT_TEST_ID
-  }
+    defaults = {
+        "TEST_STACK": "tst",
+        "TEST_APP": "kubv2arti" + KubeV2ArtifactTestScenario.DEFAULT_TEST_ID,
+    }
 
-  return citest.base.TestRunner.main(
-      parser_inits=[KubeV2ArtifactTestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[KubeV2ArtifactTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[KubeV2ArtifactTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[KubeV2ArtifactTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/kube_v2_cache_test.py
+++ b/testing/citest/tests/kube_v2_cache_test.py
@@ -39,401 +39,482 @@ import citest.base
 
 ov_factory = jc.ObservationPredicateFactory()
 
+
 class KubeV2CacheTestScenario(sk.SpinnakerTestScenario):
-  """Defines the scenario for the kube v2 cache test.
-  """
+    """Defines the scenario for the kube v2 cache test."""
 
-  @classmethod
-  def new_agent(cls, bindings):
-    """Implements citest.service_testing.AgentTestScenario.new_agent."""
-    agent = gate.new_agent(bindings)
-    agent.default_max_wait_secs = 180
-    return agent
+    @classmethod
+    def new_agent(cls, bindings):
+        """Implements citest.service_testing.AgentTestScenario.new_agent."""
+        agent = gate.new_agent(bindings)
+        agent.default_max_wait_secs = 180
+        return agent
 
-  @classmethod
-  def initArgumentParser(cls, parser, defaults=None):
-    """Initialize command line argument parser.
+    @classmethod
+    def initArgumentParser(cls, parser, defaults=None):
+        """Initialize command line argument parser.
 
-    Args:
-      parser: argparse.ArgumentParser
-    """
-    super(KubeV2CacheTestScenario, cls).initArgumentParser(
-        parser, defaults=defaults)
+        Args:
+          parser: argparse.ArgumentParser
+        """
+        super(KubeV2CacheTestScenario, cls).initArgumentParser(
+            parser, defaults=defaults
+        )
 
-    defaults = defaults or {}
-    parser.add_argument(
-      '--test_namespace', default='default',
-      help='The namespace to manage within the tests.')
+        defaults = defaults or {}
+        parser.add_argument(
+            "--test_namespace",
+            default="default",
+            help="The namespace to manage within the tests.",
+        )
 
-  def __init__(self, bindings, agent=None):
-    """Constructor.
+    def __init__(self, bindings, agent=None):
+        """Constructor.
 
-    Args:
-      bindings: [dict] The data bindings to use to configure the scenario.
-      agent: [GateAgent] The agent for invoking the test operations on Gate.
-    """
-    super(KubeV2CacheTestScenario, self).__init__(bindings, agent)
-    bindings = self.bindings
+        Args:
+          bindings: [dict] The data bindings to use to configure the scenario.
+          agent: [GateAgent] The agent for invoking the test operations on Gate.
+        """
+        super(KubeV2CacheTestScenario, self).__init__(bindings, agent)
+        bindings = self.bindings
 
-    # We'll call out the app name because it is widely used
-    # because it scopes the context of our activities.
-    # pylint: disable=invalid-name
-    self.TEST_APP = bindings['TEST_APP']
+        # We'll call out the app name because it is widely used
+        # because it scopes the context of our activities.
+        # pylint: disable=invalid-name
+        self.TEST_APP = bindings["TEST_APP"]
 
-    # Take just the first if there are multiple
-    # because some uses below assume just one.
-    self.TEST_NAMESPACE = bindings['TEST_NAMESPACE'].split(',')[0]
+        # Take just the first if there are multiple
+        # because some uses below assume just one.
+        self.TEST_NAMESPACE = bindings["TEST_NAMESPACE"].split(",")[0]
 
-    self.mf = sk.KubernetesManifestFactory(self)
-    self.mp = sk.KubernetesManifestPredicateFactory()
+        self.mf = sk.KubernetesManifestFactory(self)
+        self.mp = sk.KubernetesManifestPredicateFactory()
 
-  def create_app(self):
-    """Creates OperationContract that creates a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_create_app_operation(
-            bindings=self.bindings, application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            cloud_providers="kubernetes"),
-        contract=contract)
+    def create_app(self):
+        """Creates OperationContract that creates a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_create_app_operation(
+                bindings=self.bindings,
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                cloud_providers="kubernetes",
+            ),
+            contract=contract,
+        )
 
-  def delete_app(self):
-    """Creates OperationContract that deletes a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_delete_app_operation(
+    def delete_app(self):
+        """Creates OperationContract that deletes a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_delete_app_operation(
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+            ),
+            contract=contract,
+        )
+
+    def deploy_deployment(self, image):
+        """Creates OperationContract for deploying and substituting one image into
+        a Deployment object
+
+        To verify the operation, we just check that the deployment was created with
+        the correct image.
+        """
+        name = self.TEST_APP + "-deployment"
+        account = self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"]
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "moniker": {"app": self.TEST_APP},
+                    "account": account,
+                    "source": "text",
+                    "type": "deployManifest",
+                    "user": "[anonymous]",
+                    "manifests": [self.mf.deployment(name, image)],
+                }
+            ],
+            description="Deploy manifest",
             application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']),
-        contract=contract)
+        )
 
-  def deploy_deployment(self, image):
-    """Creates OperationContract for deploying and substituting one image into
-    a Deployment object
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Deployment created", retryable_for_secs=15)
+            .get_resources(
+                "deploy", extra_args=[name, "--namespace", self.TEST_NAMESPACE]
+            )
+            .EXPECT(self.mp.deployment_image_predicate(image))
+        )
 
-    To verify the operation, we just check that the deployment was created with
-    the correct image.
-    """
-    name = self.TEST_APP + '-deployment'
-    account = self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'moniker': {
-                'app': self.TEST_APP
-            },
-            'account': account,
-            'source': 'text',
-            'type': 'deployManifest',
-            'user': '[anonymous]',
-            'manifests': [self.mf.deployment(name, image)],
-        }],
-        description='Deploy manifest',
-        application=self.TEST_APP)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="deploy_manifest", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Deployment created',
-                                retryable_for_secs=15)
-     .get_resources(
-         'deploy',
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.deployment_image_predicate(image)))
+    def deploy_service(self):
+        """Creates an OperationContract for deploying a service object
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='deploy_manifest', data=payload, path='tasks'),
-        contract=builder.build())
+        To verify the operation, we just check that the service was created.
+        """
+        name = self.TEST_APP + "-service"
+        account = self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"]
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "moniker": {"app": self.TEST_APP},
+                    "account": account,
+                    "source": "text",
+                    "type": "deployManifest",
+                    "user": "[anonymous]",
+                    "manifests": [self.mf.service(name)],
+                }
+            ],
+            description="Deploy manifest",
+            application=self.TEST_APP,
+        )
 
-  def deploy_service(self):
-    """Creates an OperationContract for deploying a service object
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Service created", retryable_for_secs=15)
+            .get_resources(
+                "service", extra_args=[name, "--namespace", self.TEST_NAMESPACE]
+            )
+            .EXPECT(self.mp.service_selector_predicate("app", self.TEST_APP))
+        )
 
-    To verify the operation, we just check that the service was created.
-    """
-    name = self.TEST_APP + '-service'
-    account = self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'moniker': {
-                'app': self.TEST_APP
-            },
-            'account': account,
-            'source': 'text',
-            'type': 'deployManifest',
-            'user': '[anonymous]',
-            'manifests': [self.mf.service(name)],
-        }],
-        description='Deploy manifest',
-        application=self.TEST_APP)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="deploy_manifest", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Service created',
-                                retryable_for_secs=15)
-     .get_resources(
-         'service',
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.service_selector_predicate('app', self.TEST_APP)))
+    def check_manifest_endpoint_exists(self, kind):
+        name = self.TEST_APP + "-" + kind
+        account = self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"]
+        builder = HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder("Has recorded a manifest")
+            .get_url_path(
+                "/manifests/{account}/{namespace}/{name}".format(
+                    account=account,
+                    namespace=self.TEST_NAMESPACE,
+                    name="{}%20{}".format(kind, name),
+                )
+            )
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES({"account": jp.STR_EQ(account)})
+                )
+            )
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='deploy_manifest', data=payload, path='tasks'),
-        contract=builder.build())
+        return st.OperationContract(
+            NoOpOperation("Has recorded a manifest"), contract=builder.build()
+        )
 
-  def check_manifest_endpoint_exists(self, kind):
-    name = self.TEST_APP + '-' + kind
-    account = self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']
-    builder = HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has recorded a manifest')
-       .get_url_path('/manifests/{account}/{namespace}/{name}'.format(
-           account=account,
-           namespace=self.TEST_NAMESPACE,
-           name='{}%20{}'.format(kind, name)
-       ))
-       .EXPECT(
-           ov_factory.value_list_contains(jp.DICT_MATCHES({
-               'account': jp.STR_EQ(account)
-           }))
-    ))
+    def check_applications_endpoint(self):
+        account = self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"]
+        builder = HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder(
+                "Has recorded an app for the deployed manifest", retryable_for_secs=120
+            )
+            .get_url_path("/applications")
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_EQ(self.TEST_APP),
+                            "accounts": jp.STR_SUBSTR(account),
+                        }
+                    )
+                )
+            )
+        )
 
-    return st.OperationContract(
-        NoOpOperation('Has recorded a manifest'),
-        contract=builder.build())
+        return st.OperationContract(
+            NoOpOperation("Has recorded an application"), contract=builder.build()
+        )
 
-  def check_applications_endpoint(self):
-    account = self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']
-    builder = HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has recorded an app for the deployed manifest',
-                                retryable_for_secs=120)
-       .get_url_path('/applications')
-       .EXPECT(
-           ov_factory.value_list_contains(jp.DICT_MATCHES({
-               'name': jp.STR_EQ(self.TEST_APP),
-               'accounts': jp.STR_SUBSTR(account),
-           }))
-    ))
+    def check_server_groups_endpoint(self, kind, image, has_lb=True):
+        name = self.TEST_APP + "-" + kind
+        account = self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"]
+        builder = HttpContractBuilder(self.agent)
+        lb_pred = (
+            jp.LIST_MATCHES([jp.STR_EQ("service {}-service".format(self.TEST_APP))])
+            if has_lb
+            else jp.LIST_EQ([])
+        )
+        (
+            builder.new_clause_builder(
+                "Has recorded a server group for the deployed manifest",
+                retryable_for_secs=120,
+            )
+            .get_url_path("/applications/{}/serverGroups".format(self.TEST_APP))
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_SUBSTR(name),
+                            "cluster": jp.STR_EQ(kind + " " + name),
+                            "account": jp.STR_EQ(account),
+                            "cloudProvider": jp.STR_EQ("kubernetes"),
+                            "buildInfo": jp.DICT_MATCHES(
+                                {
+                                    "images": jp.LIST_MATCHES([jp.STR_EQ(image)]),
+                                }
+                            ),
+                            "loadBalancers": lb_pred,
+                        }
+                    )
+                )
+            )
+        )
 
-    return st.OperationContract(
-        NoOpOperation('Has recorded an application'),
-        contract=builder.build())
+        return st.OperationContract(
+            NoOpOperation("Has recorded a server group"), contract=builder.build()
+        )
 
-  def check_server_groups_endpoint(self, kind, image, has_lb=True):
-    name = self.TEST_APP + '-' + kind
-    account = self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']
-    builder = HttpContractBuilder(self.agent)
-    lb_pred = (
-        jp.LIST_MATCHES([jp.STR_EQ('service {}-service'.format(self.TEST_APP))])
-        if has_lb else jp.LIST_EQ([])
-    )
-    (builder.new_clause_builder('Has recorded a server group for the deployed manifest',
-                                retryable_for_secs=120)
-      .get_url_path('/applications/{}/serverGroups'.format(self.TEST_APP))
-       .EXPECT(
-           ov_factory.value_list_contains(jp.DICT_MATCHES({
-               'name': jp.STR_SUBSTR(name),
-               'cluster': jp.STR_EQ(kind + ' ' + name),
-               'account': jp.STR_EQ(account),
-               'cloudProvider': jp.STR_EQ('kubernetes'),
-               'buildInfo': jp.DICT_MATCHES({
-                   'images': jp.LIST_MATCHES([jp.STR_EQ(image)]),
-               }),
-               'loadBalancers': lb_pred,
-           }))
-    ))
+    def check_load_balancers_endpoint(self, kind):
+        name = kind + " " + self.TEST_APP + "-" + kind
+        account = self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"]
+        builder = HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder(
+                "Has recorded a load balancer", retryable_for_secs=120
+            )
+            .get_url_path("/applications/{}/loadBalancers".format(self.TEST_APP))
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "name": jp.STR_EQ(name),
+                            "kind": jp.STR_EQ(kind),
+                            "account": jp.STR_EQ(account),
+                            "cloudProvider": jp.STR_EQ("kubernetes"),
+                            "serverGroups": jp.LIST_MATCHES(
+                                [
+                                    jp.DICT_MATCHES(
+                                        {
+                                            "account": jp.STR_EQ(account),
+                                            "name": jp.STR_SUBSTR(self.TEST_APP),
+                                        }
+                                    ),
+                                ]
+                            ),
+                        }
+                    )
+                )
+            )
+        )
 
-    return st.OperationContract(
-        NoOpOperation('Has recorded a server group'),
-        contract=builder.build())
+        return st.OperationContract(
+            NoOpOperation("Has recorded a load balancer"), contract=builder.build()
+        )
 
-  def check_load_balancers_endpoint(self, kind):
-    name = kind + ' ' + self.TEST_APP + '-' + kind
-    account = self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']
-    builder = HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has recorded a load balancer',
-                                retryable_for_secs=120)
-       .get_url_path('/applications/{}/loadBalancers'.format(self.TEST_APP))
-       .EXPECT(
-           ov_factory.value_list_contains(jp.DICT_MATCHES({
-               'name': jp.STR_EQ(name),
-               'kind': jp.STR_EQ(kind),
-               'account': jp.STR_EQ(account),
-               'cloudProvider': jp.STR_EQ('kubernetes'),
-               'serverGroups': jp.LIST_MATCHES([
-                 jp.DICT_MATCHES({
-                   'account': jp.STR_EQ(account),
-                   'name': jp.STR_SUBSTR(self.TEST_APP),
-                 }),
-               ]),
-           }))
-    ))
+    def check_load_balancers_endpoint_empty(self):
+        builder = HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder("Has no load balancer", retryable_for_secs=120)
+            .get_url_path("/applications/{}/loadBalancers".format(self.TEST_APP))
+            .EXPECT(ov_factory.value_list_matches([]))
+        )
 
-    return st.OperationContract(
-        NoOpOperation('Has recorded a load balancer'),
-        contract=builder.build())
+        return st.OperationContract(
+            NoOpOperation("Has no load balancer"), contract=builder.build()
+        )
 
-  def check_load_balancers_endpoint_empty(self):
-    builder = HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has no load balancer',
-                                retryable_for_secs=120)
-      .get_url_path('/applications/{}/loadBalancers'.format(self.TEST_APP))
-      .EXPECT(ov_factory.value_list_matches([])))
+    def check_clusters_endpoint(self, kind):
+        name = kind + " " + self.TEST_APP + "-" + kind
+        account = self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"]
+        builder = HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder(
+                "Has recorded a cluster for the deployed manifest",
+                retryable_for_secs=120,
+            )
+            .get_url_path("/applications/{}/clusters".format(self.TEST_APP))
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            account: jp.LIST_MATCHES([jp.STR_EQ(name)]),
+                        }
+                    )
+                )
+            )
+        )
 
-    return st.OperationContract(
-        NoOpOperation('Has no load balancer'),
-        contract=builder.build())
+        return st.OperationContract(
+            NoOpOperation("Has recorded a cluster"), contract=builder.build()
+        )
 
-  def check_clusters_endpoint(self, kind):
-    name = kind + ' ' + self.TEST_APP + '-' + kind
-    account = self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']
-    builder = HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has recorded a cluster for the deployed manifest',
-                                retryable_for_secs=120)
-       .get_url_path('/applications/{}/clusters'.format(self.TEST_APP))
-       .EXPECT(
-           ov_factory.value_list_contains(jp.DICT_MATCHES({
-               account: jp.LIST_MATCHES([jp.STR_EQ(name)]),
-           }))
-    ))
+    def check_detailed_clusters_endpoint(self, kind):
+        name = kind + " " + self.TEST_APP + "-" + kind
+        url_name = name.replace(" ", "%20")
+        account = self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"]
+        builder = HttpContractBuilder(self.agent)
+        (
+            builder.new_clause_builder(
+                "Has recorded a cluster for the deployed manifest",
+                retryable_for_secs=120,
+            )
+            .get_url_path(
+                "/applications/{app}/clusters/{account}/{name}".format(
+                    app=self.TEST_APP, account=account, name=url_name
+                )
+            )
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "accountName": jp.STR_EQ(account),
+                            "name": jp.STR_EQ(name),
+                            "serverGroups": jp.LIST_MATCHES(
+                                [
+                                    jp.DICT_MATCHES(
+                                        {
+                                            "account": jp.STR_EQ(account),
+                                        }
+                                    )
+                                ]
+                            ),
+                        }
+                    )
+                )
+            )
+        )
 
-    return st.OperationContract(
-        NoOpOperation('Has recorded a cluster'),
-        contract=builder.build())
+        return st.OperationContract(
+            NoOpOperation("Has recorded a cluster"), contract=builder.build()
+        )
 
-  def check_detailed_clusters_endpoint(self, kind):
-    name = kind + ' ' + self.TEST_APP + '-' + kind
-    url_name = name.replace(' ', '%20')
-    account = self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']
-    builder = HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has recorded a cluster for the deployed manifest',
-                                retryable_for_secs=120)
-       .get_url_path('/applications/{app}/clusters/{account}/{name}'.format(
-         app=self.TEST_APP, account=account, name=url_name))
-       .EXPECT(
-           ov_factory.value_list_contains(jp.DICT_MATCHES({
-               'accountName': jp.STR_EQ(account),
-               'name': jp.STR_EQ(name),
-               'serverGroups': jp.LIST_MATCHES([
-                 jp.DICT_MATCHES({
-                   'account': jp.STR_EQ(account),
-                 })
-               ]),
-           }))
-    ))
+    def delete_kind(self, kind, version=None):
+        """Creates OperationContract for deleteManifest
 
-    return st.OperationContract(
-        NoOpOperation('Has recorded a cluster'),
-        contract=builder.build())
+        To verify the operation, we just check that the Kubernetes deployment
+        is no longer visible (or is in the process of terminating).
+        """
+        bindings = self.bindings
+        name = self.TEST_APP + "-" + kind
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "type": "deleteManifest",
+                    "account": bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "user": "[anonymous]",
+                    "kinds": [kind],
+                    "location": self.TEST_NAMESPACE,
+                    "options": {},
+                    "labelSelectors": {
+                        "selectors": [
+                            {"kind": "EQUALS", "key": "app", "values": [self.TEST_APP]}
+                        ]
+                    },
+                }
+            ],
+            application=self.TEST_APP,
+            description="Destroy Manifest",
+        )
 
-  def delete_kind(self, kind, version=None):
-    """Creates OperationContract for deleteManifest
+        if version is not None:
+            name = name + "-" + version
 
-    To verify the operation, we just check that the Kubernetes deployment
-    is no longer visible (or is in the process of terminating).
-    """
-    bindings = self.bindings
-    name = self.TEST_APP + '-' + kind
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'type': 'deleteManifest',
-            'account': bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'user': '[anonymous]',
-            'kinds': [ kind ],
-            'location': self.TEST_NAMESPACE,
-            'options': { },
-            'labelSelectors': {
-                'selectors': [{
-                    'kind': 'EQUALS',
-                    'key': 'app',
-                    'values': [ self.TEST_APP ]
-                }]
-            }
-        }],
-        application=self.TEST_APP,
-        description='Destroy Manifest')
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Manifest Removed")
+            .get_resources(kind, extra_args=[name, "--namespace", self.TEST_NAMESPACE])
+            .EXPECT(self.mp.not_found_observation_predicate())
+        )
 
-    if version is not None:
-      name = name + '-' + version
+        return st.OperationContract(
+            self.new_post_operation(title="delete_kind", data=payload, path="tasks"),
+            contract=builder.build(),
+        )
 
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Manifest Removed')
-     .get_resources(
-         kind,
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.not_found_observation_predicate()))
-
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_kind', data=payload, path='tasks'),
-        contract=builder.build())
 
 class KubeV2CacheTest(st.AgentTestCase):
-  """The test fixture for the KubeV2CacheTest.
+    """The test fixture for the KubeV2CacheTest.
 
-  This is implemented using citest OperationContract instances that are
-  created by the KubeV2CacheTestScenario.
-  """
-  # pylint: disable=missing-docstring
+    This is implemented using citest OperationContract instances that are
+    created by the KubeV2CacheTestScenario.
+    """
 
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-        KubeV2CacheTestScenario)
+    # pylint: disable=missing-docstring
 
-  def test_a_create_app(self):
-    self.run_test_case(self.scenario.create_app())
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            KubeV2CacheTestScenario
+        )
 
-  def test_b1_deploy_deployment(self):
-    self.run_test_case(self.scenario.deploy_deployment('library/nginx'))
+    def test_a_create_app(self):
+        self.run_test_case(self.scenario.create_app())
 
-  def test_b1_deploy_service(self):
-    self.run_test_case(self.scenario.deploy_service())
+    def test_b1_deploy_deployment(self):
+        self.run_test_case(self.scenario.deploy_deployment("library/nginx"))
 
-  def test_b2_check_manifest_endpoint(self):
-    self.run_test_case(self.scenario.check_manifest_endpoint_exists('deployment'))
+    def test_b1_deploy_service(self):
+        self.run_test_case(self.scenario.deploy_service())
 
-  def test_b2_check_applications_endpoint(self):
-    self.run_test_case(self.scenario.check_applications_endpoint())
+    def test_b2_check_manifest_endpoint(self):
+        self.run_test_case(self.scenario.check_manifest_endpoint_exists("deployment"))
 
-  def test_b2_check_clusters_endpoint(self):
-    self.run_test_case(self.scenario.check_clusters_endpoint('deployment'))
+    def test_b2_check_applications_endpoint(self):
+        self.run_test_case(self.scenario.check_applications_endpoint())
 
-  def test_b2_check_detailed_clusters_endpoint(self):
-    self.run_test_case(self.scenario.check_detailed_clusters_endpoint('deployment'))
+    def test_b2_check_clusters_endpoint(self):
+        self.run_test_case(self.scenario.check_clusters_endpoint("deployment"))
 
-  def test_b2_check_server_groups_endpoint(self):
-    self.run_test_case(self.scenario.check_server_groups_endpoint('deployment', 'library/nginx'))
+    def test_b2_check_detailed_clusters_endpoint(self):
+        self.run_test_case(self.scenario.check_detailed_clusters_endpoint("deployment"))
 
-  def test_b2_check_load_balancers_endpoint(self):
-    self.run_test_case(self.scenario.check_load_balancers_endpoint('service'))
+    def test_b2_check_server_groups_endpoint(self):
+        self.run_test_case(
+            self.scenario.check_server_groups_endpoint("deployment", "library/nginx")
+        )
 
-  def test_b3_delete_service(self):
-    self.run_test_case(self.scenario.delete_kind('service'), max_retries=2)
+    def test_b2_check_load_balancers_endpoint(self):
+        self.run_test_case(self.scenario.check_load_balancers_endpoint("service"))
 
-  def test_b4_check_load_balancers_endpoint_no_load_balancer(self):
-    self.run_test_case(self.scenario.check_load_balancers_endpoint_empty())
+    def test_b3_delete_service(self):
+        self.run_test_case(self.scenario.delete_kind("service"), max_retries=2)
 
-  def test_b9_delete_deployment(self):
-    self.run_test_case(self.scenario.delete_kind('deployment'), max_retries=2)
+    def test_b4_check_load_balancers_endpoint_no_load_balancer(self):
+        self.run_test_case(self.scenario.check_load_balancers_endpoint_empty())
 
-  def test_z_delete_app(self):
-    # Give a total of 2 minutes because it might also need
-    # an internal cache update
-    self.run_test_case(self.scenario.delete_app(),
-                       retry_interval_secs=8, max_retries=15)
+    def test_b9_delete_deployment(self):
+        self.run_test_case(self.scenario.delete_kind("deployment"), max_retries=2)
+
+    def test_z_delete_app(self):
+        # Give a total of 2 minutes because it might also need
+        # an internal cache update
+        self.run_test_case(
+            self.scenario.delete_app(), retry_interval_secs=8, max_retries=15
+        )
 
 
 def main():
-  """Implements the main method running this cache test."""
+    """Implements the main method running this cache test."""
 
-  defaults = {
-      'TEST_STACK': 'tst',
-      'TEST_APP': 'kubv2cache' + KubeV2CacheTestScenario.DEFAULT_TEST_ID
-  }
+    defaults = {
+        "TEST_STACK": "tst",
+        "TEST_APP": "kubv2cache" + KubeV2CacheTestScenario.DEFAULT_TEST_ID,
+    }
 
-  return citest.base.TestRunner.main(
-      parser_inits=[KubeV2CacheTestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[KubeV2CacheTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[KubeV2CacheTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[KubeV2CacheTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/kube_v2_gcs_test.py
+++ b/testing/citest/tests/kube_v2_gcs_test.py
@@ -37,278 +37,308 @@ import citest.base
 
 ov_factory = jc.ObservationPredicateFactory()
 
+
 class KubeV2GcsTestScenario(sk.SpinnakerTestScenario):
-  """Defines the scenario for the kube v2 gcs test.
-  """
+    """Defines the scenario for the kube v2 gcs test."""
 
-  @classmethod
-  def new_agent(cls, bindings):
-    """Implements citest.service_testing.AgentTestScenario.new_agent."""
-    agent = gate.new_agent(bindings)
-    agent.default_max_wait_secs = 180
-    return agent
+    @classmethod
+    def new_agent(cls, bindings):
+        """Implements citest.service_testing.AgentTestScenario.new_agent."""
+        agent = gate.new_agent(bindings)
+        agent.default_max_wait_secs = 180
+        return agent
 
-  @classmethod
-  def initArgumentParser(cls, parser, defaults=None):
-    """Initialize command line argument parser.
+    @classmethod
+    def initArgumentParser(cls, parser, defaults=None):
+        """Initialize command line argument parser.
 
-    Args:
-      parser: argparse.ArgumentParser
-    """
-    super(KubeV2GcsTestScenario, cls).initArgumentParser(
-        parser, defaults=defaults)
+        Args:
+          parser: argparse.ArgumentParser
+        """
+        super(KubeV2GcsTestScenario, cls).initArgumentParser(parser, defaults=defaults)
 
-    defaults = defaults or {}
-    parser.add_argument(
-      '--test_namespace', default='default',
-      help='The namespace to manage within the tests.')
+        defaults = defaults or {}
+        parser.add_argument(
+            "--test_namespace",
+            default="default",
+            help="The namespace to manage within the tests.",
+        )
 
-    parser.add_argument(
-        '--test_gcs_artifact_account',
-        default='gcs-artifact-account',
-        help='Spinnaker GCS artifact account name to use for test operations'
-             ' against artifacts stored in GCS.')
+        parser.add_argument(
+            "--test_gcs_artifact_account",
+            default="gcs-artifact-account",
+            help="Spinnaker GCS artifact account name to use for test operations"
+            " against artifacts stored in GCS.",
+        )
 
-    parser.add_argument(
-        '--test_gcs_bucket',
-        help='GCS bucket to upload & read manifests from.')
+        parser.add_argument(
+            "--test_gcs_bucket", help="GCS bucket to upload & read manifests from."
+        )
 
-    parser.add_argument(
-        '--test_gcs_credentials_path', default=None,
-        help='GCS bucket to upload & read manifests from.')
+        parser.add_argument(
+            "--test_gcs_credentials_path",
+            default=None,
+            help="GCS bucket to upload & read manifests from.",
+        )
 
-  def __init__(self, bindings, agent=None):
-    """Constructor.
+    def __init__(self, bindings, agent=None):
+        """Constructor.
 
-    Args:
-      bindings: [dict] The data bindings to use to configure the scenario.
-      agent: [GateAgent] The agent for invoking the test operations on Gate.
-    """
-    super(KubeV2GcsTestScenario, self).__init__(bindings, agent)
-    bindings = self.bindings
+        Args:
+          bindings: [dict] The data bindings to use to configure the scenario.
+          agent: [GateAgent] The agent for invoking the test operations on Gate.
+        """
+        super(KubeV2GcsTestScenario, self).__init__(bindings, agent)
+        bindings = self.bindings
 
-    # We'll call out the app name because it is widely used
-    # because it scopes the context of our activities.
-    # pylint: disable=invalid-name
-    self.TEST_APP = bindings['TEST_APP']
+        # We'll call out the app name because it is widely used
+        # because it scopes the context of our activities.
+        # pylint: disable=invalid-name
+        self.TEST_APP = bindings["TEST_APP"]
 
-    # Take just the first if there are multiple
-    # because some uses below assume just one.
-    self.TEST_NAMESPACE = bindings['TEST_NAMESPACE'].split(',')[0]
+        # Take just the first if there are multiple
+        # because some uses below assume just one.
+        self.TEST_NAMESPACE = bindings["TEST_NAMESPACE"].split(",")[0]
 
-    self.ARTIFACT_ACCOUNT = bindings['TEST_GCS_ARTIFACT_ACCOUNT']
-    self.BUCKET = bindings['TEST_GCS_BUCKET']
+        self.ARTIFACT_ACCOUNT = bindings["TEST_GCS_ARTIFACT_ACCOUNT"]
+        self.BUCKET = bindings["TEST_GCS_BUCKET"]
 
-    self.mf = sk.KubernetesManifestFactory(self)
-    self.mp = sk.KubernetesManifestPredicateFactory()
-    self.gcs = sk.GcsFileUploadAgent(bindings['TEST_GCS_CREDENTIALS_PATH'])
+        self.mf = sk.KubernetesManifestFactory(self)
+        self.mp = sk.KubernetesManifestPredicateFactory()
+        self.gcs = sk.GcsFileUploadAgent(bindings["TEST_GCS_CREDENTIALS_PATH"])
 
-  def create_app(self):
-    """Creates OperationContract that creates a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_create_app_operation(
-            bindings=self.bindings, application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            cloud_providers="kubernetes"),
-        contract=contract)
+    def create_app(self):
+        """Creates OperationContract that creates a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_create_app_operation(
+                bindings=self.bindings,
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                cloud_providers="kubernetes",
+            ),
+            contract=contract,
+        )
 
-  def delete_app(self):
-    """Creates OperationContract that deletes a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_delete_app_operation(
+    def delete_app(self):
+        """Creates OperationContract that deletes a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_delete_app_operation(
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+            ),
+            contract=contract,
+        )
+
+    def __gcs_manifest_expected_artifact(self, contents, path):
+        self.gcs.upload_string(self.BUCKET, path, contents)
+        id_ = "".join(
+            random.choice(string.ascii_uppercase + string.digits) for _ in range(10)
+        )
+        return {
+            "boundArtifact": {
+                "type": "gcs/object",
+                "name": path,
+                "reference": "gs://{}/{}".format(self.BUCKET, path),
+            },
+            "id": id_,
+        }
+
+    def deploy_spel_deployment_from_gcs(self, image):
+        """Creates OperationContract for deploying and substituting one image into
+        a Deployment object using a SpEL expression.
+
+        To verify the operation, we just check that the deployment was created with
+        the correct image.
+        """
+        bindings = self.bindings
+        name = self.TEST_APP + "-deployment"
+        manifest = self.mf.deployment(name, "${image}")
+        manifest_artifact = self.__gcs_manifest_expected_artifact(
+            json.dumps(manifest), "manifest-spel.yaml"
+        )
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "moniker": {"app": self.TEST_APP},
+                    "account": bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "source": "artifact",
+                    "type": "deployManifest",
+                    "user": "[anonymous]",
+                    "image": image,
+                    "manifestArtifactAccount": self.ARTIFACT_ACCOUNT,
+                    "manifestArtifactId": manifest_artifact["id"],
+                    "resolvedExpectedArtifacts": [manifest_artifact],
+                }
+            ],
+            description="Deploy manifest",
             application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']),
-        contract=contract)
+        )
 
-  def __gcs_manifest_expected_artifact(self, contents, path):
-    self.gcs.upload_string(self.BUCKET, path, contents)
-    id_ = ''.join(random.choice(string.ascii_uppercase + string.digits)
-                  for _ in range(10))
-    return {
-      'boundArtifact': {
-        'type': 'gcs/object',
-        'name': path,
-        'reference': 'gs://{}/{}'.format(self.BUCKET, path),
-      },
-      'id': id_
-    }
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Deployment created", retryable_for_secs=15)
+            .get_resources(
+                "deploy", extra_args=[name, "--namespace", self.TEST_NAMESPACE]
+            )
+            .EXPECT(self.mp.deployment_image_predicate(image))
+        )
 
-  def deploy_spel_deployment_from_gcs(self, image):
-    """Creates OperationContract for deploying and substituting one image into
-    a Deployment object using a SpEL expression.
+        return st.OperationContract(
+            self.new_post_operation(
+                title="deploy_manifest", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
-    To verify the operation, we just check that the deployment was created with
-    the correct image.
-    """
-    bindings = self.bindings
-    name = self.TEST_APP + '-deployment'
-    manifest = self.mf.deployment(name, '${image}')
-    manifest_artifact = self.__gcs_manifest_expected_artifact(json.dumps(manifest), 'manifest-spel.yaml')
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'moniker': {
-                'app': self.TEST_APP
-            },
-            'account': bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'source': 'artifact',
-            'type': 'deployManifest',
-            'user': '[anonymous]',
-            'image': image,
-            'manifestArtifactAccount': self.ARTIFACT_ACCOUNT,
-            'manifestArtifactId': manifest_artifact['id'],
-            'resolvedExpectedArtifacts': [manifest_artifact]
-        }],
-        description='Deploy manifest',
-        application=self.TEST_APP)
+    def deploy_deployment_from_gcs(self, image):
+        """Creates OperationContract for deploying and substituting one image into
+        a Deployment object
 
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Deployment created',
-                                retryable_for_secs=15)
-     .get_resources(
-         'deploy',
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.deployment_image_predicate(image)))
+        To verify the operation, we just check that the deployment was created with
+        the correct image.
+        """
+        bindings = self.bindings
+        name = self.TEST_APP + "-deployment"
+        manifest = self.mf.deployment(name, image)
+        manifest_artifact = self.__gcs_manifest_expected_artifact(
+            json.dumps(manifest), "manifest.yaml"
+        )
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "moniker": {"app": self.TEST_APP},
+                    "account": bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "source": "artifact",
+                    "type": "deployManifest",
+                    "user": "[anonymous]",
+                    "manifestArtifactAccount": self.ARTIFACT_ACCOUNT,
+                    "manifestArtifactId": manifest_artifact["id"],
+                    "resolvedExpectedArtifacts": [manifest_artifact],
+                }
+            ],
+            description="Deploy manifest",
+            application=self.TEST_APP,
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='deploy_manifest', data=payload, path='tasks'),
-        contract=builder.build())
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Deployment created", retryable_for_secs=15)
+            .get_resources(
+                "deploy", extra_args=[name, "--namespace", self.TEST_NAMESPACE]
+            )
+            .EXPECT(self.mp.deployment_image_predicate(image))
+        )
 
-  def deploy_deployment_from_gcs(self, image):
-    """Creates OperationContract for deploying and substituting one image into
-    a Deployment object
+        return st.OperationContract(
+            self.new_post_operation(
+                title="deploy_manifest", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
-    To verify the operation, we just check that the deployment was created with
-    the correct image.
-    """
-    bindings = self.bindings
-    name = self.TEST_APP + '-deployment'
-    manifest = self.mf.deployment(name, image)
-    manifest_artifact = self.__gcs_manifest_expected_artifact(json.dumps(manifest), 'manifest.yaml')
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'moniker': {
-                'app': self.TEST_APP
-            },
-            'account': bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'source': 'artifact',
-            'type': 'deployManifest',
-            'user': '[anonymous]',
-            'manifestArtifactAccount': self.ARTIFACT_ACCOUNT,
-            'manifestArtifactId': manifest_artifact['id'],
-            'resolvedExpectedArtifacts': [manifest_artifact]
-        }],
-        description='Deploy manifest',
-        application=self.TEST_APP)
+    def delete_kind(self, kind, version=None):
+        """Creates OperationContract for deleteManifest
 
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Deployment created',
-                                retryable_for_secs=15)
-     .get_resources(
-         'deploy',
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.deployment_image_predicate(image)))
+        To verify the operation, we just check that the Kubernetes deployment
+        is no longer visible (or is in the process of terminating).
+        """
+        bindings = self.bindings
+        name = self.TEST_APP + "-" + kind
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "type": "deleteManifest",
+                    "account": bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "user": "[anonymous]",
+                    "kinds": [kind],
+                    "location": self.TEST_NAMESPACE,
+                    "options": {},
+                    "labelSelectors": {
+                        "selectors": [
+                            {"kind": "EQUALS", "key": "app", "values": [self.TEST_APP]}
+                        ]
+                    },
+                }
+            ],
+            application=self.TEST_APP,
+            description="Destroy Manifest",
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='deploy_manifest', data=payload, path='tasks'),
-        contract=builder.build())
+        if version is not None:
+            name = name + "-" + version
 
-  def delete_kind(self, kind, version=None):
-    """Creates OperationContract for deleteManifest
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Manifest Removed")
+            .get_resources(kind, extra_args=[name, "--namespace", self.TEST_NAMESPACE])
+            .EXPECT(self.mp.not_found_observation_predicate())
+        )
 
-    To verify the operation, we just check that the Kubernetes deployment
-    is no longer visible (or is in the process of terminating).
-    """
-    bindings = self.bindings
-    name = self.TEST_APP + '-' + kind
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'type': 'deleteManifest',
-            'account': bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'user': '[anonymous]',
-            'kinds': [ kind ],
-            'location': self.TEST_NAMESPACE,
-            'options': { },
-            'labelSelectors': {
-                'selectors': [{
-                    'kind': 'EQUALS',
-                    'key': 'app',
-                    'values': [ self.TEST_APP ]
-                }]
-            }
-        }],
-        application=self.TEST_APP,
-        description='Destroy Manifest')
+        return st.OperationContract(
+            self.new_post_operation(title="delete_kind", data=payload, path="tasks"),
+            contract=builder.build(),
+        )
 
-    if version is not None:
-      name = name + '-' + version
-
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Manifest Removed')
-     .get_resources(
-         kind,
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.not_found_observation_predicate()))
-
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_kind', data=payload, path='tasks'),
-        contract=builder.build())
 
 class KubeV2GcsTest(st.AgentTestCase):
-  """The test fixture for the KubeV2GcsTest.
+    """The test fixture for the KubeV2GcsTest.
 
-  This is implemented using citest OperationContract instances that are
-  created by the KubeV2GcsTestScenario.
-  """
-  # pylint: disable=missing-docstring
+    This is implemented using citest OperationContract instances that are
+    created by the KubeV2GcsTestScenario.
+    """
 
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-        KubeV2GcsTestScenario)
+    # pylint: disable=missing-docstring
 
-  def test_a_create_app(self):
-    self.run_test_case(self.scenario.create_app())
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            KubeV2GcsTestScenario
+        )
 
-  def test_b1_deploy_from_gcs(self):
-    self.run_test_case(self.scenario.deploy_deployment_from_gcs('library/nginx'))
+    def test_a_create_app(self):
+        self.run_test_case(self.scenario.create_app())
 
-  def test_b2_delete_deployment(self):
-    self.run_test_case(self.scenario.delete_kind('deployment'), max_retries=2)
+    def test_b1_deploy_from_gcs(self):
+        self.run_test_case(self.scenario.deploy_deployment_from_gcs("library/nginx"))
 
-  def test_c1_spel_deploy_from_gcs(self):
-    self.run_test_case(self.scenario.deploy_spel_deployment_from_gcs('library/nginx'))
+    def test_b2_delete_deployment(self):
+        self.run_test_case(self.scenario.delete_kind("deployment"), max_retries=2)
 
-  def test_c2_delete_deployment(self):
-    self.run_test_case(self.scenario.delete_kind('deployment'), max_retries=2)
+    def test_c1_spel_deploy_from_gcs(self):
+        self.run_test_case(
+            self.scenario.deploy_spel_deployment_from_gcs("library/nginx")
+        )
 
-  def test_z_delete_app(self):
-    # Give a total of 2 minutes because it might also need
-    # an internal cache update
-    self.run_test_case(self.scenario.delete_app(),
-                       retry_interval_secs=8, max_retries=15)
+    def test_c2_delete_deployment(self):
+        self.run_test_case(self.scenario.delete_kind("deployment"), max_retries=2)
+
+    def test_z_delete_app(self):
+        # Give a total of 2 minutes because it might also need
+        # an internal cache update
+        self.run_test_case(
+            self.scenario.delete_app(), retry_interval_secs=8, max_retries=15
+        )
 
 
 def main():
-  """Implements the main method running this gcs test."""
+    """Implements the main method running this gcs test."""
 
-  defaults = {
-      'TEST_STACK': 'tst',
-      'TEST_APP': 'kubv2gcs' + KubeV2GcsTestScenario.DEFAULT_TEST_ID
-  }
+    defaults = {
+        "TEST_STACK": "tst",
+        "TEST_APP": "kubv2gcs" + KubeV2GcsTestScenario.DEFAULT_TEST_ID,
+    }
 
-  return citest.base.TestRunner.main(
-      parser_inits=[KubeV2GcsTestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[KubeV2GcsTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[KubeV2GcsTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[KubeV2GcsTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/kube_v2_helm_test.py
+++ b/testing/citest/tests/kube_v2_helm_test.py
@@ -47,302 +47,334 @@ import citest.base
 
 ov_factory = jc.ObservationPredicateFactory()
 
+
 class KubeV2HelmTestScenario(sk.SpinnakerTestScenario):
-  """Defines the scenario for the kube v2 helm test.
-  """
+    """Defines the scenario for the kube v2 helm test."""
 
-  @classmethod
-  def new_agent(cls, bindings):
-    """Implements citest.service_testing.AgentTestScenario.new_agent."""
-    agent = gate.new_agent(bindings)
-    agent.default_max_wait_secs = 180
-    return agent
+    @classmethod
+    def new_agent(cls, bindings):
+        """Implements citest.service_testing.AgentTestScenario.new_agent."""
+        agent = gate.new_agent(bindings)
+        agent.default_max_wait_secs = 180
+        return agent
 
-  @classmethod
-  def initArgumentParser(cls, parser, defaults=None):
-    """Initialize command line argument parser.
+    @classmethod
+    def initArgumentParser(cls, parser, defaults=None):
+        """Initialize command line argument parser.
 
-    Args:
-      parser: argparse.ArgumentParser
-    """
-    super(KubeV2HelmTestScenario, cls).initArgumentParser(
-        parser, defaults=defaults)
+        Args:
+          parser: argparse.ArgumentParser
+        """
+        super(KubeV2HelmTestScenario, cls).initArgumentParser(parser, defaults=defaults)
 
-    defaults = defaults or {}
-    parser.add_argument(
-      '--test_namespace', default='default',
-      help='The namespace to manage within the tests.')
+        defaults = defaults or {}
+        parser.add_argument(
+            "--test_namespace",
+            default="default",
+            help="The namespace to manage within the tests.",
+        )
 
-    parser.add_argument(
-        '--test_gcs_artifact_account',
-        default='gcs-artifact-account',
-        help='Spinnaker GCS artifact account name to use for test operations'
-             ' against artifacts stored in GCS.')
+        parser.add_argument(
+            "--test_gcs_artifact_account",
+            default="gcs-artifact-account",
+            help="Spinnaker GCS artifact account name to use for test operations"
+            " against artifacts stored in GCS.",
+        )
 
-    parser.add_argument(
-        '--test_gcs_bucket',
-        help='GCS bucket to upload & read manifests from.')
+        parser.add_argument(
+            "--test_gcs_bucket", help="GCS bucket to upload & read manifests from."
+        )
 
-    parser.add_argument(
-        '--test_gcs_credentials_path', default=None,
-        help='GCS bucket to upload & read manifests from.')
+        parser.add_argument(
+            "--test_gcs_credentials_path",
+            default=None,
+            help="GCS bucket to upload & read manifests from.",
+        )
 
-  def __init__(self, bindings, agent=None):
-    """Constructor.
+    def __init__(self, bindings, agent=None):
+        """Constructor.
 
-    Args:
-      bindings: [dict] The data bindings to use to configure the scenario.
-      agent: [GateAgent] The agent for invoking the test operations on Gate.
-    """
-    super(KubeV2HelmTestScenario, self).__init__(bindings, agent)
-    bindings = self.bindings
+        Args:
+          bindings: [dict] The data bindings to use to configure the scenario.
+          agent: [GateAgent] The agent for invoking the test operations on Gate.
+        """
+        super(KubeV2HelmTestScenario, self).__init__(bindings, agent)
+        bindings = self.bindings
 
-    # We'll call out the app name because it is widely used
-    # because it scopes the context of our activities.
-    # pylint: disable=invalid-name
-    self.TEST_APP = bindings['TEST_APP']
-    self.TEST_USER = bindings['TEST_USER']
+        # We'll call out the app name because it is widely used
+        # because it scopes the context of our activities.
+        # pylint: disable=invalid-name
+        self.TEST_APP = bindings["TEST_APP"]
+        self.TEST_USER = bindings["TEST_USER"]
 
-    # Take just the first if there are multiple
-    # because some uses below assume just one.
-    self.TEST_NAMESPACE = bindings['TEST_NAMESPACE'].split(',')[0]
+        # Take just the first if there are multiple
+        # because some uses below assume just one.
+        self.TEST_NAMESPACE = bindings["TEST_NAMESPACE"].split(",")[0]
 
-    self.ARTIFACT_ACCOUNT = bindings['TEST_GCS_ARTIFACT_ACCOUNT']
-    self.BUCKET = bindings['TEST_GCS_BUCKET']
+        self.ARTIFACT_ACCOUNT = bindings["TEST_GCS_ARTIFACT_ACCOUNT"]
+        self.BUCKET = bindings["TEST_GCS_BUCKET"]
 
-    self.mf = sk.KubernetesManifestFactory(self)
-    self.mp = sk.KubernetesManifestPredicateFactory()
-    self.gcs = sk.GcsFileUploadAgent(bindings['TEST_GCS_CREDENTIALS_PATH'])
-    self.ps = sk.PipelineSupport(self)
+        self.mf = sk.KubernetesManifestFactory(self)
+        self.mp = sk.KubernetesManifestPredicateFactory()
+        self.gcs = sk.GcsFileUploadAgent(bindings["TEST_GCS_CREDENTIALS_PATH"])
+        self.ps = sk.PipelineSupport(self)
 
-  def create_app(self):
-    """Creates OperationContract that creates a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_create_app_operation(
-            bindings=self.bindings, application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            cloud_providers="kubernetes"),
-        contract=contract)
+    def create_app(self):
+        """Creates OperationContract that creates a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_create_app_operation(
+                bindings=self.bindings,
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                cloud_providers="kubernetes",
+            ),
+            contract=contract,
+        )
 
-  def delete_app(self):
-    """Creates OperationContract that deletes a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_delete_app_operation(
-            application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']),
-        contract=contract)
+    def delete_app(self):
+        """Creates OperationContract that deletes a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_delete_app_operation(
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+            ),
+            contract=contract,
+        )
 
-  def __create_helm_chart(self):
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    command = 'helm package {}/kube_v2_data/helm-test'.format(dir_path)
-    subprocess.Popen(command, stderr=sys.stderr, shell=True).wait()
-    return os.getcwd() + '/helm-test-0.1.0.tgz'
+    def __create_helm_chart(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        command = "helm package {}/kube_v2_data/helm-test".format(dir_path)
+        subprocess.Popen(command, stderr=sys.stderr, shell=True).wait()
+        return os.getcwd() + "/helm-test-0.1.0.tgz"
 
-  def __gcs_file_expected_artifact(self, contents, path):
-    self.gcs.upload_string(self.BUCKET, path, contents)
-    id_ = ''.join(random.choice(string.ascii_uppercase + string.digits)
-                  for _ in range(10))
-    artifact = {
-        'type': 'gcs/object',
-        'name': path,
-        'reference': 'gs://{}/{}'.format(self.BUCKET, path),
-    }
-    return {
-      'matchArtifact': artifact,
-      'defaultArtifact': artifact,
-      'useDefaultArtifact': True,
-      'id': id_,
-    }
+    def __gcs_file_expected_artifact(self, contents, path):
+        self.gcs.upload_string(self.BUCKET, path, contents)
+        id_ = "".join(
+            random.choice(string.ascii_uppercase + string.digits) for _ in range(10)
+        )
+        artifact = {
+            "type": "gcs/object",
+            "name": path,
+            "reference": "gs://{}/{}".format(self.BUCKET, path),
+        }
+        return {
+            "matchArtifact": artifact,
+            "defaultArtifact": artifact,
+            "useDefaultArtifact": True,
+            "id": id_,
+        }
 
-  def __gcs_helm_chart_expected_artifact(self, path):
-    chart = self.__create_helm_chart()
-    self.gcs.upload_file(self.BUCKET, path, chart)
-    os.remove(chart)
-    id_ = ''.join(random.choice(string.ascii_uppercase + string.digits)
-                  for _ in range(10))
-    artifact = {
-        'type': 'gcs/object',
-        'name': path,
-        'reference': 'gs://{}/{}'.format(self.BUCKET, path),
-    }
-    return {
-      'matchArtifact': artifact,
-      'defaultArtifact': artifact,
-      'useDefaultArtifact': True,
-      'id': id_,
-    }
+    def __gcs_helm_chart_expected_artifact(self, path):
+        chart = self.__create_helm_chart()
+        self.gcs.upload_file(self.BUCKET, path, chart)
+        os.remove(chart)
+        id_ = "".join(
+            random.choice(string.ascii_uppercase + string.digits) for _ in range(10)
+        )
+        artifact = {
+            "type": "gcs/object",
+            "name": path,
+            "reference": "gs://{}/{}".format(self.BUCKET, path),
+        }
+        return {
+            "matchArtifact": artifact,
+            "defaultArtifact": artifact,
+            "useDefaultArtifact": True,
+            "id": id_,
+        }
 
-  def save_bake_deploy_manifest_pipeline(self, image):
-    name = self.TEST_APP + '-deployment'
-    chart_expected_artifact = self.__gcs_helm_chart_expected_artifact('helm-test.tgz')
-    values_expected_artifact = self.__gcs_file_expected_artifact("""
+    def save_bake_deploy_manifest_pipeline(self, image):
+        name = self.TEST_APP + "-deployment"
+        chart_expected_artifact = self.__gcs_helm_chart_expected_artifact(
+            "helm-test.tgz"
+        )
+        values_expected_artifact = self.__gcs_file_expected_artifact(
+            """
     image: {image}
     namespace: {namespace}
     app: {app}
     name: {name}
-    """.format(image=image,
-               namespace=self.TEST_NAMESPACE,
-               app=self.TEST_APP,
-               name=name),
-    'helm-values.yml')
-    bake_artifact_id = 'bake-artifact'
-    bake_artifact_name = 'demo'
-    bake_stage = {
-        'type': 'bakeManifest',
-        'refId': 'bake',
-        'outputName': bake_artifact_name,
-        'inputArtifacts': [{
-            'account': self.ARTIFACT_ACCOUNT,
-            'id': chart_expected_artifact['id']
-        }, {
-            'account': self.ARTIFACT_ACCOUNT,
-            'id': values_expected_artifact['id']
-        },
-        ],
-        'expectedArtifacts': [{
-            'id': bake_artifact_id,
-            'matchArtifact': {
-                'type': 'embedded/base64',
-                'name': bake_artifact_name,
-            },
-        }],
-        'templateRenderer': 'HELM2',
-        'overrides': {},
-    }
+    """.format(
+                image=image, namespace=self.TEST_NAMESPACE, app=self.TEST_APP, name=name
+            ),
+            "helm-values.yml",
+        )
+        bake_artifact_id = "bake-artifact"
+        bake_artifact_name = "demo"
+        bake_stage = {
+            "type": "bakeManifest",
+            "refId": "bake",
+            "outputName": bake_artifact_name,
+            "inputArtifacts": [
+                {"account": self.ARTIFACT_ACCOUNT, "id": chart_expected_artifact["id"]},
+                {
+                    "account": self.ARTIFACT_ACCOUNT,
+                    "id": values_expected_artifact["id"],
+                },
+            ],
+            "expectedArtifacts": [
+                {
+                    "id": bake_artifact_id,
+                    "matchArtifact": {
+                        "type": "embedded/base64",
+                        "name": bake_artifact_name,
+                    },
+                }
+            ],
+            "templateRenderer": "HELM2",
+            "overrides": {},
+        }
 
-    deploy_stage = {
-        'type': 'deployManifest',
-        'refId': 'deploy',
-        'requisiteStageRefIds': ['bake'],
-        'cloudProvider': 'kubernetes',
-        'moniker': {
-            'app': self.TEST_APP
-        },
-        'account': self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-        'source': 'artifact',
-        'manifestArtifactAccount': 'embedded-artifact',
-        'manifestArtifactId': bake_artifact_id,
-    }
+        deploy_stage = {
+            "type": "deployManifest",
+            "refId": "deploy",
+            "requisiteStageRefIds": ["bake"],
+            "cloudProvider": "kubernetes",
+            "moniker": {"app": self.TEST_APP},
+            "account": self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+            "source": "artifact",
+            "manifestArtifactAccount": "embedded-artifact",
+            "manifestArtifactId": bake_artifact_id,
+        }
 
-    return self.ps.submit_pipeline_contract('bake-deploy-pipeline',
+        return self.ps.submit_pipeline_contract(
+            "bake-deploy-pipeline",
             [bake_stage, deploy_stage],
             expectedArtifacts=[chart_expected_artifact, values_expected_artifact],
-            user=self.TEST_USER)
+            user=self.TEST_USER,
+        )
 
-  def execute_bake_deploy_manifest_pipeline(self, image):
-    name = self.TEST_APP + '-deployment'
-    bindings = self.bindings
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'type': 'manual',
-            'user': '[anonymous]',
-        }],
-        description='Deploy manifest in ' + self.TEST_APP,
-        application=self.TEST_APP)
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Deployment deployed',
-                                retryable_for_secs=90)
-     .get_resources(
-         'deploy',
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.deployment_image_predicate(image)))
+    def execute_bake_deploy_manifest_pipeline(self, image):
+        name = self.TEST_APP + "-deployment"
+        bindings = self.bindings
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "type": "manual",
+                    "user": "[anonymous]",
+                }
+            ],
+            description="Deploy manifest in " + self.TEST_APP,
+            application=self.TEST_APP,
+        )
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Deployment deployed", retryable_for_secs=90)
+            .get_resources(
+                "deploy", extra_args=[name, "--namespace", self.TEST_NAMESPACE]
+            )
+            .EXPECT(self.mp.deployment_image_predicate(image))
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='Deploy manifest', data=payload,
-            path='pipelines/' + self.TEST_APP + '/bake-deploy-pipeline'),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(
+                title="Deploy manifest",
+                data=payload,
+                path="pipelines/" + self.TEST_APP + "/bake-deploy-pipeline",
+            ),
+            contract=builder.build(),
+        )
 
-  def delete_kind(self, kind, version=None):
-    """Creates OperationContract for deleteManifest
+    def delete_kind(self, kind, version=None):
+        """Creates OperationContract for deleteManifest
 
-    To verify the operation, we just check that the Kubernetes deployment
-    is no longer visible (or is in the process of terminating).
-    """
-    bindings = self.bindings
-    name = self.TEST_APP + '-' + kind
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'type': 'deleteManifest',
-            'account': bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'user': '[anonymous]',
-            'kinds': [ kind ],
-            'location': self.TEST_NAMESPACE,
-            'options': { },
-            'labelSelectors': {
-                'selectors': [{
-                    'kind': 'EQUALS',
-                    'key': 'app',
-                    'values': [ self.TEST_APP ]
-                }]
-            }
-        }],
-        application=self.TEST_APP,
-        description='Destroy Manifest')
+        To verify the operation, we just check that the Kubernetes deployment
+        is no longer visible (or is in the process of terminating).
+        """
+        bindings = self.bindings
+        name = self.TEST_APP + "-" + kind
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "type": "deleteManifest",
+                    "account": bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "user": "[anonymous]",
+                    "kinds": [kind],
+                    "location": self.TEST_NAMESPACE,
+                    "options": {},
+                    "labelSelectors": {
+                        "selectors": [
+                            {"kind": "EQUALS", "key": "app", "values": [self.TEST_APP]}
+                        ]
+                    },
+                }
+            ],
+            application=self.TEST_APP,
+            description="Destroy Manifest",
+        )
 
-    if version is not None:
-      name = name + '-' + version
+        if version is not None:
+            name = name + "-" + version
 
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Manifest Removed')
-     .get_resources(
-         kind,
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.not_found_observation_predicate()))
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Manifest Removed")
+            .get_resources(kind, extra_args=[name, "--namespace", self.TEST_NAMESPACE])
+            .EXPECT(self.mp.not_found_observation_predicate())
+        )
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_kind', data=payload, path='tasks'),
-        contract=builder.build())
+        return st.OperationContract(
+            self.new_post_operation(title="delete_kind", data=payload, path="tasks"),
+            contract=builder.build(),
+        )
+
 
 class KubeV2HelmTest(st.AgentTestCase):
-  """The test fixture for the KubeV2HelmTest.
+    """The test fixture for the KubeV2HelmTest.
 
-  This is implemented using citest OperationContract instances that are
-  created by the KubeV2HelmTestScenario.
-  """
-  # pylint: disable=missing-docstring
+    This is implemented using citest OperationContract instances that are
+    created by the KubeV2HelmTestScenario.
+    """
 
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-        KubeV2HelmTestScenario)
+    # pylint: disable=missing-docstring
 
-  def test_a_create_app(self):
-    self.run_test_case(self.scenario.create_app())
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            KubeV2HelmTestScenario
+        )
 
-  def test_b1_save_bake_deploy_manifest_pipeline(self):
-    self.run_test_case(self.scenario.save_bake_deploy_manifest_pipeline('library/nginx'))
+    def test_a_create_app(self):
+        self.run_test_case(self.scenario.create_app())
 
-  def test_b2_execute_bake_deploy_manifest_pipeline(self):
-    self.run_test_case(self.scenario.execute_bake_deploy_manifest_pipeline('library/nginx'))
+    def test_b1_save_bake_deploy_manifest_pipeline(self):
+        self.run_test_case(
+            self.scenario.save_bake_deploy_manifest_pipeline("library/nginx")
+        )
 
-  def test_b3_delete_deployment(self):
-    self.run_test_case(self.scenario.delete_kind('deployment'), max_retries=2)
+    def test_b2_execute_bake_deploy_manifest_pipeline(self):
+        self.run_test_case(
+            self.scenario.execute_bake_deploy_manifest_pipeline("library/nginx")
+        )
 
-  def test_z_delete_app(self):
-    # Give a total of 2 minutes because it might also need
-    # an internal cache update
-    self.run_test_case(self.scenario.delete_app(),
-                       retry_interval_secs=8, max_retries=15)
+    def test_b3_delete_deployment(self):
+        self.run_test_case(self.scenario.delete_kind("deployment"), max_retries=2)
+
+    def test_z_delete_app(self):
+        # Give a total of 2 minutes because it might also need
+        # an internal cache update
+        self.run_test_case(
+            self.scenario.delete_app(), retry_interval_secs=8, max_retries=15
+        )
 
 
 def main():
-  """Implements the main method running this helm test."""
+    """Implements the main method running this helm test."""
 
-  defaults = {
-      'TEST_STACK': 'tst',
-      'TEST_APP': 'kubv2helm' + KubeV2HelmTestScenario.DEFAULT_TEST_ID
-  }
+    defaults = {
+        "TEST_STACK": "tst",
+        "TEST_APP": "kubv2helm" + KubeV2HelmTestScenario.DEFAULT_TEST_ID,
+    }
 
-  return citest.base.TestRunner.main(
-      parser_inits=[KubeV2HelmTestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[KubeV2HelmTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[KubeV2HelmTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[KubeV2HelmTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/kube_v2_smoke_test.py
+++ b/testing/citest/tests/kube_v2_smoke_test.py
@@ -34,379 +34,432 @@ import citest.base
 
 ov_factory = jc.ObservationPredicateFactory()
 
+
 class KubeV2SmokeTestScenario(sk.SpinnakerTestScenario):
-  """Defines the scenario for the kube v2 smoke test.
-  """
+    """Defines the scenario for the kube v2 smoke test."""
 
-  @classmethod
-  def new_agent(cls, bindings):
-    """Implements citest.service_testing.AgentTestScenario.new_agent."""
-    agent = gate.new_agent(bindings)
-    agent.default_max_wait_secs = 180
-    return agent
+    @classmethod
+    def new_agent(cls, bindings):
+        """Implements citest.service_testing.AgentTestScenario.new_agent."""
+        agent = gate.new_agent(bindings)
+        agent.default_max_wait_secs = 180
+        return agent
 
-  @classmethod
-  def initArgumentParser(cls, parser, defaults=None):
-    """Initialize command line argument parser.
+    @classmethod
+    def initArgumentParser(cls, parser, defaults=None):
+        """Initialize command line argument parser.
 
-    Args:
-      parser: argparse.ArgumentParser
-    """
-    super(KubeV2SmokeTestScenario, cls).initArgumentParser(
-        parser, defaults=defaults)
+        Args:
+          parser: argparse.ArgumentParser
+        """
+        super(KubeV2SmokeTestScenario, cls).initArgumentParser(
+            parser, defaults=defaults
+        )
 
-    defaults = defaults or {}
-    parser.add_argument(
-      '--test_namespace', default='default',
-      help='The namespace to manage within the tests.')
+        defaults = defaults or {}
+        parser.add_argument(
+            "--test_namespace",
+            default="default",
+            help="The namespace to manage within the tests.",
+        )
 
-  def __init__(self, bindings, agent=None):
-    """Constructor.
+    def __init__(self, bindings, agent=None):
+        """Constructor.
 
-    Args:
-      bindings: [dict] The data bindings to use to configure the scenario.
-      agent: [GateAgent] The agent for invoking the test operations on Gate.
-    """
-    super(KubeV2SmokeTestScenario, self).__init__(bindings, agent)
-    bindings = self.bindings
+        Args:
+          bindings: [dict] The data bindings to use to configure the scenario.
+          agent: [GateAgent] The agent for invoking the test operations on Gate.
+        """
+        super(KubeV2SmokeTestScenario, self).__init__(bindings, agent)
+        bindings = self.bindings
 
-    # We'll call out the app name because it is widely used
-    # because it scopes the context of our activities.
-    # pylint: disable=invalid-name
-    self.TEST_APP = bindings['TEST_APP']
-    self.TEST_USER = bindings['TEST_USER']
+        # We'll call out the app name because it is widely used
+        # because it scopes the context of our activities.
+        # pylint: disable=invalid-name
+        self.TEST_APP = bindings["TEST_APP"]
+        self.TEST_USER = bindings["TEST_USER"]
 
-    # Take just the first if there are multiple
-    # because some uses below assume just one.
-    self.TEST_NAMESPACE = bindings['TEST_NAMESPACE'].split(',')[0]
-    self.pipeline_id = None
+        # Take just the first if there are multiple
+        # because some uses below assume just one.
+        self.TEST_NAMESPACE = bindings["TEST_NAMESPACE"].split(",")[0]
+        self.pipeline_id = None
 
-    self.mf = sk.KubernetesManifestFactory(self)
-    self.mp = sk.KubernetesManifestPredicateFactory()
-    self.ps = sk.PipelineSupport(self)
+        self.mf = sk.KubernetesManifestFactory(self)
+        self.mp = sk.KubernetesManifestPredicateFactory()
+        self.ps = sk.PipelineSupport(self)
 
-  def create_app(self):
-    """Creates OperationContract that creates a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_create_app_operation(
-            bindings=self.bindings, application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            cloud_providers="kubernetes"),
-        contract=contract)
+    def create_app(self):
+        """Creates OperationContract that creates a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_create_app_operation(
+                bindings=self.bindings,
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                cloud_providers="kubernetes",
+            ),
+            contract=contract,
+        )
 
-  def delete_app(self):
-    """Creates OperationContract that deletes a new Spinnaker Application."""
-    contract = jc.Contract()
-    return st.OperationContract(
-        self.agent.make_delete_app_operation(
+    def delete_app(self):
+        """Creates OperationContract that deletes a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_delete_app_operation(
+                application=self.TEST_APP,
+                account_name=self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+            ),
+            contract=contract,
+        )
+
+    def deploy_manifest(self, image):
+        """Creates OperationContract for deployManifest.
+
+        To verify the operation, we just check that the deployment was created.
+        """
+        bindings = self.bindings
+        name = self.TEST_APP + "-deployment"
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "moniker": {"app": self.TEST_APP},
+                    "account": bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "source": "text",
+                    "type": "deployManifest",
+                    "user": "[anonymous]",
+                    "manifests": [self.mf.deployment(name, image)],
+                }
+            ],
+            description="Deploy manifest",
             application=self.TEST_APP,
-            account_name=self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT']),
-        contract=contract)
+        )
 
-  def deploy_manifest(self, image):
-    """Creates OperationContract for deployManifest.
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Deployment created", retryable_for_secs=15)
+            .get_resources(
+                "deploy", extra_args=[name, "--namespace", self.TEST_NAMESPACE]
+            )
+            .EXPECT(self.mp.deployment_image_predicate(image))
+        )
 
-    To verify the operation, we just check that the deployment was created.
-    """
-    bindings = self.bindings
-    name = self.TEST_APP + '-deployment'
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'moniker': {
-                'app': self.TEST_APP
-            },
-            'account': bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'source': 'text',
-            'type': 'deployManifest',
-            'user': '[anonymous]',
-            'manifests': [self.mf.deployment(name, image)],
-        }],
-        description='Deploy manifest',
-        application=self.TEST_APP)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="deploy_manifest", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Deployment created',
-                                retryable_for_secs=15)
-     .get_resources(
-         'deploy',
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.deployment_image_predicate(image)))
+    def patch_manifest(self):
+        """Creates OperationContract for patchManifest.
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='deploy_manifest', data=payload, path='tasks'),
-        contract=builder.build())
+        To verify the operation, we just check that the deployment was created.
+        """
+        bindings = self.bindings
+        name = self.TEST_APP + "-deployment"
+        test_label = "patchedLabel"
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "account": bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "cloudProvider": "kubernetes",
+                    "kind": "deployment",
+                    "location": self.TEST_NAMESPACE,
+                    "manifestName": "deployment " + name,
+                    "type": "patchManifest",
+                    "user": "[anonymous]",
+                    "source": "text",
+                    "patchBody": {
+                        "metadata": {
+                            "labels": {
+                                "testLabel": test_label,
+                            }
+                        }
+                    },
+                    "options": {"mergeStrategy": "strategic", "record": True},
+                }
+            ],
+            description="Patch manifest",
+            application=self.TEST_APP,
+        )
 
-  def patch_manifest(self):
-    """Creates OperationContract for patchManifest.
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Deployment patched", retryable_for_secs=15)
+            .get_resources(
+                "deploy", extra_args=[name, "--namespace", self.TEST_NAMESPACE]
+            )
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {
+                            "metadata": jp.DICT_MATCHES(
+                                {
+                                    "labels": jp.DICT_MATCHES(
+                                        {"testLabel": jp.STR_EQ(test_label)}
+                                    )
+                                }
+                            )
+                        }
+                    )
+                )
+            )
+        )
 
-    To verify the operation, we just check that the deployment was created.
-    """
-    bindings = self.bindings
-    name = self.TEST_APP + '-deployment'
-    test_label = 'patchedLabel'
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-          'account': bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-          'cloudProvider': 'kubernetes',
-          'kind': 'deployment',
-          'location': self.TEST_NAMESPACE,
-          'manifestName': 'deployment ' + name,
-          'type': 'patchManifest',
-          'user': '[anonymous]',
-          'source': 'text',
-          'patchBody': {
-            'metadata': {
-              'labels': {
-                'testLabel': test_label,
-              }
-            }
-          },
-          'options': {
-            'mergeStrategy': 'strategic',
-            'record': True
-          }
-        }],
-        description='Patch manifest',
-        application=self.TEST_APP)
+        return st.OperationContract(
+            self.new_post_operation(title="patch_manifest", data=payload, path="tasks"),
+            contract=builder.build(),
+        )
 
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Deployment patched',
-                                retryable_for_secs=15)
-     .get_resources(
-        'deploy',
-        extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES({
-      'metadata': jp.DICT_MATCHES({
-        'labels': jp.DICT_MATCHES({
-          'testLabel': jp.STR_EQ(test_label)
-        })
-      })
-    }))))
+    def undo_rollout_manifest(self, image):
+        """Creates OperationContract for undoRolloutManifest.
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='patch_manifest', data=payload, path='tasks'),
-        contract=builder.build())
+        To verify the operation, we just check that the deployment has changed size
+        """
+        bindings = self.bindings
+        name = self.TEST_APP + "-deployment"
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "account": bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "manifestName": "deployment " + name,
+                    "location": self.TEST_NAMESPACE,
+                    "type": "undoRolloutManifest",
+                    "user": "[anonymous]",
+                    "numRevisionsBack": 1,
+                }
+            ],
+            description="Deploy manifest",
+            application=self.TEST_APP,
+        )
 
-  def undo_rollout_manifest(self, image):
-    """Creates OperationContract for undoRolloutManifest.
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Deployment rolled back", retryable_for_secs=15)
+            .get_resources(
+                "deploy", extra_args=[name, "--namespace", self.TEST_NAMESPACE]
+            )
+            .EXPECT(self.mp.deployment_image_predicate(image))
+        )
 
-    To verify the operation, we just check that the deployment has changed size
-    """
-    bindings = self.bindings
-    name = self.TEST_APP + '-deployment'
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'account': bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'manifestName': 'deployment ' + name,
-            'location': self.TEST_NAMESPACE,
-            'type': 'undoRolloutManifest',
-            'user': '[anonymous]',
-            'numRevisionsBack': 1
-        }],
-        description='Deploy manifest',
-        application=self.TEST_APP)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="undo_rollout_manifest", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Deployment rolled back',
-                                retryable_for_secs=15)
-     .get_resources(
-         'deploy',
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.deployment_image_predicate(image)))
+    def scale_manifest(self):
+        """Creates OperationContract for scaleManifest.
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='undo_rollout_manifest', data=payload, path='tasks'),
-        contract=builder.build())
+        To verify the operation, we just check that the deployment has changed size
+        """
+        bindings = self.bindings
+        name = self.TEST_APP + "-deployment"
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "account": bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "manifestName": "deployment " + name,
+                    "location": self.TEST_NAMESPACE,
+                    "type": "scaleManifest",
+                    "user": "[anonymous]",
+                    "replicas": 2,
+                }
+            ],
+            description="Deploy manifest",
+            application=self.TEST_APP,
+        )
 
-  def scale_manifest(self):
-    """Creates OperationContract for scaleManifest.
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Deployment scaled", retryable_for_secs=15)
+            .get_resources(
+                "deploy", extra_args=[name, "--namespace", self.TEST_NAMESPACE]
+            )
+            .EXPECT(
+                ov_factory.value_list_contains(
+                    jp.DICT_MATCHES(
+                        {"spec": jp.DICT_MATCHES({"replicas": jp.NUM_EQ(2)})}
+                    )
+                )
+            )
+        )
 
-    To verify the operation, we just check that the deployment has changed size
-    """
-    bindings = self.bindings
-    name = self.TEST_APP + '-deployment'
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'account': bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'manifestName': 'deployment ' + name,
-            'location': self.TEST_NAMESPACE,
-            'type': 'scaleManifest',
-            'user': '[anonymous]',
-            'replicas': 2
-        }],
-        description='Deploy manifest',
-        application=self.TEST_APP)
+        return st.OperationContract(
+            self.new_post_operation(title="scale_manifest", data=payload, path="tasks"),
+            contract=builder.build(),
+        )
 
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Deployment scaled',
-                                retryable_for_secs=15)
-     .get_resources(
-         'deploy',
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(ov_factory.value_list_contains(jp.DICT_MATCHES(
-         { 'spec': jp.DICT_MATCHES({ 'replicas': jp.NUM_EQ(2) }) }))))
+    def save_deploy_manifest_pipeline(self, image):
+        name = self.TEST_APP + "-deployment"
+        stage = {
+            "type": "deployManifest",
+            "cloudProvider": "kubernetes",
+            "moniker": {"app": self.TEST_APP},
+            "account": self.bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+            "source": "text",
+            "manifests": [self.mf.deployment(name, image)],
+        }
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='scale_manifest', data=payload, path='tasks'),
-        contract=builder.build())
+        return self.ps.submit_pipeline_contract(
+            "deploy-manifest-pipeline", [stage], user=self.TEST_USER
+        )
 
-  def save_deploy_manifest_pipeline(self, image):
-    name = self.TEST_APP + '-deployment'
-    stage = {
-        'type': 'deployManifest',
-        'cloudProvider': 'kubernetes',
-        'moniker': {
-            'app': self.TEST_APP
-        },
-        'account': self.bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-        'source': 'text',
-        'manifests': [self.mf.deployment(name, image)],
-    }
+    def execute_deploy_manifest_pipeline(self, image):
+        name = self.TEST_APP + "-deployment"
+        bindings = self.bindings
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[{"type": "manual", "user": "[anonymous]"}],
+            description="Deploy manifest in " + self.TEST_APP,
+            application=self.TEST_APP,
+        )
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Deployment deployed", retryable_for_secs=15)
+            .get_resources(
+                "deploy", extra_args=[name, "--namespace", self.TEST_NAMESPACE]
+            )
+            .EXPECT(self.mp.deployment_image_predicate(image))
+        )
 
-    return self.ps.submit_pipeline_contract('deploy-manifest-pipeline',
-            [stage],
-            user=self.TEST_USER)
+        return st.OperationContract(
+            self.new_post_operation(
+                title="Deploy manifest",
+                data=payload,
+                path="pipelines/" + self.TEST_APP + "/deploy-manifest-pipeline",
+            ),
+            contract=builder.build(),
+        )
 
-  def execute_deploy_manifest_pipeline(self, image):
-    name = self.TEST_APP + '-deployment'
-    bindings = self.bindings
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'type': 'manual',
-            'user': '[anonymous]'
-        }],
-        description='Deploy manifest in ' + self.TEST_APP,
-        application=self.TEST_APP)
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Deployment deployed',
-                                retryable_for_secs=15)
-     .get_resources(
-         'deploy',
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.deployment_image_predicate(image)))
+    def delete_manifest(self):
+        """Creates OperationContract for deleteManifest
 
-    return st.OperationContract(
-        self.new_post_operation(
-            title='Deploy manifest', data=payload,
-            path='pipelines/' + self.TEST_APP + '/deploy-manifest-pipeline'),
-        contract=builder.build())
+        To verify the operation, we just check that the Kubernetes deployment
+        is no longer visible (or is in the process of terminating).
+        """
+        bindings = self.bindings
+        name = self.TEST_APP + "-deployment"
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[
+                {
+                    "cloudProvider": "kubernetes",
+                    "type": "deleteManifest",
+                    "account": bindings["SPINNAKER_KUBERNETES_V2_ACCOUNT"],
+                    "user": "[anonymous]",
+                    "kinds": ["deployment"],
+                    "location": self.TEST_NAMESPACE,
+                    "options": {},
+                    "labelSelectors": {
+                        "selectors": [
+                            {"kind": "EQUALS", "key": "app", "values": [self.TEST_APP]}
+                        ]
+                    },
+                }
+            ],
+            application=self.TEST_APP,
+            description="Destroy Manifest",
+        )
 
-  def delete_manifest(self):
-    """Creates OperationContract for deleteManifest
+        builder = kube.KubeContractBuilder(self.kube_v2_observer)
+        (
+            builder.new_clause_builder("Replica Set Removed")
+            .get_resources(
+                "deployment", extra_args=[name, "--namespace", self.TEST_NAMESPACE]
+            )
+            .EXPECT(self.mp.not_found_observation_predicate())
+        )
 
-    To verify the operation, we just check that the Kubernetes deployment
-    is no longer visible (or is in the process of terminating).
-    """
-    bindings = self.bindings
-    name = self.TEST_APP + '-deployment'
-    payload = self.agent.make_json_payload_from_kwargs(
-        job=[{
-            'cloudProvider': 'kubernetes',
-            'type': 'deleteManifest',
-            'account': bindings['SPINNAKER_KUBERNETES_V2_ACCOUNT'],
-            'user': '[anonymous]',
-            'kinds': [ 'deployment' ],
-            'location': self.TEST_NAMESPACE,
-            'options': { },
-            'labelSelectors': {
-                'selectors': [{
-                    'kind': 'EQUALS',
-                    'key': 'app',
-                    'values': [ self.TEST_APP ]
-                }]
-            }
-        }],
-        application=self.TEST_APP,
-        description='Destroy Manifest')
+        return st.OperationContract(
+            self.new_post_operation(
+                title="delete_manifest", data=payload, path="tasks"
+            ),
+            contract=builder.build(),
+        )
 
-    builder = kube.KubeContractBuilder(self.kube_v2_observer)
-    (builder.new_clause_builder('Replica Set Removed')
-     .get_resources(
-         'deployment',
-         extra_args=[name, '--namespace', self.TEST_NAMESPACE])
-     .EXPECT(self.mp.not_found_observation_predicate()))
-
-    return st.OperationContract(
-        self.new_post_operation(
-            title='delete_manifest', data=payload, path='tasks'),
-        contract=builder.build())
 
 class KubeV2SmokeTest(st.AgentTestCase):
-  """The test fixture for the KubeV2SmokeTest.
+    """The test fixture for the KubeV2SmokeTest.
 
-  This is implemented using citest OperationContract instances that are
-  created by the KubeV2SmokeTestScenario.
-  """
-  # pylint: disable=missing-docstring
+    This is implemented using citest OperationContract instances that are
+    created by the KubeV2SmokeTestScenario.
+    """
 
-  @property
-  def scenario(self):
-    return citest.base.TestRunner.global_runner().get_shared_data(
-        KubeV2SmokeTestScenario)
+    # pylint: disable=missing-docstring
 
-  def test_a_create_app(self):
-    self.run_test_case(self.scenario.create_app())
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            KubeV2SmokeTestScenario
+        )
 
-  def test_b1_deploy_manifest(self):
-    self.run_test_case(self.scenario.deploy_manifest('library/nginx'),
-                       max_retries=1,
-                       timeout_ok=True)
+    def test_a_create_app(self):
+        self.run_test_case(self.scenario.create_app())
 
-  def test_b2_update_manifest(self):
-    self.run_test_case(self.scenario.deploy_manifest('library/redis'),
-                       max_retries=1,
-                       timeout_ok=True)
+    def test_b1_deploy_manifest(self):
+        self.run_test_case(
+            self.scenario.deploy_manifest("library/nginx"),
+            max_retries=1,
+            timeout_ok=True,
+        )
 
-  def test_b3_undo_rollout_manifest(self):
-    self.run_test_case(self.scenario.undo_rollout_manifest('library/nginx'),
-                       max_retries=1)
+    def test_b2_update_manifest(self):
+        self.run_test_case(
+            self.scenario.deploy_manifest("library/redis"),
+            max_retries=1,
+            timeout_ok=True,
+        )
 
-  def test_b4_scale_manifest(self):
-    self.run_test_case(self.scenario.scale_manifest(), max_retries=1)
+    def test_b3_undo_rollout_manifest(self):
+        self.run_test_case(
+            self.scenario.undo_rollout_manifest("library/nginx"), max_retries=1
+        )
 
-  def test_b5_patch_manifest(self):
-    self.run_test_case(self.scenario.patch_manifest(), max_retries=1)
+    def test_b4_scale_manifest(self):
+        self.run_test_case(self.scenario.scale_manifest(), max_retries=1)
 
-  def test_b6_delete_manifest(self):
-    self.run_test_case(self.scenario.delete_manifest(), max_retries=2)
+    def test_b5_patch_manifest(self):
+        self.run_test_case(self.scenario.patch_manifest(), max_retries=1)
 
-  def test_c1_save_deploy_manifest_pipeline(self):
-    self.run_test_case(self.scenario.save_deploy_manifest_pipeline('library/nginx'))
+    def test_b6_delete_manifest(self):
+        self.run_test_case(self.scenario.delete_manifest(), max_retries=2)
 
-  def test_c2_execute_deploy_manifest_pipeline(self):
-    self.run_test_case(self.scenario.execute_deploy_manifest_pipeline('library/nginx'))
+    def test_c1_save_deploy_manifest_pipeline(self):
+        self.run_test_case(self.scenario.save_deploy_manifest_pipeline("library/nginx"))
 
-  def test_c3_delete_manifest(self):
-    self.run_test_case(self.scenario.delete_manifest(), max_retries=2)
+    def test_c2_execute_deploy_manifest_pipeline(self):
+        self.run_test_case(
+            self.scenario.execute_deploy_manifest_pipeline("library/nginx")
+        )
 
-  def test_z_delete_app(self):
-    # Give a total of 2 minutes because it might also need
-    # an internal cache update
-    self.run_test_case(self.scenario.delete_app(),
-                       retry_interval_secs=8, max_retries=15)
+    def test_c3_delete_manifest(self):
+        self.run_test_case(self.scenario.delete_manifest(), max_retries=2)
+
+    def test_z_delete_app(self):
+        # Give a total of 2 minutes because it might also need
+        # an internal cache update
+        self.run_test_case(
+            self.scenario.delete_app(), retry_interval_secs=8, max_retries=15
+        )
 
 
 def main():
-  """Implements the main method running this smoke test."""
+    """Implements the main method running this smoke test."""
 
-  defaults = {
-      'TEST_STACK': 'tst',
-      'TEST_APP': 'kubv2smok' + KubeV2SmokeTestScenario.DEFAULT_TEST_ID
-  }
+    defaults = {
+        "TEST_STACK": "tst",
+        "TEST_APP": "kubv2smok" + KubeV2SmokeTestScenario.DEFAULT_TEST_ID,
+    }
 
-  return citest.base.TestRunner.main(
-      parser_inits=[KubeV2SmokeTestScenario.initArgumentParser],
-      default_binding_overrides=defaults,
-      test_case_list=[KubeV2SmokeTest])
+    return citest.base.TestRunner.main(
+        parser_inits=[KubeV2SmokeTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[KubeV2SmokeTest],
+    )
 
 
-if __name__ == '__main__':
-  sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/citest/tests/plugin_stage_test.py
+++ b/testing/citest/tests/plugin_stage_test.py
@@ -33,6 +33,7 @@ import citest.base
 import spinnaker_testing as sk
 import spinnaker_testing.gate as gate
 
+
 class PluginStageTestScenario(sk.SpinnakerTestScenario):
     """Defines the scenario for testing a stage implemented as a plugin."""
 
@@ -50,16 +51,19 @@ class PluginStageTestScenario(sk.SpinnakerTestScenario):
           parser: argparse.ArgumentParser
         """
         super(PluginStageTestScenario, cls).initArgumentParser(
-            parser, defaults=defaults)
+            parser, defaults=defaults
+        )
 
         defaults = defaults or {}
         parser.add_argument(
-            '--stage_name', default='randomWait',
-            help='The name of the plugin stage.')
+            "--stage_name", default="randomWait", help="The name of the plugin stage."
+        )
 
         parser.add_argument(
-            '--stage_params', default='{"maxWaitTime": 5}',
-            help='The stage params as a JSON-encoded string.')
+            "--stage_params",
+            default='{"maxWaitTime": 5}',
+            help="The stage params as a JSON-encoded string.",
+        )
 
     def __init__(self, bindings, agent=None):
         """Constructor.
@@ -70,26 +74,32 @@ class PluginStageTestScenario(sk.SpinnakerTestScenario):
         """
         super(PluginStageTestScenario, self).__init__(bindings, agent)
 
-        self.STAGE_NAME = bindings['STAGE_NAME']
-        self.STAGE_PARAMS = json.loads(bindings['STAGE_PARAMS'])
-        self.TEST_APP = 'app-{stage}'.format(stage=bindings['STAGE_NAME'])
+        self.STAGE_NAME = bindings["STAGE_NAME"]
+        self.STAGE_PARAMS = json.loads(bindings["STAGE_PARAMS"])
+        self.TEST_APP = "app-{stage}".format(stage=bindings["STAGE_NAME"])
 
     def run_stage_as_task(self):
         """Runs the configured stage as a Spinnaker task."""
         stage = {
-            'type': self.STAGE_NAME,
-            'user': '[anonymous]',
+            "type": self.STAGE_NAME,
+            "user": "[anonymous]",
         }
         stage.update(self.STAGE_PARAMS)
 
         payload = self.agent.make_json_payload_from_kwargs(
-            job=[stage], description='Execute plugin stage type {stage}'.format(
-                stage=self.STAGE_NAME), application=self.TEST_APP)
+            job=[stage],
+            description="Execute plugin stage type {stage}".format(
+                stage=self.STAGE_NAME
+            ),
+            application=self.TEST_APP,
+        )
 
         return st.OperationContract(
             self.new_post_operation(
-                title='execute_plugin_stage', data=payload, path='tasks'),
-            contract=jc.Contract())
+                title="execute_plugin_stage", data=payload, path="tasks"
+            ),
+            contract=jc.Contract(),
+        )
 
 
 class PluginStageTest(st.AgentTestCase):
@@ -102,13 +112,13 @@ class PluginStageTest(st.AgentTestCase):
     @property
     def scenario(self):
         return citest.base.TestRunner.global_runner().get_shared_data(
-            PluginStageTestScenario)
+            PluginStageTestScenario
+        )
 
     def test_run_stage(self):
         self.run_test_case(
-            self.scenario.run_stage_as_task(),
-            retry_interval_secs=5,
-            max_retries=5)
+            self.scenario.run_stage_as_task(), retry_interval_secs=5, max_retries=5
+        )
 
 
 def main():
@@ -117,7 +127,9 @@ def main():
     return citest.base.TestRunner.main(
         parser_inits=[PluginStageTestScenario.initArgumentParser],
         default_binding_overrides={},
-        test_case_list=[PluginStageTest])
+        test_case_list=[PluginStageTest],
+    )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(main())

--- a/testing/citest/unittests/expression_dict_test.py
+++ b/testing/citest/unittests/expression_dict_test.py
@@ -17,69 +17,77 @@ import unittest
 
 from spinnaker_testing.expression_dict import ExpressionDict
 
+
 class ExpressionDictTest(unittest.TestCase):
-  def test_constructor(self):
-    d = {'a': 'A'}
-    x = ExpressionDict({'a': 'A'})
-    self.assertEquals('A', x['a'])
-    self.assertEquals(d.items(), x.items())
-    self.assertEquals(d, x)
-    
-  def test_load_composite_value(self):
-    x = ExpressionDict({'a':'A', 'b':'B', 'test':'${a}/${b}'})
-    self.assertEqual('A/B', x.get('test'))
+    def test_constructor(self):
+        d = {"a": "A"}
+        x = ExpressionDict({"a": "A"})
+        self.assertEquals("A", x["a"])
+        self.assertEquals(d.items(), x.items())
+        self.assertEquals(d, x)
 
-  def test_load_default(self):
-    x = ExpressionDict({'field': '${injected.value}'})
-    self.assertEqual('MISSING', x.get('missing', 'MISSING'))
+    def test_load_composite_value(self):
+        x = ExpressionDict({"a": "A", "b": "B", "test": "${a}/${b}"})
+        self.assertEqual("A/B", x.get("test"))
 
-  def test_load_not_found(self):
-    x = ExpressionDict({'field': '${injected.value}'})
-    self.assertEqual('${injected.value}', x.get('field', None))
-    self.assertEqual('${injected.value}', x['field'])
+    def test_load_default(self):
+        x = ExpressionDict({"field": "${injected.value}"})
+        self.assertEqual("MISSING", x.get("missing", "MISSING"))
 
-  def test_load_tail_not_found(self):
-    x = ExpressionDict({'field': '${injected.value}', 'injected': {}})
-    self.assertEqual('${injected.value}', x.get('field'))
+    def test_load_not_found(self):
+        x = ExpressionDict({"field": "${injected.value}"})
+        self.assertEqual("${injected.value}", x.get("field", None))
+        self.assertEqual("${injected.value}", x["field"])
 
-  def test_load_default(self):
-    x = ExpressionDict({'field': '${injected.value:HELLO}'})
-    self.assertEqual('HELLO', x.get('field'))
+    def test_load_tail_not_found(self):
+        x = ExpressionDict({"field": "${injected.value}", "injected": {}})
+        self.assertEqual("${injected.value}", x.get("field"))
 
-  def test_load_transitive(self):
-    x = ExpressionDict({'field': '${injected.value}',
-                        'injected.value': 'HELLO'})
-    self.assertEqual('HELLO', x.get('field'))
+    def test_load_default(self):
+        x = ExpressionDict({"field": "${injected.value:HELLO}"})
+        self.assertEqual("HELLO", x.get("field"))
 
-  def test_load_transitive_indirect(self):
-    x = ExpressionDict({'field': '${injected.value}', 'found': 'FOUND',
-                        'injected.value': '${found}'})
-    self.assertEqual('FOUND', x.get('field'))
+    def test_load_transitive(self):
+        x = ExpressionDict({"field": "${injected.value}", "injected.value": "HELLO"})
+        self.assertEqual("HELLO", x.get("field"))
 
-  def test_load_key_not_found(self):
-    x = ExpressionDict({'field': '${injected.value}', 'injected': {}})
-    self.assertIsNone(x.get('unknown'))
-    with self.assertRaises(KeyError):
-      x['unknown']
+    def test_load_transitive_indirect(self):
+        x = ExpressionDict(
+            {
+                "field": "${injected.value}",
+                "found": "FOUND",
+                "injected.value": "${found}",
+            }
+        )
+        self.assertEqual("FOUND", x.get("field"))
 
-  def test_cyclic_reference(self):
-    x = ExpressionDict({'field': '${injected.value}',
-                        'injected.value': '${field}'})
-    with self.assertRaises(ValueError):
-      x['field']
-    with self.assertRaises(ValueError):
-      x.get('field')
+    def test_load_key_not_found(self):
+        x = ExpressionDict({"field": "${injected.value}", "injected": {}})
+        self.assertIsNone(x.get("unknown"))
+        with self.assertRaises(KeyError):
+            x["unknown"]
 
-  def test_def_value(self):
-    x = ExpressionDict({'t': 'true', 'f': 'false',
-                        'def': '${unknown:true}', 'indirect': '${f}'})
-    x.default_value_interpreter = lambda x: True if x == 'true' else False if x == 'false' else x
-    self.assertEqual('true', x.get('t'))
-    self.assertEqual('false', x.get('f'))
-    self.assertEqual(True, x.get('def'))
-    self.assertEqual('false', x.get('indirect'))
+    def test_cyclic_reference(self):
+        x = ExpressionDict({"field": "${injected.value}", "injected.value": "${field}"})
+        with self.assertRaises(ValueError):
+            x["field"]
+        with self.assertRaises(ValueError):
+            x.get("field")
 
-if __name__ == '__main__':
-  loader = unittest.TestLoader()
-  suite = loader.loadTestsFromTestCase(ExpressionDictTest)
-  unittest.TextTestRunner(verbosity=2).run(suite)
+    def test_def_value(self):
+        x = ExpressionDict(
+            {"t": "true", "f": "false", "def": "${unknown:true}", "indirect": "${f}"}
+        )
+        x.default_value_interpreter = (
+            lambda x: True if x == "true" else False if x == "false" else x
+        )
+        self.assertEqual("true", x.get("t"))
+        self.assertEqual("false", x.get("f"))
+        self.assertEqual(True, x.get("def"))
+        self.assertEqual("false", x.get("indirect"))
+
+
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromTestCase(ExpressionDictTest)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/testing/citest/unittests/yaml_accumulator_test.py
+++ b/testing/citest/unittests/yaml_accumulator_test.py
@@ -20,8 +20,8 @@ import spinnaker_testing.yaml_accumulator as yaml_accumulator
 
 
 class YamlAccumulatorTest(unittest.TestCase):
-  def test_load_string(self):
-    yaml = """
+    def test_load_string(self):
+        yaml = """
 a: A
 b: 0
 c:
@@ -32,17 +32,19 @@ d:
     grandchild: x
 e:
 """
-    expect = {'a': 'A',
-              'b': 0,
-              'c': ['A','B'],
-              'd.child.grandchild': 'x',
-              'e': None}
-    got = {}
-    yaml_accumulator.load_string(yaml, got)
-    self.assertEqual(expect, got)
+        expect = {
+            "a": "A",
+            "b": 0,
+            "c": ["A", "B"],
+            "d.child.grandchild": "x",
+            "e": None,
+        }
+        got = {}
+        yaml_accumulator.load_string(yaml, got)
+        self.assertEqual(expect, got)
 
-  def test_load_path(self):
-    yaml = """
+    def test_load_path(self):
+        yaml = """
 a: A
 b: 0
 c:
@@ -53,22 +55,24 @@ d:
     grandchild: x
 e:
 """
-    expect = {'a': 'A',
-              'b': 0,
-              'c': ['A','B'],
-              'd.child.grandchild': 'x',
-              'e': None}
+        expect = {
+            "a": "A",
+            "b": 0,
+            "c": ["A", "B"],
+            "d.child.grandchild": "x",
+            "e": None,
+        }
 
-    fd, temp_path = tempfile.mkstemp()
-    os.write(fd, yaml)
-    os.close(fd)
+        fd, temp_path = tempfile.mkstemp()
+        os.write(fd, yaml)
+        os.close(fd)
 
-    got = {}
-    yaml_accumulator.load_path(temp_path, got)
-    self.assertEqual(expect, got)
+        got = {}
+        yaml_accumulator.load_path(temp_path, got)
+        self.assertEqual(expect, got)
 
 
-if __name__ == '__main__':
-  loader = unittest.TestLoader()
-  suite = loader.loadTestsFromTestCase(YamlAccumulatorTest)
-  unittest.TextTestRunner(verbosity=2).run(suite)
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromTestCase(YamlAccumulatorTest)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/unittest/buildtool/branch_scm_test.py
+++ b/unittest/buildtool/branch_scm_test.py
@@ -28,215 +28,225 @@ from buildtool import (
     BranchSourceCodeManager,
     SpinnakerSourceCodeManager,
     UnexpectedError,
-
-    check_subprocess_sequence)
+    check_subprocess_sequence,
+)
 
 from test_util import init_runtime
 
 
-SCM_USER = 'scm_user'
-TEST_USER = 'test_user'
+SCM_USER = "scm_user"
+TEST_USER = "test_user"
 
-BASE_VERSION = 'v7.8.9'
-UNTAGGED_BRANCH = 'untagged-branch'
+BASE_VERSION = "v7.8.9"
+UNTAGGED_BRANCH = "untagged-branch"
 
 
 def make_default_options():
-  """Helper function for creating default options for runner."""
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--output_dir',
-                      default=os.path.join('/tmp', 'scmtest.%d' % os.getpid()))
-  GitRunner.add_parser_args(parser, {'github_owner': 'test_github_owner'})
-  options = parser.parse_args([])
-  options.command = 'test-command'
-  options.git_branch = 'testing'
-  options.github_hostname = 'test-githost'
-  options.github_upstream_owner = 'spinnaker'
-  return options
+    """Helper function for creating default options for runner."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output_dir", default=os.path.join("/tmp", "scmtest.%d" % os.getpid())
+    )
+    GitRunner.add_parser_args(parser, {"github_owner": "test_github_owner"})
+    options = parser.parse_args([])
+    options.command = "test-command"
+    options.git_branch = "testing"
+    options.github_hostname = "test-githost"
+    options.github_upstream_owner = "spinnaker"
+    return options
 
 
 class TestSourceCodeManager(unittest.TestCase):
-  @classmethod
-  def setUpClass(cls):
-    cls.base_temp_dir = tempfile.mkdtemp(prefix='scm_test')
-    origin_root = os.path.join(cls.base_temp_dir, 'test-githost')
+    @classmethod
+    def setUpClass(cls):
+        cls.base_temp_dir = tempfile.mkdtemp(prefix="scm_test")
+        origin_root = os.path.join(cls.base_temp_dir, "test-githost")
 
-    cls.ORIGIN_URLS = {
-        'RepoOne': os.path.join(origin_root, SCM_USER, 'RepoOne'),
-        'RepoTwo': os.path.join(origin_root, SCM_USER, 'RepoTwo'),
-        'RepoTest': os.path.join(origin_root, TEST_USER, 'RepoTest'),
-    }
+        cls.ORIGIN_URLS = {
+            "RepoOne": os.path.join(origin_root, SCM_USER, "RepoOne"),
+            "RepoTwo": os.path.join(origin_root, SCM_USER, "RepoTwo"),
+            "RepoTest": os.path.join(origin_root, TEST_USER, "RepoTest"),
+        }
 
-    for repo_name, repo_origin in cls.ORIGIN_URLS.items():
-      os.makedirs(repo_origin)
-      base_file = os.path.join(
-          repo_origin, '{name}-base.txt'.format(name=repo_name))
-      unique_file = os.path.join(
-          repo_origin, '{name}-unique.txt'.format(name=repo_name))
-      untagged_file = os.path.join(
-          repo_origin, '{name}-untagged.txt'.format(name=repo_name))
+        for repo_name, repo_origin in cls.ORIGIN_URLS.items():
+            os.makedirs(repo_origin)
+            base_file = os.path.join(
+                repo_origin, "{name}-base.txt".format(name=repo_name)
+            )
+            unique_file = os.path.join(
+                repo_origin, "{name}-unique.txt".format(name=repo_name)
+            )
+            untagged_file = os.path.join(
+                repo_origin, "{name}-untagged.txt".format(name=repo_name)
+            )
 
-      logging.debug('Initializing repository %s', repo_origin)
-      git_prefix = 'git -C "{dir}" '.format(dir=repo_origin)
-      run_git = lambda cmd: git_prefix + cmd
+            logging.debug("Initializing repository %s", repo_origin)
+            git_prefix = 'git -C "{dir}" '.format(dir=repo_origin)
+            run_git = lambda cmd: git_prefix + cmd
 
-      check_subprocess_sequence([
-          # BASE_VERSION
-          'touch "{file}"'.format(file=base_file),
-          run_git(' init'),
-          run_git('add "{file}"'.format(
-              file=os.path.basename(base_file))),
-          run_git('commit -a -m "feat(first): first commit"'),
-          run_git('tag {base_version} HEAD'.format(
-              base_version=BASE_VERSION)),
+            check_subprocess_sequence(
+                [
+                    # BASE_VERSION
+                    'touch "{file}"'.format(file=base_file),
+                    run_git(" init"),
+                    run_git('add "{file}"'.format(file=os.path.basename(base_file))),
+                    run_git('commit -a -m "feat(first): first commit"'),
+                    run_git(
+                        "tag {base_version} HEAD".format(base_version=BASE_VERSION)
+                    ),
+                    # Add Unique branch name per repo
+                    run_git("checkout -b {name}-branch".format(name=repo_name)),
+                    'touch "{file}"'.format(file=unique_file),
+                    run_git('add "{file}"'.format(file=os.path.basename(unique_file))),
+                    run_git('commit -a -m "chore(uniq): unique commit"'),
+                    # Add a common branch name, but without a tag on HEAD
+                    run_git("checkout master"),
+                    run_git("checkout -b {branch}".format(branch=UNTAGGED_BRANCH)),
+                    'touch "{file}"'.format(file=untagged_file),
+                    run_git(
+                        'add "{file}"'.format(file=os.path.basename(untagged_file))
+                    ),
+                    run_git('commit -a -m "feat(uniq): untagged commit"'),
+                    run_git("checkout master"),
+                ]
+            )
 
-          # Add Unique branch name per repo
-          run_git('checkout -b {name}-branch'.format(name=repo_name)),
-          'touch "{file}"'.format(file=unique_file),
-          run_git('add "{file}"'.format(file=os.path.basename(unique_file))),
-          run_git('commit -a -m "chore(uniq): unique commit"'),
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.base_temp_dir)
 
-          # Add a common branch name, but without a tag on HEAD
-          run_git('checkout master'),
-          run_git('checkout -b {branch}'
-                  .format(branch=UNTAGGED_BRANCH)),
-          'touch "{file}"'.format(file=untagged_file),
-          run_git('add "{file}"'.format(
-              file=os.path.basename(untagged_file))),
-          run_git('commit -a -m "feat(uniq): untagged commit"'),
-          run_git('checkout master')
-          ])
+    def setUp(self):
+        self.options = make_default_options()
 
-  @classmethod
-  def tearDownClass(cls):
-    shutil.rmtree(cls.base_temp_dir)
+    def test_get_local_repository_path(self):
+        test_root = os.path.join(self.base_temp_dir, "unused_source")
+        scm = BranchSourceCodeManager(self.options, test_root)
 
-  def setUp(self):
-    self.options = make_default_options()
+        tests = ["RepoOne", "RepoTwo", "RepoTest", "DoesNotExist"]
+        for repo_name in tests:
+            repository = scm.make_repository_spec(repo_name)
+            expect = os.path.join(test_root, repo_name)
+            self.assertEqual(expect, repository.git_dir)
+            self.assertFalse(os.path.exists(expect))
 
-  def test_get_local_repository_path(self):
-    test_root = os.path.join(self.base_temp_dir, 'unused_source')
-    scm = BranchSourceCodeManager(self.options, test_root)
+    def test_maybe_pull_repository_branch(self):
+        test_root = os.path.join(self.base_temp_dir, "pulled_test")
+        options = make_default_options()
+        options.git_branch = UNTAGGED_BRANCH
+        options.build_number = "maybe_pull_branch_buildnum"
+        scm = BranchSourceCodeManager(options, test_root)
 
-    tests = ['RepoOne', 'RepoTwo', 'RepoTest', 'DoesNotExist']
-    for repo_name in tests:
-      repository = scm.make_repository_spec(repo_name)
-      expect = os.path.join(test_root, repo_name)
-      self.assertEqual(expect, repository.git_dir)
-      self.assertFalse(os.path.exists(expect))
+        for repository_name, origin in self.ORIGIN_URLS.items():
+            repository = scm.make_repository_spec(
+                repository_name, origin=origin, upstream=None
+            )
+            scm.ensure_local_repository(repository)
 
-  def test_maybe_pull_repository_branch(self):
-    test_root = os.path.join(self.base_temp_dir, 'pulled_test')
-    options = make_default_options()
-    options.git_branch = UNTAGGED_BRANCH
-    options.build_number = 'maybe_pull_branch_buildnum'
-    scm = BranchSourceCodeManager(options, test_root)
+            git_dir = repository.git_dir
+            spec = scm.git.determine_git_repository_spec(git_dir)
+            self.assertEqual(repository, spec)
 
-    for repository_name, origin in self.ORIGIN_URLS.items():
-      repository = scm.make_repository_spec(repository_name, origin=origin,
-                                            upstream=None)
-      scm.ensure_local_repository(repository)
+            in_branch = scm.git.query_local_repository_branch(git_dir)
+            self.assertEqual(UNTAGGED_BRANCH, in_branch)
 
-      git_dir = repository.git_dir
-      spec = scm.git.determine_git_repository_spec(git_dir)
-      self.assertEqual(repository, spec)
+            summary = scm.git.collect_repository_summary(git_dir)
+            # always use last tag as version
+            semver = SemanticVersion.make(BASE_VERSION)
+            expect_version = semver.to_version()
 
-      in_branch = scm.git.query_local_repository_branch(git_dir)
-      self.assertEqual(UNTAGGED_BRANCH, in_branch)
+            self.assertEqual(expect_version, summary.version)
 
-      summary = scm.git.collect_repository_summary(git_dir)
-      # always use last tag as version
-      semver = SemanticVersion.make(BASE_VERSION)
-      expect_version = semver.to_version()
+    def test_pull_repository_fallback_branch(self):
+        test_root = os.path.join(self.base_temp_dir, "fallback_test")
+        unique_branch = "RepoTwo-branch"
+        options = make_default_options()
+        options.git_branch = unique_branch
+        options.git_fallback_branch = "master"
+        options.build_number = "pull_repository_fallback_buildnumber"
+        scm = BranchSourceCodeManager(options, test_root)
 
-      self.assertEqual(expect_version, summary.version)
+        for repo_name, origin in self.ORIGIN_URLS.items():
+            repository = scm.make_repository_spec(repo_name, origin=origin)
+            scm.ensure_local_repository(repository)
+            git_dir = repository.git_dir
+            want_branch = unique_branch if repository.name == "RepoTwo" else "master"
+            in_branch = scm.git.query_local_repository_branch(git_dir)
+            self.assertEqual(want_branch, in_branch)
 
-  def test_pull_repository_fallback_branch(self):
-    test_root = os.path.join(self.base_temp_dir, 'fallback_test')
-    unique_branch = 'RepoTwo-branch'
-    options = make_default_options()
-    options.git_branch = unique_branch
-    options.git_fallback_branch = 'master'
-    options.build_number = 'pull_repository_fallback_buildnumber'
-    scm = BranchSourceCodeManager(options, test_root)
+    def test_foreach_repo(self):
+        test_root = os.path.join(self.base_temp_dir, "foreach_test")
+        pos_args = [1, 2, 3]
+        kwargs = {"a": "A", "b": "B"}
 
-    for repo_name, origin in self.ORIGIN_URLS.items():
-      repository = scm.make_repository_spec(repo_name, origin=origin)
-      scm.ensure_local_repository(repository)
-      git_dir = repository.git_dir
-      want_branch = (unique_branch
-                     if repository.name == 'RepoTwo'
-                     else 'master')
-      in_branch = scm.git.query_local_repository_branch(git_dir)
-      self.assertEqual(want_branch, in_branch)
+        scm = SpinnakerSourceCodeManager(self.options, test_root)
+        all_repos = [
+            scm.make_repository_spec(repo_name, origin=origin)
+            for repo_name, origin in self.ORIGIN_URLS.items()
+        ]
+        expect = {
+            repository.name: (repository, pos_args, kwargs) for repository in all_repos
+        }
 
-  def test_foreach_repo(self):
-    test_root = os.path.join(self.base_temp_dir, 'foreach_test')
-    pos_args = [1, 2, 3]
-    kwargs = {'a': 'A', 'b': 'B'}
+        def _foreach_func(repository, *pos_args, **kwargs):
+            return (repository, list(pos_args), dict(kwargs))
 
-    scm = SpinnakerSourceCodeManager(self.options, test_root)
-    all_repos = [scm.make_repository_spec(repo_name, origin=origin)
-                 for repo_name, origin in self.ORIGIN_URLS.items()]
-    expect = {
-        repository.name: (repository, pos_args, kwargs)
-        for repository in all_repos
-    }
+        got = scm.foreach_source_repository(
+            all_repos, _foreach_func, *pos_args, **kwargs
+        )
+        self.assertEqual(expect, got)
 
-    def _foreach_func(repository, *pos_args, **kwargs):
-      return (repository, list(pos_args), dict(kwargs))
-    got = scm.foreach_source_repository(
-        all_repos, _foreach_func, *pos_args, **kwargs)
-    self.assertEqual(expect, got)
+    def test_check_repository_branch(self):
+        self.options.git_branch = UNTAGGED_BRANCH
 
-  def test_check_repository_branch(self):
-    self.options.git_branch = UNTAGGED_BRANCH
+        test_root = os.path.join(self.base_temp_dir, "check_branch_test")
+        scm = BranchSourceCodeManager(self.options, test_root)
+        repository_name = "RepoOne"
+        origin = self.ORIGIN_URLS[repository_name]
+        repository = scm.make_repository_spec(
+            repository_name, origin=origin, upstream=None
+        )
+        scm.ensure_local_repository(repository)
+        scm.check_repository_is_current(repository)
 
-    test_root = os.path.join(self.base_temp_dir, 'check_branch_test')
-    scm = BranchSourceCodeManager(self.options, test_root)
-    repository_name = 'RepoOne'
-    origin = self.ORIGIN_URLS[repository_name]
-    repository = scm.make_repository_spec(repository_name, origin=origin,
-                                          upstream=None)
-    scm.ensure_local_repository(repository)
-    scm.check_repository_is_current(repository)
+        scm.git.check_run(repository.git_dir, "checkout master")
+        self.assertRaises(UnexpectedError, scm.check_repository_is_current, repository)
 
-    scm.git.check_run(repository.git_dir, 'checkout master')
-    self.assertRaises(UnexpectedError, scm.check_repository_is_current, repository)
+    def test_check_repository_commit(self):
+        self.options.git_branch = UNTAGGED_BRANCH
 
-  def test_check_repository_commit(self):
-    self.options.git_branch = UNTAGGED_BRANCH
+        test_root = os.path.join(self.base_temp_dir, "check_commit_test")
+        scm = BranchSourceCodeManager(self.options, test_root)
+        repository_name = "RepoOne"
+        origin = self.ORIGIN_URLS[repository_name]
+        repository = scm.make_repository_spec(
+            repository_name, origin=origin, upstream=None
+        )
+        scm.ensure_local_repository(repository)
+        scm.check_repository_is_current(repository)
 
-    test_root = os.path.join(self.base_temp_dir, 'check_commit_test')
-    scm = BranchSourceCodeManager(self.options, test_root)
-    repository_name = 'RepoOne'
-    origin = self.ORIGIN_URLS[repository_name]
-    repository = scm.make_repository_spec(repository_name, origin=origin,
-                                          upstream=None)
-    scm.ensure_local_repository(repository)
-    scm.check_repository_is_current(repository)
+        # Create another repo pinned to this particular commit.
+        commit = scm.git.query_local_repository_commit_id(repository.git_dir)
+        repository_at_commit = scm.make_repository_spec(
+            repository_name, origin=origin, upstream=None, commit_id=commit
+        )
 
-    # Create another repo pinned to this particular commit.
-    commit = scm.git.query_local_repository_commit_id(repository.git_dir)
-    repository_at_commit = scm.make_repository_spec(
-        repository_name, origin=origin, upstream=None, commit_id=commit)
+        # We're at the commit, so this should validate.
+        scm.check_repository_is_current(repository_at_commit)
 
-    # We're at the commit, so this should validate.
-    scm.check_repository_is_current(repository_at_commit)
+        # Make a change to the repo so commit differs.
+        with open(os.path.join(repository.git_dir, "scrap"), "w") as stream:
+            stream.write("hello")
+        scm.git.check_run(repository.git_dir, "add scrap")
+        scm.git.check_run(repository.git_dir, 'commit -a -m "added file"')
 
-    # Make a change to the repo so commit differs.
-    with open(os.path.join(repository.git_dir, 'scrap'), 'w') as stream:
-      stream.write('hello');
-    scm.git.check_run(repository.git_dir, 'add scrap')
-    scm.git.check_run(repository.git_dir, 'commit -a -m "added file"')
-
-    # We're still in the branch, so the branch only repository is still ok,
-    # but no longer at the same commit, so the commit-pinned repository is bad.
-    scm.check_repository_is_current(repository)
-    self.assertRaises(UnexpectedError, scm.check_repository_is_current,
-                      repository_at_commit)
+        # We're still in the branch, so the branch only repository is still ok,
+        # but no longer at the same commit, so the commit-pinned repository is bad.
+        scm.check_repository_is_current(repository)
+        self.assertRaises(
+            UnexpectedError, scm.check_repository_is_current, repository_at_commit
+        )
 
 
-if __name__ == '__main__':
-  init_runtime()
-  unittest.main(verbosity=2)
+if __name__ == "__main__":
+    init_runtime()
+    unittest.main(verbosity=2)

--- a/unittest/buildtool/custom_test_command.py
+++ b/unittest/buildtool/custom_test_command.py
@@ -16,33 +16,36 @@
 
 import buildtool.command
 
-COMMAND = 'test_command_example'
-CUSTOM_ARG_NAME = 'custom_test_arg'
-CUSTOM_ARG_DEFAULT_VALUE = 'Custom Default Value'
+COMMAND = "test_command_example"
+CUSTOM_ARG_NAME = "custom_test_arg"
+CUSTOM_ARG_DEFAULT_VALUE = "Custom Default Value"
 
 
 class TestCommand(buildtool.command.CommandProcessor):
-  @property
-  def calls(self):
-    return self.__calls
+    @property
+    def calls(self):
+        return self.__calls
 
-  def __init__(self, factory, options):
-    super(TestCommand, self).__init__(factory, options)
-    self.__calls = 0
+    def __init__(self, factory, options):
+        super(TestCommand, self).__init__(factory, options)
+        self.__calls = 0
 
-  def _do_command(self):
-    self.__calls += 1
+    def _do_command(self):
+        self.__calls += 1
 
 
 class TestCommandFactory(buildtool.command.CommandFactory):
-  def __init__(self):
-    super(TestCommandFactory, self).__init__(
-        COMMAND, TestCommand, 'My Test Command')
+    def __init__(self):
+        super(TestCommandFactory, self).__init__(
+            COMMAND, TestCommand, "My Test Command"
+        )
 
-  def init_argparser(self, parser, defaults):
-    super(TestCommandFactory, self).init_argparser(parser, defaults)
-    TestCommandFactory.add_argument(
-        parser, CUSTOM_ARG_NAME, defaults, CUSTOM_ARG_DEFAULT_VALUE)
+    def init_argparser(self, parser, defaults):
+        super(TestCommandFactory, self).init_argparser(parser, defaults)
+        TestCommandFactory.add_argument(
+            parser, CUSTOM_ARG_NAME, defaults, CUSTOM_ARG_DEFAULT_VALUE
+        )
+
 
 def register_commands(registry, subparsers, defaults):
-  TestCommandFactory().register(registry, subparsers, defaults)
+    TestCommandFactory().register(registry, subparsers, defaults)

--- a/unittest/buildtool/git_support_test.py
+++ b/unittest/buildtool/git_support_test.py
@@ -30,560 +30,620 @@ from buildtool import (
     GitRunner,
     RepositorySummary,
     SemanticVersion,
-
     check_subprocess,
-    check_subprocess_sequence)
+    check_subprocess_sequence,
+)
 
 from test_util import init_runtime
 
 
-TAG_VERSION_PATTERN = r'^v[0-9]+\.[0-9]+\.[0-9]+$'
+TAG_VERSION_PATTERN = r"^v[0-9]+\.[0-9]+\.[0-9]+$"
 
-VERSION_BASE = 'v0.1.0'
-VERSION_A = 'v0.4.0'
-VERSION_B = 'v0.5.0'
-BRANCH_A = 'release-a'
-BRANCH_B = 'release-b'
-BRANCH_C = 'release-c'
-BRANCH_BASE = 'baseline'
-UPSTREAM_USER = 'unittest'
-TEST_REPO_NAME = 'test_repository'
+VERSION_BASE = "v0.1.0"
+VERSION_A = "v0.4.0"
+VERSION_B = "v0.5.0"
+BRANCH_A = "release-a"
+BRANCH_B = "release-b"
+BRANCH_C = "release-c"
+BRANCH_BASE = "baseline"
+UPSTREAM_USER = "unittest"
+TEST_REPO_NAME = "test_repository"
 
 
 def make_default_options():
-  """Helper function for creating default options for runner."""
-  parser = argparse.ArgumentParser()
-  GitRunner.add_parser_args(parser, {'github_disable_upstream_push': True})
-  parser.add_argument('--output_dir',
-                      default=os.path.join('/tmp', 'gittest.%d' % os.getpid()))
-  return parser.parse_args([])
+    """Helper function for creating default options for runner."""
+    parser = argparse.ArgumentParser()
+    GitRunner.add_parser_args(parser, {"github_disable_upstream_push": True})
+    parser.add_argument(
+        "--output_dir", default=os.path.join("/tmp", "gittest.%d" % os.getpid())
+    )
+    return parser.parse_args([])
 
 
 class TestGitRunner(unittest.TestCase):
-  @classmethod
-  def run_git(cls, command):
-    return check_subprocess(
-        'git -C "{dir}" {command}'.format(dir=cls.git_dir, command=command))
+    @classmethod
+    def run_git(cls, command):
+        return check_subprocess(
+            'git -C "{dir}" {command}'.format(dir=cls.git_dir, command=command)
+        )
 
-  @classmethod
-  def setUpClass(cls):
-    cls.git = GitRunner(make_default_options())
-    cls.base_temp_dir = tempfile.mkdtemp(prefix='git_test')
-    cls.git_dir = os.path.join(cls.base_temp_dir, UPSTREAM_USER, TEST_REPO_NAME)
-    os.makedirs(cls.git_dir)
+    @classmethod
+    def setUpClass(cls):
+        cls.git = GitRunner(make_default_options())
+        cls.base_temp_dir = tempfile.mkdtemp(prefix="git_test")
+        cls.git_dir = os.path.join(cls.base_temp_dir, UPSTREAM_USER, TEST_REPO_NAME)
+        os.makedirs(cls.git_dir)
 
-    git_dir = cls.git_dir
-    gitify = lambda args: 'git -C "{dir}" {args}'.format(dir=git_dir, args=args)
-    check_subprocess_sequence([
-        gitify('init'),
-        'touch "{dir}/base_file"'.format(dir=git_dir),
-        gitify('add "{dir}/base_file"'.format(dir=git_dir)),
-        gitify('commit -a -m "feat(test): added file"'),
-        gitify('tag {base_version} HEAD'.format(base_version=VERSION_BASE)),
-        gitify('checkout -b {base_branch}'.format(base_branch=BRANCH_BASE)),
-        gitify('checkout -b {a_branch}'.format(a_branch=BRANCH_A)),
-        'touch "{dir}/a_file"'.format(dir=git_dir),
-        gitify('add "{dir}/a_file"'.format(dir=git_dir)),
-        gitify('commit -a -m "feat(test): added a_file"'),
-        gitify('tag {a_version} HEAD'.format(a_version=VERSION_A)),
-        gitify('checkout master'),
-        gitify('checkout -b {b_branch}'.format(b_branch=BRANCH_B)),
-        'touch "{dir}/b_file"'.format(dir=git_dir),
-        gitify('add "{dir}/b_file"'.format(dir=git_dir)),
-        gitify('commit -a -m "feat(test): added b_file"'),
-        gitify('tag {b_version} HEAD'.format(b_version=VERSION_B)),
+        git_dir = cls.git_dir
+        gitify = lambda args: 'git -C "{dir}" {args}'.format(dir=git_dir, args=args)
+        check_subprocess_sequence(
+            [
+                gitify("init"),
+                'touch "{dir}/base_file"'.format(dir=git_dir),
+                gitify('add "{dir}/base_file"'.format(dir=git_dir)),
+                gitify('commit -a -m "feat(test): added file"'),
+                gitify("tag {base_version} HEAD".format(base_version=VERSION_BASE)),
+                gitify("checkout -b {base_branch}".format(base_branch=BRANCH_BASE)),
+                gitify("checkout -b {a_branch}".format(a_branch=BRANCH_A)),
+                'touch "{dir}/a_file"'.format(dir=git_dir),
+                gitify('add "{dir}/a_file"'.format(dir=git_dir)),
+                gitify('commit -a -m "feat(test): added a_file"'),
+                gitify("tag {a_version} HEAD".format(a_version=VERSION_A)),
+                gitify("checkout master"),
+                gitify("checkout -b {b_branch}".format(b_branch=BRANCH_B)),
+                'touch "{dir}/b_file"'.format(dir=git_dir),
+                gitify('add "{dir}/b_file"'.format(dir=git_dir)),
+                gitify('commit -a -m "feat(test): added b_file"'),
+                gitify("tag {b_version} HEAD".format(b_version=VERSION_B)),
+                gitify("checkout master"),
+                'touch "{dir}/master_file"'.format(dir=git_dir),
+                gitify('add "{dir}/master_file"'.format(dir=git_dir)),
+                gitify('commit -a -m "feat(test): added master_file"'),
+                gitify("checkout -b {c_branch}".format(c_branch=BRANCH_C)),
+                'touch "{dir}/c_file"'.format(dir=git_dir),
+                gitify('add "{dir}/c_file"'.format(dir=git_dir)),
+                gitify('commit -a -m "feat(test): added c_file"'),
+                gitify("checkout master"),
+                'touch "{dir}/extra_file"'.format(dir=git_dir),
+                gitify('add "{dir}/extra_file"'.format(dir=git_dir)),
+                gitify('commit -a -m "feat(test): added extra_file"'),
+                gitify("tag v9.9.9 HEAD"),
+            ]
+        )
 
-        gitify('checkout master'),
-        'touch "{dir}/master_file"'.format(dir=git_dir),
-        gitify('add "{dir}/master_file"'.format(dir=git_dir)),
-        gitify('commit -a -m "feat(test): added master_file"'),
-        gitify('checkout -b {c_branch}'.format(c_branch=BRANCH_C)),
-        'touch "{dir}/c_file"'.format(dir=git_dir),
-        gitify('add "{dir}/c_file"'.format(dir=git_dir)),
-        gitify('commit -a -m "feat(test): added c_file"'),
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.base_temp_dir)
 
-        gitify('checkout master'),
-        'touch "{dir}/extra_file"'.format(dir=git_dir),
-        gitify('add "{dir}/extra_file"'.format(dir=git_dir)),
-        gitify('commit -a -m "feat(test): added extra_file"'),
-        gitify('tag v9.9.9 HEAD')])
+    def setUp(self):
+        self.run_git("checkout master".format(dir=self.git_dir))
 
-  @classmethod
-  def tearDownClass(cls):
-    shutil.rmtree(cls.base_temp_dir)
+    def test_query_local_repository_branch(self):
+        initial_branch = self.git.query_local_repository_branch(self.git_dir)
+        self.assertEqual("master", initial_branch)
 
-  def setUp(self):
-    self.run_git('checkout master'.format(dir=self.git_dir))
+        self.run_git("checkout -b branch_test")
+        final_branch = self.git.query_local_repository_branch(self.git_dir)
+        self.assertEqual("branch_test", final_branch)
 
-  def test_query_local_repository_branch(self):
-    initial_branch = self.git.query_local_repository_branch(self.git_dir)
-    self.assertEqual('master', initial_branch)
+    def test_find_newest_tag_and_common_commit_from_id(self):
+        # pylint: disable=too-many-locals
+        git = self.git
 
-    self.run_git('checkout -b branch_test')
-    final_branch = self.git.query_local_repository_branch(self.git_dir)
-    self.assertEqual('branch_test', final_branch)
+        tests = [
+            (BRANCH_BASE, VERSION_BASE),
+            (BRANCH_A, VERSION_A),
+            (BRANCH_B, VERSION_B),
+            (BRANCH_B, VERSION_B),
+        ]
+        for branch, version in tests:
+            self.run_git("checkout " + branch)
+            head_commit_id = git.query_local_repository_commit_id(self.git_dir)
+            tag, _ = git.find_newest_tag_and_common_commit_from_id(
+                self.git_dir, head_commit_id
+            )
 
-  def test_find_newest_tag_and_common_commit_from_id(self):
-    # pylint: disable=too-many-locals
-    git = self.git
+            self.assertEqual(version, tag)
 
-    tests = [(BRANCH_BASE, VERSION_BASE),
-             (BRANCH_A, VERSION_A),
-             (BRANCH_B, VERSION_B),
-             (BRANCH_B, VERSION_B)]
-    for branch, version in tests:
-      self.run_git('checkout ' + branch)
-      head_commit_id = git.query_local_repository_commit_id(self.git_dir)
-      tag, _ = git.find_newest_tag_and_common_commit_from_id(
-          self.git_dir, head_commit_id)
+    def test_is_same_repo(self):
+        variants = [
+            "http://github.com/user/spinnaker",
+            "http://github.com/user/spinnaker.git",
+            "https://github.com/user/spinnaker",
+            "https://github.com/user/spinnaker.git",
+            "git@github.com:user/spinnaker.git",
+            "git@github.com:user/spinnaker.git",
+        ]
+        for url in variants:
+            self.assertTrue(GitRunner.is_same_repo(variants[0], url))
 
-      self.assertEqual(version, tag)
+    def test_different_repo(self):
+        variants = [
+            "http://github.com/user/spinnaker",
+            "http://github.com/path/user/spinnaker",
+            "http://github.com/user/spinnaker/path",
+            "http://github.com/user/spinnaker.github",
+            "http://github/user/spinnaker",
+            "http://mydomain.com/user/spinnaker",
+            "path/user/spinnaker",
+        ]
+        for url in variants[1:]:
+            self.assertFalse(GitRunner.is_same_repo(variants[0], url))
 
-  def test_is_same_repo(self):
-    variants = [
-        'http://github.com/user/spinnaker',
-        'http://github.com/user/spinnaker.git',
-        'https://github.com/user/spinnaker',
-        'https://github.com/user/spinnaker.git',
-        'git@github.com:user/spinnaker.git',
-        'git@github.com:user/spinnaker.git'
-    ]
-    for url in variants:
-      self.assertTrue(GitRunner.is_same_repo(variants[0], url))
+    def test_query_local_repository_commits_between_two_commit_ids(self):
+        git = self.git
+        test_method = git.query_local_repository_commits_between_two_commit_ids
 
-  def test_different_repo(self):
-    variants = [
-        'http://github.com/user/spinnaker',
-        'http://github.com/path/user/spinnaker',
-        'http://github.com/user/spinnaker/path',
-        'http://github.com/user/spinnaker.github',
-        'http://github/user/spinnaker',
-        'http://mydomain.com/user/spinnaker',
-        'path/user/spinnaker'
-    ]
-    for url in variants[1:]:
-      self.assertFalse(GitRunner.is_same_repo(variants[0], url))
+        tests = [(BRANCH_A, VERSION_A), (BRANCH_B, VERSION_B)]
 
-  def test_query_local_repository_commits_between_two_commit_ids(self):
-    git = self.git
-    test_method = git.query_local_repository_commits_between_two_commit_ids
+        for branch, version in tests:
+            new_version = str(version)
+            new_version = new_version[:-1] + "1"
+            self.run_git("checkout " + branch)
+            self.run_git("checkout -b {branch}-patch".format(branch=branch))
+            start_commit_id = git.query_local_repository_commit_id(self.git_dir)
+            new_messages = []
+            for change in ["first", "second"]:
+                new_path = os.path.join(self.git_dir, change + "_file")
+                check_subprocess('touch "{path}"'.format(path=new_path))
+                self.run_git('add "{path}"'.format(path=new_path))
+                message = "fix(test): Made {change} change for testing.".format(
+                    change=change
+                )
+                self.run_git('commit -a -m "{message}"'.format(message=message))
+                new_messages.append(" " * 4 + message)
 
-    tests = [(BRANCH_A, VERSION_A),
-             (BRANCH_B, VERSION_B)]
+            # Clone the repo because the <test_method> only works on remote repositories
+            # so we need to give a local repository in front of the test repo we set up.
+            # The reason for the remote constraint is because it wants to use "branch -r".
+            clone_dir = os.path.join(self.base_temp_dir, "tag_at_patch", branch)
+            os.makedirs(clone_dir)
+            check_subprocess(
+                "git clone {source} {target}".format(
+                    source=self.git_dir, target=clone_dir
+                )
+            )
+            head_commit_id = git.query_local_repository_commit_id(clone_dir)
 
-    for branch, version in tests:
-      new_version = str(version)
-      new_version = new_version[:-1] + '1'
-      self.run_git('checkout ' + branch)
-      self.run_git('checkout -b {branch}-patch'.format(branch=branch))
-      start_commit_id = git.query_local_repository_commit_id(self.git_dir)
-      new_messages = []
-      for change in ['first', 'second']:
-        new_path = os.path.join(self.git_dir, change + '_file')
-        check_subprocess('touch "{path}"'.format(path=new_path))
-        self.run_git('add "{path}"'.format(path=new_path))
-        message = 'fix(test): Made {change} change for testing.'.format(
-            change=change)
-        self.run_git('commit -a -m "{message}"'.format(message=message))
-        new_messages.append(' '*4 + message)
+            # The new messages show as we are providing pre and post commit ids in
+            # the correct chronological order
+            base_to_head_messages = test_method(
+                clone_dir, start_commit_id, head_commit_id
+            )
+            self.assertEqual(2, len(base_to_head_messages))
+            self.assertEqual(
+                sorted(new_messages, reverse=True),
+                [m.message for m in base_to_head_messages],
+            )
 
-      # Clone the repo because the <test_method> only works on remote repositories
-      # so we need to give a local repository in front of the test repo we set up.
-      # The reason for the remote constraint is because it wants to use "branch -r".
-      clone_dir = os.path.join(self.base_temp_dir, 'tag_at_patch', branch)
-      os.makedirs(clone_dir)
-      check_subprocess('git clone {source} {target}'.format(
-          source=self.git_dir, target=clone_dir))
-      head_commit_id = git.query_local_repository_commit_id(clone_dir)
+            # The new messages won't show if we provide pre and post commit ids in
+            # the incorrect chronological order
+            head_to_base_messages = test_method(
+                clone_dir, head_commit_id, start_commit_id
+            )
+            self.assertEqual(0, len(head_to_base_messages))
 
-      # The new messages show as we are providing pre and post commit ids in
-      # the correct chronological order
-      base_to_head_messages = test_method(clone_dir, start_commit_id, head_commit_id)
-      self.assertEqual(2, len(base_to_head_messages))
-      self.assertEqual(sorted(new_messages, reverse=True),
-                       [m.message for m in base_to_head_messages])
+    def test_clone_upstream(self):
+        git = self.git
+        test_parent = os.path.join(self.base_temp_dir, "test_clone_upstream")
+        os.makedirs(test_parent)
 
-      # The new messages won't show if we provide pre and post commit ids in
-      # the incorrect chronological order
-      head_to_base_messages = test_method(clone_dir, head_commit_id, start_commit_id)
-      self.assertEqual(0, len(head_to_base_messages))
+        test_dir = os.path.join(test_parent, TEST_REPO_NAME)
+        repository = GitRepositorySpec(
+            TEST_REPO_NAME, git_dir=test_dir, origin=self.git_dir
+        )
+        git.clone_repository_to_path(repository)
+        self.assertTrue(os.path.exists(os.path.join(test_dir, "base_file")))
 
-  def test_clone_upstream(self):
-    git = self.git
-    test_parent = os.path.join(self.base_temp_dir, 'test_clone_upstream')
-    os.makedirs(test_parent)
+        want_tags = git.query_tag_commits(self.git_dir, TAG_VERSION_PATTERN)
+        have_tags = git.query_tag_commits(test_dir, TAG_VERSION_PATTERN)
+        self.assertEqual(want_tags, have_tags)
 
-    test_dir = os.path.join(test_parent, TEST_REPO_NAME)
-    repository = GitRepositorySpec(
-        TEST_REPO_NAME, git_dir=test_dir, origin=self.git_dir)
-    git.clone_repository_to_path(repository)
-    self.assertTrue(os.path.exists(os.path.join(test_dir, 'base_file')))
+        got = check_subprocess('git -C "{dir}" remote -v'.format(dir=test_dir))
+        # Disable pushes to the origni
+        # No upstream since origin is upstream
+        self.assertEqual(
+            "\n".join(
+                [
+                    "origin\t{origin} (fetch)".format(origin=self.git_dir),
+                    "origin\tdisabled (push)",
+                ]
+            ),
+            got,
+        )
 
-    want_tags = git.query_tag_commits(self.git_dir, TAG_VERSION_PATTERN)
-    have_tags = git.query_tag_commits(test_dir, TAG_VERSION_PATTERN)
-    self.assertEqual(want_tags, have_tags)
+        reference = git.determine_git_repository_spec(test_dir)
+        expect = GitRepositorySpec(
+            os.path.basename(self.git_dir), origin=self.git_dir, git_dir=test_dir
+        )
+        self.assertEqual(expect, reference)
 
-    got = check_subprocess('git -C "{dir}" remote -v'.format(dir=test_dir))
-    # Disable pushes to the origni
-    # No upstream since origin is upstream
-    self.assertEqual(
-        '\n'.join([
-            'origin\t{origin} (fetch)'.format(origin=self.git_dir),
-            'origin\tdisabled (push)']),
-        got)
+    def test_clone_origin(self):
+        git = self.git
 
-    reference = git.determine_git_repository_spec(test_dir)
-    expect = GitRepositorySpec(os.path.basename(self.git_dir),
-                               origin=self.git_dir, git_dir=test_dir)
-    self.assertEqual(expect, reference)
+        # Make the origin we're going to test the clone against
+        # This is intentionally different from upstream so that
+        # we can confirm that upstream is also setup properly.
+        origin_user = "origin_user"
+        origin_basedir = os.path.join(self.base_temp_dir, origin_user)
+        os.makedirs(origin_basedir)
+        check_subprocess(
+            'git -C "{origin_dir}" clone "{upstream}"'.format(
+                origin_dir=origin_basedir, upstream=self.git_dir
+            )
+        )
 
-  def test_clone_origin(self):
-    git = self.git
+        test_parent = os.path.join(self.base_temp_dir, "test_clone_origin")
+        os.makedirs(test_parent)
 
-    # Make the origin we're going to test the clone against
-    # This is intentionally different from upstream so that
-    # we can confirm that upstream is also setup properly.
-    origin_user = 'origin_user'
-    origin_basedir = os.path.join(self.base_temp_dir, origin_user)
-    os.makedirs(origin_basedir)
-    check_subprocess(
-        'git -C "{origin_dir}" clone "{upstream}"'.format(
-            origin_dir=origin_basedir, upstream=self.git_dir))
+        test_dir = os.path.join(test_parent, TEST_REPO_NAME)
+        origin_dir = os.path.join(origin_basedir, TEST_REPO_NAME)
+        repository = GitRepositorySpec(
+            TEST_REPO_NAME, git_dir=test_dir, origin=origin_dir, upstream=self.git_dir
+        )
+        self.git.clone_repository_to_path(repository)
 
-    test_parent = os.path.join(self.base_temp_dir, 'test_clone_origin')
-    os.makedirs(test_parent)
+        want_tags = git.query_tag_commits(self.git_dir, TAG_VERSION_PATTERN)
+        have_tags = git.query_tag_commits(test_dir, TAG_VERSION_PATTERN)
+        self.assertEqual(want_tags, have_tags)
 
-    test_dir = os.path.join(test_parent, TEST_REPO_NAME)
-    origin_dir = os.path.join(origin_basedir, TEST_REPO_NAME)
-    repository = GitRepositorySpec(
-        TEST_REPO_NAME,
-        git_dir=test_dir, origin=origin_dir, upstream=self.git_dir)
-    self.git.clone_repository_to_path(repository)
+        got = check_subprocess('git -C "{dir}" remote -v'.format(dir=test_dir))
 
-    want_tags = git.query_tag_commits(self.git_dir, TAG_VERSION_PATTERN)
-    have_tags = git.query_tag_commits(test_dir, TAG_VERSION_PATTERN)
-    self.assertEqual(want_tags, have_tags)
+        # Upstream repo is configured for pulls, but not for pushes.
+        self.assertEqual(
+            "\n".join(
+                [
+                    "origin\t{origin} (fetch)".format(origin=origin_dir),
+                    "origin\t{origin} (push)".format(origin=origin_dir),
+                    "upstream\t{upstream} (fetch)".format(upstream=self.git_dir),
+                    "upstream\tdisabled (push)",
+                ]
+            ),
+            got,
+        )
 
-    got = check_subprocess('git -C "{dir}" remote -v'.format(dir=test_dir))
+        reference = git.determine_git_repository_spec(test_dir)
+        expect = GitRepositorySpec(
+            os.path.basename(origin_dir),
+            upstream=self.git_dir,
+            origin=origin_dir,
+            git_dir=test_dir,
+        )
+        self.assertEqual(expect, reference)
 
-    # Upstream repo is configured for pulls, but not for pushes.
-    self.assertEqual(
-        '\n'.join([
-            'origin\t{origin} (fetch)'.format(origin=origin_dir),
-            'origin\t{origin} (push)'.format(origin=origin_dir),
-            'upstream\t{upstream} (fetch)'.format(upstream=self.git_dir),
-            'upstream\tdisabled (push)'
-            ]),
-        got)
+    def test_clone_branch(self):
+        test_parent = os.path.join(self.base_temp_dir, "test_clone_branch")
+        os.makedirs(test_parent)
 
-    reference = git.determine_git_repository_spec(test_dir)
-    expect = GitRepositorySpec(
-        os.path.basename(origin_dir),
-        upstream=self.git_dir, origin=origin_dir, git_dir=test_dir)
-    self.assertEqual(expect, reference)
+        test_dir = os.path.join(test_parent, TEST_REPO_NAME)
+        repository = GitRepositorySpec(
+            TEST_REPO_NAME, git_dir=test_dir, origin=self.git_dir
+        )
+        self.git.clone_repository_to_path(repository, branch=BRANCH_A)
+        self.assertEqual(BRANCH_A, self.git.query_local_repository_branch(test_dir))
 
-  def test_clone_branch(self):
-    test_parent = os.path.join(self.base_temp_dir, 'test_clone_branch')
-    os.makedirs(test_parent)
+    def test_branch_not_found_exception(self):
+        test_parent = os.path.join(self.base_temp_dir, "test_bad_branch")
+        os.makedirs(test_parent)
+        test_dir = os.path.join(test_parent, TEST_REPO_NAME)
+        self.assertFalse(os.path.exists(test_dir))
 
-    test_dir = os.path.join(test_parent, TEST_REPO_NAME)
-    repository = GitRepositorySpec(
-        TEST_REPO_NAME, git_dir=test_dir, origin=self.git_dir)
-    self.git.clone_repository_to_path(repository, branch=BRANCH_A)
-    self.assertEqual(BRANCH_A,
-                     self.git.query_local_repository_branch(test_dir))
+        repository = GitRepositorySpec(
+            TEST_REPO_NAME, git_dir=test_dir, origin=self.git_dir
+        )
 
-  def test_branch_not_found_exception(self):
-    test_parent = os.path.join(self.base_temp_dir, 'test_bad_branch')
-    os.makedirs(test_parent)
-    test_dir = os.path.join(test_parent, TEST_REPO_NAME)
-    self.assertFalse(os.path.exists(test_dir))
+        branch = "Bogus"
+        regexp = r"Branches \['{branch}'\] do not exist in {url}\.".format(
+            branch=branch, url=self.git_dir
+        )
+        with self.assertRaisesRegexp(Exception, regexp):
+            self.git.clone_repository_to_path(repository, branch=branch)
+        self.assertFalse(os.path.exists(test_dir))
 
-    repository = GitRepositorySpec(
-        TEST_REPO_NAME, git_dir=test_dir, origin=self.git_dir)
+    def test_clone_failure(self):
+        test_dir = os.path.join(self.base_temp_dir, "clone_failure", TEST_REPO_NAME)
+        os.makedirs(test_dir)
+        with open(os.path.join(test_dir, "something"), "w") as f:
+            f.write("not empty")
 
-    branch = 'Bogus'
-    regexp = r"Branches \['{branch}'\] do not exist in {url}\.".format(
-        branch=branch, url=self.git_dir)
-    with self.assertRaisesRegexp(Exception, regexp):
-      self.git.clone_repository_to_path(repository, branch=branch)
-    self.assertFalse(os.path.exists(test_dir))
+        repository = GitRepositorySpec(
+            TEST_REPO_NAME, git_dir=test_dir, origin=self.git_dir
+        )
+        regexp = ".* clone .*"
+        with self.assertRaisesRegexp(Exception, regexp):
+            self.git.clone_repository_to_path(repository, branch="master")
 
-  def test_clone_failure(self):
-    test_dir = os.path.join(
-        self.base_temp_dir, 'clone_failure', TEST_REPO_NAME)
-    os.makedirs(test_dir)
-    with open(os.path.join(test_dir, 'something'), 'w') as f:
-      f.write('not empty')
+    def test_default_branch(self):
+        test_parent = os.path.join(self.base_temp_dir, "test_default_branch")
+        os.makedirs(test_parent)
+        test_dir = os.path.join(test_parent, TEST_REPO_NAME)
 
-    repository = GitRepositorySpec(
-        TEST_REPO_NAME, git_dir=test_dir, origin=self.git_dir)
-    regexp = '.* clone .*'
-    with self.assertRaisesRegexp(Exception, regexp):
-      self.git.clone_repository_to_path(repository, branch='master')
+        repository = GitRepositorySpec(
+            TEST_REPO_NAME, git_dir=test_dir, origin=self.git_dir
+        )
+        self.git.clone_repository_to_path(
+            repository, branch="Bogus", default_branch=BRANCH_B
+        )
+        self.assertEqual(BRANCH_B, self.git.query_local_repository_branch(test_dir))
 
-  def test_default_branch(self):
-    test_parent = os.path.join(self.base_temp_dir, 'test_default_branch')
-    os.makedirs(test_parent)
-    test_dir = os.path.join(test_parent, TEST_REPO_NAME)
+    def test_commit_at_tag(self):
+        self.run_git("checkout " + VERSION_A)
+        want = self.git.query_local_repository_commit_id(self.git_dir)
+        self.run_git("checkout master")
+        self.assertEqual(want, self.git.query_commit_at_tag(self.git_dir, VERSION_A))
+        self.assertIsNone(self.git.query_commit_at_tag(self.git_dir, "BogusTag"))
 
-    repository = GitRepositorySpec(
-        TEST_REPO_NAME, git_dir=test_dir, origin=self.git_dir)
-    self.git.clone_repository_to_path(
-        repository, branch='Bogus', default_branch=BRANCH_B)
-    self.assertEqual(BRANCH_B,
-                     self.git.query_local_repository_branch(test_dir))
-
-  def test_commit_at_tag(self):
-    self.run_git('checkout ' + VERSION_A)
-    want = self.git.query_local_repository_commit_id(self.git_dir)
-    self.run_git('checkout master')
-    self.assertEqual(
-        want, self.git.query_commit_at_tag(self.git_dir, VERSION_A))
-    self.assertIsNone(
-        self.git.query_commit_at_tag(self.git_dir, 'BogusTag'))
-
-  def test_summarize(self):
-    # All the tags in this fixture are where the head is tagged, so
-    # these are not that interesting. This is tested again in the
-    # CommitMessage fixture for more interesting cases.
-    tests = [(BRANCH_BASE, VERSION_BASE),
-             (BRANCH_A, VERSION_A)]
-    for branch, tag in tests:
-      self.run_git('checkout ' + branch)
-      summary = self.git.collect_repository_summary(self.git_dir)
-      self.assertEqual(self.git.query_local_repository_commit_id(self.git_dir),
-                       summary.commit_id)
-      self.assertEqual(tag, summary.tag)
-      self.assertEqual(tag.split('v')[1], summary.version)
-      self.assertEqual([], summary.commit_messages)
+    def test_summarize(self):
+        # All the tags in this fixture are where the head is tagged, so
+        # these are not that interesting. This is tested again in the
+        # CommitMessage fixture for more interesting cases.
+        tests = [(BRANCH_BASE, VERSION_BASE), (BRANCH_A, VERSION_A)]
+        for branch, tag in tests:
+            self.run_git("checkout " + branch)
+            summary = self.git.collect_repository_summary(self.git_dir)
+            self.assertEqual(
+                self.git.query_local_repository_commit_id(self.git_dir),
+                summary.commit_id,
+            )
+            self.assertEqual(tag, summary.tag)
+            self.assertEqual(tag.split("v")[1], summary.version)
+            self.assertEqual([], summary.commit_messages)
 
 
 class TestSemanticVersion(unittest.TestCase):
-  def test_semver_make_valid(self):
-    tests = [('v1.0.0', SemanticVersion('v', 1, 0, 0)),
-             ('v10.11.12', SemanticVersion('v', 10, 11, 12))]
-    for tag, expect in tests:
-      semver = SemanticVersion.make(tag)
-      self.assertEqual(semver, expect)
-      self.assertEqual(tag, semver.to_tag())
-      self.assertEqual(tag[tag.rfind('v') + 1:], semver.to_version())
+    def test_semver_make_valid(self):
+        tests = [
+            ("v1.0.0", SemanticVersion("v", 1, 0, 0)),
+            ("v10.11.12", SemanticVersion("v", 10, 11, 12)),
+        ]
+        for tag, expect in tests:
+            semver = SemanticVersion.make(tag)
+            self.assertEqual(semver, expect)
+            self.assertEqual(tag, semver.to_tag())
+            self.assertEqual(tag[tag.rfind("v") + 1 :], semver.to_version())
 
-  def test_semver_next(self):
-    semver = SemanticVersion('A', 1, 2, 3)
-    tests = [
-        (SemanticVersion.TAG_INDEX, SemanticVersion('B', 1, 2, 3), None),
-        (None, SemanticVersion('A', 1, 2, 3), None),
+    def test_semver_next(self):
+        semver = SemanticVersion("A", 1, 2, 3)
+        tests = [
+            (SemanticVersion.TAG_INDEX, SemanticVersion("B", 1, 2, 3), None),
+            (None, SemanticVersion("A", 1, 2, 3), None),
+            (
+                SemanticVersion.MAJOR_INDEX,
+                SemanticVersion("A", 2, 2, 3),
+                SemanticVersion("A", 2, 0, 0),
+            ),  # next major index to semver
+            (
+                SemanticVersion.MINOR_INDEX,
+                SemanticVersion("A", 1, 3, 3),
+                SemanticVersion("A", 1, 3, 0),
+            ),  # next minor index to semver
+            (
+                SemanticVersion.PATCH_INDEX,
+                SemanticVersion("A", 1, 2, 4),
+                SemanticVersion("A", 1, 2, 4),
+            ),  # next patch index to semver
+        ]
+        for expect_index, test, next_semver in tests:
+            self.assertEqual(expect_index, semver.most_significant_diff_index(test))
+            self.assertEqual(expect_index, test.most_significant_diff_index(semver))
+            if expect_index is not None and expect_index > SemanticVersion.TAG_INDEX:
+                self.assertEqual(next_semver, semver.next(expect_index))
 
-        (SemanticVersion.MAJOR_INDEX,
-         SemanticVersion('A', 2, 2, 3),
-         SemanticVersion('A', 2, 0, 0)),  # next major index to semver
+    def test_semver_sort(self):
+        versions = [
+            SemanticVersion.make("v1.9.7"),
+            SemanticVersion.make("v9.8.7"),
+            SemanticVersion.make("v11.0.0"),
+            SemanticVersion.make("v3.10.2"),
+            SemanticVersion.make("v3.0.4"),
+            SemanticVersion.make("v3.2.2"),
+            SemanticVersion.make("v3.2.0"),
+            SemanticVersion.make("v3.2.1"),
+        ]
 
-        (SemanticVersion.MINOR_INDEX,
-         SemanticVersion('A', 1, 3, 3),
-         SemanticVersion('A', 1, 3, 0)),  # next minor index to semver
-
-        (SemanticVersion.PATCH_INDEX,
-         SemanticVersion('A', 1, 2, 4),
-         SemanticVersion('A', 1, 2, 4)),  # next patch index to semver
-    ]
-    for expect_index, test, next_semver in tests:
-      self.assertEqual(expect_index, semver.most_significant_diff_index(test))
-      self.assertEqual(expect_index, test.most_significant_diff_index(semver))
-      if expect_index is not None and expect_index > SemanticVersion.TAG_INDEX:
-        self.assertEqual(next_semver, semver.next(expect_index))
-
-  def test_semver_sort(self):
-    versions = [
-        SemanticVersion.make('v1.9.7'),
-        SemanticVersion.make('v9.8.7'),
-        SemanticVersion.make('v11.0.0'),
-        SemanticVersion.make('v3.10.2'),
-        SemanticVersion.make('v3.0.4'),
-        SemanticVersion.make('v3.2.2'),
-        SemanticVersion.make('v3.2.0'),
-        SemanticVersion.make('v3.2.1'),
-    ]
-
-    got = sorted(versions)
-    expect = [
-        SemanticVersion.make('v1.9.7'),
-        SemanticVersion.make('v3.0.4'),
-        SemanticVersion.make('v3.2.0'),
-        SemanticVersion.make('v3.2.1'),
-        SemanticVersion.make('v3.2.2'),
-        SemanticVersion.make('v3.10.2'),
-        SemanticVersion.make('v9.8.7'),
-        SemanticVersion.make('v11.0.0'),
-    ]
-    self.assertEqual(expect, got)
+        got = sorted(versions)
+        expect = [
+            SemanticVersion.make("v1.9.7"),
+            SemanticVersion.make("v3.0.4"),
+            SemanticVersion.make("v3.2.0"),
+            SemanticVersion.make("v3.2.1"),
+            SemanticVersion.make("v3.2.2"),
+            SemanticVersion.make("v3.10.2"),
+            SemanticVersion.make("v9.8.7"),
+            SemanticVersion.make("v11.0.0"),
+        ]
+        self.assertEqual(expect, got)
 
 
 class TestCommitMessage(unittest.TestCase):
-  PATCH_BRANCH = 'patch_branch'
-  MINOR_BRANCH = 'minor_branch'
-  MAJOR_BRANCH = 'major_branch'
-  MERGED_BRANCH = 'merged_branch'
+    PATCH_BRANCH = "patch_branch"
+    MINOR_BRANCH = "minor_branch"
+    MAJOR_BRANCH = "major_branch"
+    MERGED_BRANCH = "merged_branch"
 
-  PATCH_MINOR_BRANCH = 'patch_minor_branch'
-  PATCH_MINOR_X = 'marker_for_minor_x'
+    PATCH_MINOR_BRANCH = "patch_minor_branch"
+    PATCH_MINOR_X = "marker_for_minor_x"
 
-  @classmethod
-  def run_git(cls, command):
-    return check_subprocess(
-        'git -C "{dir}" {command}'.format(dir=cls.git_dir, command=command))
+    @classmethod
+    def run_git(cls, command):
+        return check_subprocess(
+            'git -C "{dir}" {command}'.format(dir=cls.git_dir, command=command)
+        )
 
-  @classmethod
-  def setUpClass(cls):
-    cls.git = GitRunner(make_default_options())
-    cls.base_temp_dir = tempfile.mkdtemp(prefix='git_test')
-    cls.git_dir = os.path.join(cls.base_temp_dir, 'commit_message_test')
-    os.makedirs(cls.git_dir)
+    @classmethod
+    def setUpClass(cls):
+        cls.git = GitRunner(make_default_options())
+        cls.base_temp_dir = tempfile.mkdtemp(prefix="git_test")
+        cls.git_dir = os.path.join(cls.base_temp_dir, "commit_message_test")
+        os.makedirs(cls.git_dir)
 
-    git_dir = cls.git_dir
-    gitify = lambda args: 'git -C "{dir}" {args}'.format(dir=git_dir, args=args)
-    check_subprocess_sequence([
-        gitify('init'),
-        'touch "{dir}/base_file"'.format(dir=git_dir),
-        gitify('add "{dir}/base_file"'.format(dir=git_dir)),
-        gitify('commit -a -m "feat(test): added file"'),
-        gitify('tag {base_version} HEAD'.format(base_version=VERSION_BASE)),
+        git_dir = cls.git_dir
+        gitify = lambda args: 'git -C "{dir}" {args}'.format(dir=git_dir, args=args)
+        check_subprocess_sequence(
+            [
+                gitify("init"),
+                'touch "{dir}/base_file"'.format(dir=git_dir),
+                gitify('add "{dir}/base_file"'.format(dir=git_dir)),
+                gitify('commit -a -m "feat(test): added file"'),
+                gitify("tag {base_version} HEAD".format(base_version=VERSION_BASE)),
+                # For testing patches
+                gitify(
+                    "checkout -b {patch_branch}".format(patch_branch=cls.PATCH_BRANCH)
+                ),
+                'touch "{dir}/patch_file"'.format(dir=git_dir),
+                gitify('add "{dir}/patch_file"'.format(dir=git_dir)),
+                gitify('commit -a -m "fix(testA): added patch_file"'),
+                # For testing minor versions
+                gitify(
+                    "checkout -b {minor_branch}".format(minor_branch=cls.MINOR_BRANCH)
+                ),
+                'touch "{dir}/minor_file"'.format(dir=git_dir),
+                gitify('add "{dir}/minor_file"'.format(dir=git_dir)),
+                gitify('commit -a -m "feat(testB): added minor_file"'),
+                # For testing major versions
+                gitify(
+                    "checkout -b {major_branch}".format(major_branch=cls.MAJOR_BRANCH)
+                ),
+                'touch "{dir}/major_file"'.format(dir=git_dir),
+                gitify('add "{dir}/major_file"'.format(dir=git_dir)),
+                gitify(
+                    "commit -a -m"
+                    ' "feat(testC): added major_file\n'
+                    "\nInterestingly enough, this is a BREAKING CHANGE."
+                    '"'
+                ),
+                # For testing composite commits from a merge of commits
+                gitify(
+                    "checkout -b {merged_branch}".format(
+                        merged_branch=cls.MERGED_BRANCH
+                    )
+                ),
+                gitify("reset --hard HEAD~3"),
+                gitify("merge --squash HEAD@{1}"),
+            ]
+        )
 
-        # For testing patches
-        gitify('checkout -b {patch_branch}'.format(
-            patch_branch=cls.PATCH_BRANCH)),
-        'touch "{dir}/patch_file"'.format(dir=git_dir),
-        gitify('add "{dir}/patch_file"'.format(dir=git_dir)),
-        gitify('commit -a -m "fix(testA): added patch_file"'),
+        env = dict(os.environ)
+        if os.path.exists("/bin/true"):
+            env["EDITOR"] = "/bin/true"
+        elif os.path.exists("/usr/bin/true"):
+            env["EDITOR"] = "/usr/bin/true"
+        else:
+            raise NotImplementedError("platform not supported for this test")
+        check_subprocess('git -C "{dir}" commit'.format(dir=git_dir), env=env)
 
-        # For testing minor versions
-        gitify('checkout -b {minor_branch}'.format(
-            minor_branch=cls.MINOR_BRANCH)),
-        'touch "{dir}/minor_file"'.format(dir=git_dir),
-        gitify('add "{dir}/minor_file"'.format(dir=git_dir)),
-        gitify('commit -a -m "feat(testB): added minor_file"'),
+        # For testing changelog from a commit
+        check_subprocess_sequence(
+            [
+                gitify("checkout {minor_branch}".format(minor_branch=cls.MINOR_BRANCH)),
+                gitify(
+                    "checkout -b {x_branch}".format(x_branch=cls.PATCH_MINOR_BRANCH)
+                ),
+                'touch "{dir}/xbefore_file"'.format(dir=git_dir),
+                gitify('add "{dir}/xbefore_file"'.format(dir=git_dir)),
+                gitify('commit -a -m "feat(test): COMMIT AT TAG"'),
+                gitify("tag {x_marker} HEAD".format(x_marker=cls.PATCH_MINOR_X)),
+                'touch "{dir}/x_first"'.format(dir=git_dir),
+                gitify('add "{dir}/x_first"'.format(dir=git_dir)),
+                gitify('commit -a -m "fix(test): First Fix"'),
+                'rm "{dir}/x_first"'.format(dir=git_dir),
+                gitify('commit -a -m "fix(test): Second Fix"'),
+            ]
+        )
 
-        # For testing major versions
-        gitify('checkout -b {major_branch}'.format(
-            major_branch=cls.MAJOR_BRANCH)),
-        'touch "{dir}/major_file"'.format(dir=git_dir),
-        gitify('add "{dir}/major_file"'.format(dir=git_dir)),
-        gitify('commit -a -m'
-               ' "feat(testC): added major_file\n'
-               '\nInterestingly enough, this is a BREAKING CHANGE.'
-               '"'),
+    def test_summarize(self):
+        # patch, minor, major branches haven't been tagged so all should return
+        # last tag 'v0.1.0' regardless of additional commits since this tag.
+        all_tests = [
+            (self.PATCH_BRANCH, "0.1.0"),
+            (self.MINOR_BRANCH, "0.1.0"),
+            (self.MAJOR_BRANCH, "0.1.0"),
+        ]
+        for _, spec in enumerate(all_tests):
+            branch, version = spec
+            # CommitMessage fixture for more interesting cases.
+            self.run_git("checkout " + branch)
+            summary = self.git.collect_repository_summary(self.git_dir)
+            self.assertEqual("v" + version, summary.tag)
+            self.assertEqual(version, summary.version)
+            clean_messages = [
+                "\n".join([line.strip() for line in lines])
+                for lines in [m.message.split("\n") for m in summary.commit_messages]
+            ]
+            # because there has been no tag there are also no messages.
+            self.assertEqual([], clean_messages)
 
-        # For testing composite commits from a merge of commits
-        gitify('checkout -b {merged_branch}'.format(
-            merged_branch=cls.MERGED_BRANCH)),
-        gitify('reset --hard HEAD~3'),
-        gitify('merge --squash HEAD@{1}'),
-    ])
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.base_temp_dir)
 
-    env = dict(os.environ)
-    if os.path.exists('/bin/true'):
-      env['EDITOR'] = '/bin/true'
-    elif os.path.exists('/usr/bin/true'):
-      env['EDITOR'] = '/usr/bin/true'
-    else:
-      raise NotImplementedError('platform not supported for this test')
-    check_subprocess('git -C "{dir}" commit'.format(dir=git_dir), env=env)
+    def setUp(self):
+        self.run_git("checkout master".format(dir=self.git_dir))
 
-    # For testing changelog from a commit
-    check_subprocess_sequence([
-        gitify('checkout {minor_branch}'.format(
-            minor_branch=cls.MINOR_BRANCH)),
-        gitify('checkout -b {x_branch}'.format(
-            x_branch=cls.PATCH_MINOR_BRANCH)),
-        'touch "{dir}/xbefore_file"'.format(dir=git_dir),
-        gitify('add "{dir}/xbefore_file"'.format(dir=git_dir)),
-        gitify('commit -a -m "feat(test): COMMIT AT TAG"'),
-        gitify('tag {x_marker} HEAD'.format(x_marker=cls.PATCH_MINOR_X)),
-        'touch "{dir}/x_first"'.format(dir=git_dir),
-        gitify('add "{dir}/x_first"'.format(dir=git_dir)),
-        gitify('commit -a -m "fix(test): First Fix"'),
-        'rm "{dir}/x_first"'.format(dir=git_dir),
-        gitify('commit -a -m "fix(test): Second Fix"'),
-    ])
+    def test_message_analysis_with_commit_baseline(self):
+        # pylint: disable=line-too-long
+        git = self.git
 
-  def test_summarize(self):
-    # patch, minor, major branches haven't been tagged so all should return
-    # last tag 'v0.1.0' regardless of additional commits since this tag.
-    all_tests = [(self.PATCH_BRANCH, '0.1.0'),
-                 (self.MINOR_BRANCH, '0.1.0'),
-                 (self.MAJOR_BRANCH, '0.1.0')]
-    for _, spec in enumerate(all_tests):
-      branch, version = spec
-      # CommitMessage fixture for more interesting cases.
-      self.run_git('checkout ' + branch)
-      summary = self.git.collect_repository_summary(self.git_dir)
-      self.assertEqual('v' + version, summary.tag)
-      self.assertEqual(version, summary.version)
-      clean_messages = ['\n'.join([line.strip() for line in lines])
-                        for lines in [m.message.split('\n')
-                                      for m in summary.commit_messages]]
-      # because there has been no tag there are also no messages.
-      self.assertEqual([], clean_messages)
-
-
-  @classmethod
-  def tearDownClass(cls):
-    shutil.rmtree(cls.base_temp_dir)
-
-  def setUp(self):
-    self.run_git('checkout master'.format(dir=self.git_dir))
-
-  def test_message_analysis_with_commit_baseline(self):
-    # pylint: disable=line-too-long
-    git = self.git
-
-    tests = [(self.PATCH_MINOR_BRANCH, self.PATCH_MINOR_X)]
-    for branch, baseline_commit in tests:
-      self.run_git('checkout {branch}'.format(branch=branch))
-      commit_id = git.query_local_repository_commit_id(self.git_dir)
-      messages = git.query_local_repository_commits_between_two_commit_ids(
-          self.git_dir, baseline_commit, commit_id)
-      self.assertEqual(2, len(messages))
-      self.assertEqual('fix(test): Second Fix', messages[0].message.strip())
-      self.assertEqual('fix(test): First Fix', messages[1].message.strip())
+        tests = [(self.PATCH_MINOR_BRANCH, self.PATCH_MINOR_X)]
+        for branch, baseline_commit in tests:
+            self.run_git("checkout {branch}".format(branch=branch))
+            commit_id = git.query_local_repository_commit_id(self.git_dir)
+            messages = git.query_local_repository_commits_between_two_commit_ids(
+                self.git_dir, baseline_commit, commit_id
+            )
+            self.assertEqual(2, len(messages))
+            self.assertEqual("fix(test): Second Fix", messages[0].message.strip())
+            self.assertEqual("fix(test): First Fix", messages[1].message.strip())
 
 
 class TestRepositorySummary(unittest.TestCase):
-  def test_to_yaml(self):
-    summary = RepositorySummary(
-        'abcd1234', 'mytag-987', '0.0.1',
-        [CommitMessage('commit-abc', 'author', 'date', 'commit message')])
+    def test_to_yaml(self):
+        summary = RepositorySummary(
+            "abcd1234",
+            "mytag-987",
+            "0.0.1",
+            [CommitMessage("commit-abc", "author", "date", "commit message")],
+        )
 
-    expect = """commit_id: {id}
+        expect = """commit_id: {id}
 tag: {tag}
 version: {version}
-""".format(id=summary.commit_id, tag=summary.tag, version=summary.version)
-    self.assertEqual(expect, summary.to_yaml(with_commit_messages=False))
+""".format(
+            id=summary.commit_id, tag=summary.tag, version=summary.version
+        )
+        self.assertEqual(expect, summary.to_yaml(with_commit_messages=False))
 
-  def test_yamilfy(self):
-    # The summary values are arbitrary. Just verifying we can go in and out
-    # of yaml.
-    summary = RepositorySummary(
-        'abcd', 'tag-123', '1.2.0',
-        [
-            CommitMessage('commitB', 'authorB', 'dateB', 'messageB'),
-            CommitMessage('commitA', 'authorA', 'dateA', 'messageA')
-        ])
-    yamlized = yaml.safe_load(summary.to_yaml())
-    self.assertEqual(summary.commit_id, yamlized['commit_id'])
-    self.assertEqual(summary.tag, yamlized['tag'])
-    self.assertEqual(summary.version, yamlized['version'])
-    self.assertEqual(
-        [{
-            'commit_id': 'commit' + x,
-            'author': 'author' + x,
-            'date': 'date' + x,
-            'message': 'message' + x}
-         for x in ['B', 'A']],
-        yamlized['commit_messages'])
-    self.assertEqual(summary, RepositorySummary.from_dict(yamlized))
+    def test_yamilfy(self):
+        # The summary values are arbitrary. Just verifying we can go in and out
+        # of yaml.
+        summary = RepositorySummary(
+            "abcd",
+            "tag-123",
+            "1.2.0",
+            [
+                CommitMessage("commitB", "authorB", "dateB", "messageB"),
+                CommitMessage("commitA", "authorA", "dateA", "messageA"),
+            ],
+        )
+        yamlized = yaml.safe_load(summary.to_yaml())
+        self.assertEqual(summary.commit_id, yamlized["commit_id"])
+        self.assertEqual(summary.tag, yamlized["tag"])
+        self.assertEqual(summary.version, yamlized["version"])
+        self.assertEqual(
+            [
+                {
+                    "commit_id": "commit" + x,
+                    "author": "author" + x,
+                    "date": "date" + x,
+                    "message": "message" + x,
+                }
+                for x in ["B", "A"]
+            ],
+            yamlized["commit_messages"],
+        )
+        self.assertEqual(summary, RepositorySummary.from_dict(yamlized))
 
 
-if __name__ == '__main__':
-  init_runtime()
-  unittest.main(verbosity=2)
+if __name__ == "__main__":
+    init_runtime()
+    unittest.main(verbosity=2)

--- a/unittest/buildtool/gradle_support_test.py
+++ b/unittest/buildtool/gradle_support_test.py
@@ -17,18 +17,17 @@
 import textwrap
 import unittest
 
-from buildtool import (
-    GitRepositorySpec,
-    MetricsManager)
+from buildtool import GitRepositorySpec, MetricsManager
 
 from buildtool.gradle_support import GradleMetricsUpdater
 
 from test_util import init_runtime
 
 
-REPOSITORY = GitRepositorySpec('testRepo')
+REPOSITORY = GitRepositorySpec("testRepo")
 
-BINTRAY_ERROR_OUTPUT = textwrap.dedent("""\
+BINTRAY_ERROR_OUTPUT = textwrap.dedent(
+    """\
      :echo-web:publishBuildDeb
      
      FAILURE: Build completed with 9 failures.
@@ -41,42 +40,49 @@ BINTRAY_ERROR_OUTPUT = textwrap.dedent("""\
      
      * Try:
      Run with --info or --debug option to get more log output.
-""")
+"""
+)
 
 
 class TestGradleMetricsUpdater(unittest.TestCase):
-  def setUp(self):
-    self.metrics = MetricsManager.singleton()
+    def setUp(self):
+        self.metrics = MetricsManager.singleton()
 
-  def test_ok(self):
-    updater = GradleMetricsUpdater(self.metrics, REPOSITORY, 'TestWhatThing')
-    counter = updater(0, BINTRAY_ERROR_OUTPUT)
-    self.assertEqual(1, counter.count)
-    self.assertEqual('GradleOutcome', counter.family.name)
-    self.assertEqual({
-        'repository': 'testRepo',
-        'context': 'TestWhatThing',
-        'success': True,
-        'failed_task': '',
-        'failed_by': '',
-        'failed_reason': ''
-    }, counter.labels)
+    def test_ok(self):
+        updater = GradleMetricsUpdater(self.metrics, REPOSITORY, "TestWhatThing")
+        counter = updater(0, BINTRAY_ERROR_OUTPUT)
+        self.assertEqual(1, counter.count)
+        self.assertEqual("GradleOutcome", counter.family.name)
+        self.assertEqual(
+            {
+                "repository": "testRepo",
+                "context": "TestWhatThing",
+                "success": True,
+                "failed_task": "",
+                "failed_by": "",
+                "failed_reason": "",
+            },
+            counter.labels,
+        )
 
-  def test_bintray_error(self):
-    updater = GradleMetricsUpdater(self.metrics, REPOSITORY, 'TestWhatThing')
-    counter = updater(-1, BINTRAY_ERROR_OUTPUT)
-    self.assertEqual(1, counter.count)
-    self.assertEqual('GradleOutcome', counter.family.name)
-    self.assertEqual({
-        'repository': 'testRepo',
-        'context': 'TestWhatThing',
-        'success': False,
-        'failed_task': ':echo-core:bintrayUpload',
-        'failed_by': 'bintray',
-        'failed_reason': '409'
-    }, counter.labels)
+    def test_bintray_error(self):
+        updater = GradleMetricsUpdater(self.metrics, REPOSITORY, "TestWhatThing")
+        counter = updater(-1, BINTRAY_ERROR_OUTPUT)
+        self.assertEqual(1, counter.count)
+        self.assertEqual("GradleOutcome", counter.family.name)
+        self.assertEqual(
+            {
+                "repository": "testRepo",
+                "context": "TestWhatThing",
+                "success": False,
+                "failed_task": ":echo-core:bintrayUpload",
+                "failed_by": "bintray",
+                "failed_reason": "409",
+            },
+            counter.labels,
+        )
 
 
-if __name__ == '__main__':
-  init_runtime()
-  unittest.main(verbosity=2)
+if __name__ == "__main__":
+    init_runtime()
+    unittest.main(verbosity=2)

--- a/unittest/buildtool/main_test.py
+++ b/unittest/buildtool/main_test.py
@@ -28,85 +28,96 @@ buildtool.__main__.CHECK_HOME_FOR_CONFIG = False
 COMMAND = custom_test_command.COMMAND
 
 CUSTOM_DEFAULTS = {
-    'input_dir': 'my/input/path',
-    'one_at_a_time': True,
-    'unused_argument': 'Some Value',
-    custom_test_command.CUSTOM_ARG_NAME: 'Overriden Value'
+    "input_dir": "my/input/path",
+    "one_at_a_time": True,
+    "unused_argument": "Some Value",
+    custom_test_command.CUSTOM_ARG_NAME: "Overriden Value",
 }
 
 OVERRIDE_CUSTOM_DEFAULTS = {
-    'default_args_file': 'TBD below in TesTMain.setUpClass()',
-    'input_dir': 'OverridenPath'
+    "default_args_file": "TBD below in TesTMain.setUpClass()",
+    "input_dir": "OverridenPath",
 }
 
 
 class TestMain(unittest.TestCase):
-  @classmethod
-  def setUpClass(cls):
-    # pylint: disable=invalid-name
-    fd, cls.defaults_file = tempfile.mkstemp(prefix='main_test_c')
-    os.write(fd, str.encode(yaml.safe_dump(CUSTOM_DEFAULTS)))
-    os.close(fd)
-    OVERRIDE_CUSTOM_DEFAULTS['default_args_file'] = cls.defaults_file
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=invalid-name
+        fd, cls.defaults_file = tempfile.mkstemp(prefix="main_test_c")
+        os.write(fd, str.encode(yaml.safe_dump(CUSTOM_DEFAULTS)))
+        os.close(fd)
+        OVERRIDE_CUSTOM_DEFAULTS["default_args_file"] = cls.defaults_file
 
-    fd, cls.override_defaults_file = tempfile.mkstemp(prefix='main_test_d')
-    os.write(fd, str.encode(yaml.safe_dump(OVERRIDE_CUSTOM_DEFAULTS)))
-    os.close(fd)
+        fd, cls.override_defaults_file = tempfile.mkstemp(prefix="main_test_d")
+        os.write(fd, str.encode(yaml.safe_dump(OVERRIDE_CUSTOM_DEFAULTS)))
+        os.close(fd)
 
+    @classmethod
+    def tearDownClass(cls):
+        os.remove(cls.defaults_file)
 
-  @classmethod
-  def tearDownClass(cls):
-    os.remove(cls.defaults_file)
+    def get_options(self, args, modules):
+        return buildtool.__main__.init_options_and_registry(args, modules)[0]
 
-  def get_options(self, args, modules):
-    return buildtool.__main__.init_options_and_registry(args, modules)[0]
+    def test_builtin_default_options(self):
+        modules = [custom_test_command]
+        args = [COMMAND]
+        options = self.get_options(args, modules)
+        self.assertEqual("source_code", options.input_dir)
+        self.assertFalse(options.one_at_a_time)
+        self.assertEqual(
+            custom_test_command.CUSTOM_ARG_DEFAULT_VALUE,
+            vars(options)[custom_test_command.CUSTOM_ARG_NAME],
+        )
 
-  def test_builtin_default_options(self):
-    modules = [custom_test_command]
-    args = [COMMAND]
-    options = self.get_options(args, modules)
-    self.assertEqual('source_code', options.input_dir)
-    self.assertFalse(options.one_at_a_time)
-    self.assertEqual(custom_test_command.CUSTOM_ARG_DEFAULT_VALUE,
-                     vars(options)[custom_test_command.CUSTOM_ARG_NAME])
+    def test_override_file_options(self):
+        modules = [custom_test_command]
+        args = ["--default_args_file", self.defaults_file, COMMAND]
+        options = self.get_options(args, modules)
+        self.assertEqual(CUSTOM_DEFAULTS["input_dir"], options.input_dir)
+        self.assertTrue(options.one_at_a_time)
+        self.assertEqual(
+            CUSTOM_DEFAULTS[custom_test_command.CUSTOM_ARG_NAME],
+            vars(options)[custom_test_command.CUSTOM_ARG_NAME],
+        )
 
-  def test_override_file_options(self):
-    modules = [custom_test_command]
-    args = ['--default_args_file', self.defaults_file, COMMAND]
-    options = self.get_options(args, modules)
-    self.assertEqual(CUSTOM_DEFAULTS['input_dir'], options.input_dir)
-    self.assertTrue(options.one_at_a_time)
-    self.assertEqual(CUSTOM_DEFAULTS[custom_test_command.CUSTOM_ARG_NAME],
-                     vars(options)[custom_test_command.CUSTOM_ARG_NAME])
+    def test_nested_override_file_options(self):
+        modules = [custom_test_command]
+        args = ["--default_args_file", self.override_defaults_file, COMMAND]
+        options = self.get_options(args, modules)
+        self.assertEqual(OVERRIDE_CUSTOM_DEFAULTS["input_dir"], options.input_dir)
+        self.assertTrue(options.one_at_a_time)
+        self.assertEqual(
+            CUSTOM_DEFAULTS[custom_test_command.CUSTOM_ARG_NAME],
+            vars(options)[custom_test_command.CUSTOM_ARG_NAME],
+        )
 
-  def test_nested_override_file_options(self):
-    modules = [custom_test_command]
-    args = ['--default_args_file', self.override_defaults_file, COMMAND]
-    options = self.get_options(args, modules)
-    self.assertEqual(
-        OVERRIDE_CUSTOM_DEFAULTS['input_dir'], options.input_dir)
-    self.assertTrue(options.one_at_a_time)
-    self.assertEqual(CUSTOM_DEFAULTS[custom_test_command.CUSTOM_ARG_NAME],
-                     vars(options)[custom_test_command.CUSTOM_ARG_NAME])
-
-  def test_cli_override_defaults_options(self):
-    modules = [custom_test_command]
-    override = 'Overriden Value'
-    args = ['--default_args_file', self.defaults_file,
-            '--input_dir', override,
+    def test_cli_override_defaults_options(self):
+        modules = [custom_test_command]
+        override = "Overriden Value"
+        args = [
+            "--default_args_file",
+            self.defaults_file,
+            "--input_dir",
+            override,
             COMMAND,
-            '--' + custom_test_command.CUSTOM_ARG_NAME,
-            'XYZ']
-    options = self.get_options(args, modules)
-    self.assertEqual(override, options.input_dir)
-    self.assertTrue(options.one_at_a_time)
-    self.assertEqual('XYZ', vars(options)[custom_test_command.CUSTOM_ARG_NAME])
+            "--" + custom_test_command.CUSTOM_ARG_NAME,
+            "XYZ",
+        ]
+        options = self.get_options(args, modules)
+        self.assertEqual(override, options.input_dir)
+        self.assertTrue(options.one_at_a_time)
+        self.assertEqual("XYZ", vars(options)[custom_test_command.CUSTOM_ARG_NAME])
 
-if __name__ == '__main__':
-  import logging
-  logging.basicConfig(
-      format='%(levelname).1s %(asctime)s.%(msecs)03d %(message)s',
-      datefmt='%H:%M:%S',
-      level=logging.DEBUG)
 
-  unittest.main(verbosity=2)
+if __name__ == "__main__":
+    import logging
+
+    logging.basicConfig(
+        format="%(levelname).1s %(asctime)s.%(msecs)03d %(message)s",
+        datefmt="%H:%M:%S",
+        level=logging.DEBUG,
+    )
+
+    unittest.main(verbosity=2)

--- a/unittest/buildtool/repository_command_test.py
+++ b/unittest/buildtool/repository_command_test.py
@@ -22,7 +22,8 @@ import unittest
 from buildtool import (
     RepositoryCommandProcessor,
     RepositoryCommandFactory,
-    BranchSourceCodeManager)
+    BranchSourceCodeManager,
+)
 
 import custom_test_command
 
@@ -31,221 +32,253 @@ from test_util import (
     ALL_STANDARD_TEST_BOM_REPO_NAMES,
     OUTLIER_REPO,
     BaseGitRepoTestFixture,
-    init_runtime)
+    init_runtime,
+)
 
 
 COMMAND = custom_test_command.COMMAND
-FAILURE_COMMAND_NAME = 'test_command_failure'
+FAILURE_COMMAND_NAME = "test_command_failure"
 
 
 class TestRepositoryCommand(RepositoryCommandProcessor):
-  def __init__(self, factory, options, pos_arg,
-               source_repository_names=None, **kwargs):
-    super(TestRepositoryCommand, self).__init__(
-        factory, options, source_repository_names=source_repository_names)
-    self.test_init_args = (factory, options, pos_arg, kwargs)
-    self.preprocessed = False
-    self.postprocess_dict = None
-    self.ensured = set([])
-    self.repositories = set([])
-    self.test_repo_threadid = []
+    def __init__(
+        self, factory, options, pos_arg, source_repository_names=None, **kwargs
+    ):
+        super(TestRepositoryCommand, self).__init__(
+            factory, options, source_repository_names=source_repository_names
+        )
+        self.test_init_args = (factory, options, pos_arg, kwargs)
+        self.preprocessed = False
+        self.postprocess_dict = None
+        self.ensured = set([])
+        self.repositories = set([])
+        self.test_repo_threadid = []
 
-  def ensure_local_repository(self, repository):
-    assert(self.preprocessed)
-    assert(not self.postprocess_dict)
-    assert(repository.name not in self.ensured)
-    assert(repository.name not in self.repositories)
-    self.ensured.add(repository.name)
+    def ensure_local_repository(self, repository):
+        assert self.preprocessed
+        assert not self.postprocess_dict
+        assert repository.name not in self.ensured
+        assert repository.name not in self.repositories
+        self.ensured.add(repository.name)
 
-  def _do_preprocess(self):
-    assert(not self.preprocessed)
-    self.preprocessed = True
+    def _do_preprocess(self):
+        assert not self.preprocessed
+        self.preprocessed = True
 
-  def _do_postprocess(self, result_dict):
-    assert(self.preprocessed)
-    assert(not self.postprocess_dict)
-    self.postprocess_dict = result_dict
-    return {'foo': 'bar'}
+    def _do_postprocess(self, result_dict):
+        assert self.preprocessed
+        assert not self.postprocess_dict
+        self.postprocess_dict = result_dict
+        return {"foo": "bar"}
 
-  def _do_repository(self, repository):
-    assert(self.preprocessed)
-    assert(not self.postprocess_dict)
-    assert(repository.name in self.ensured)
-    assert(repository.name not in self.repositories)
-    self.repositories.add(repository.name)
-    time.sleep(0.1)  # Encourage threads to be different
-    self.test_repo_threadid.append(threading.current_thread().ident)
-    if self.name == FAILURE_COMMAND_NAME:
-      logging.info('Raising injected error')
-      raise ValueError('Injected Failure')
-    return 'TEST {0}'.format(repository.name)
+    def _do_repository(self, repository):
+        assert self.preprocessed
+        assert not self.postprocess_dict
+        assert repository.name in self.ensured
+        assert repository.name not in self.repositories
+        self.repositories.add(repository.name)
+        time.sleep(0.1)  # Encourage threads to be different
+        self.test_repo_threadid.append(threading.current_thread().ident)
+        if self.name == FAILURE_COMMAND_NAME:
+            logging.info("Raising injected error")
+            raise ValueError("Injected Failure")
+        return "TEST {0}".format(repository.name)
 
 
 class RepositoryCommandProcessorTest(BaseGitRepoTestFixture):
-  def make_test_options(self):
-    options = super(RepositoryCommandProcessorTest, self).make_test_options()
-    options.git_branch = 'test_branch'
-    options.github_hostname = 'test-hostname'
-    options.github_owner = 'test_github_owner'
-    options.github_pull_ssh = False
-    options.one_at_a_time = False
-    options.only_repositories = None
-    options.exclude_repositories = None
-    options.github_upstream_owner = None
-    return options
+    def make_test_options(self):
+        options = super(RepositoryCommandProcessorTest, self).make_test_options()
+        options.git_branch = "test_branch"
+        options.github_hostname = "test-hostname"
+        options.github_owner = "test_github_owner"
+        options.github_pull_ssh = False
+        options.one_at_a_time = False
+        options.only_repositories = None
+        options.exclude_repositories = None
+        options.github_upstream_owner = None
+        return options
 
-  def test_filter(self):
-    factory = RepositoryCommandFactory(
-        'test_filter', TestRepositoryCommand, 'A test command.',
-        BranchSourceCodeManager, 123,
-        source_repository_names=ALL_STANDARD_TEST_BOM_REPO_NAMES)
-    options = self.options
+    def test_filter(self):
+        factory = RepositoryCommandFactory(
+            "test_filter",
+            TestRepositoryCommand,
+            "A test command.",
+            BranchSourceCodeManager,
+            123,
+            source_repository_names=ALL_STANDARD_TEST_BOM_REPO_NAMES,
+        )
+        options = self.options
 
-    expected_repo_names = list(ALL_STANDARD_TEST_BOM_REPO_NAMES)
-    command = factory.make_command(options)
-    self.assertEqual(
-      expected_repo_names,
-      [repository.name for repository in command.source_repositories])
+        expected_repo_names = list(ALL_STANDARD_TEST_BOM_REPO_NAMES)
+        command = factory.make_command(options)
+        self.assertEqual(
+            expected_repo_names,
+            [repository.name for repository in command.source_repositories],
+        )
 
-    expected_repo_names = [name for name in ALL_STANDARD_TEST_BOM_REPO_NAMES
-                           if name != OUTLIER_REPO]
-    options.exclude_repositories=OUTLIER_REPO
-    command = factory.make_command(options)
-    self.assertEqual(
-      expected_repo_names,
-      [repository.name for repository in command.source_repositories])
+        expected_repo_names = [
+            name for name in ALL_STANDARD_TEST_BOM_REPO_NAMES if name != OUTLIER_REPO
+        ]
+        options.exclude_repositories = OUTLIER_REPO
+        command = factory.make_command(options)
+        self.assertEqual(
+            expected_repo_names,
+            [repository.name for repository in command.source_repositories],
+        )
 
-    expected_repo_names = [OUTLIER_REPO]
-    options.only_repositories=OUTLIER_REPO
-    options.exclude_repositories=None
-    command = factory.make_command(options)
-    self.assertEqual(
-      expected_repo_names,
-      [repository.name for repository in command.source_repositories])
+        expected_repo_names = [OUTLIER_REPO]
+        options.only_repositories = OUTLIER_REPO
+        options.exclude_repositories = None
+        command = factory.make_command(options)
+        self.assertEqual(
+            expected_repo_names,
+            [repository.name for repository in command.source_repositories],
+        )
 
-  def do_test_command(self, options, command_name):
-    init_dict = {'a': 'A', 'b': 'B'}
-    factory = RepositoryCommandFactory(
-        command_name, TestRepositoryCommand, 'A test command.',
-        BranchSourceCodeManager, 123,
-        source_repository_names=ALL_STANDARD_TEST_BOM_REPO_NAMES,
-        **init_dict)
+    def do_test_command(self, options, command_name):
+        init_dict = {"a": "A", "b": "B"}
+        factory = RepositoryCommandFactory(
+            command_name,
+            TestRepositoryCommand,
+            "A test command.",
+            BranchSourceCodeManager,
+            123,
+            source_repository_names=ALL_STANDARD_TEST_BOM_REPO_NAMES,
+            **init_dict
+        )
 
-    # Test construction
-    command = factory.make_command(options)
-    self.assertEqual((factory, options, 123, init_dict),
-                     command.test_init_args)
-    self.assertFalse(command.preprocessed)
-    self.assertEqual(factory, command.factory)
-    self.assertEqual(factory.name, command.name)
-    key_func = lambda repo: repo.name
-    expect_list = [command.source_code_manager.make_repository_spec(name)
-                   for name in ALL_STANDARD_TEST_BOM_REPO_NAMES]
-    self.assertEqual(sorted(expect_list, key=key_func),
-                     sorted(command.source_repositories, key=key_func))
-    self.assertEqual(os.path.join(options.input_dir, options.command),
-                     command.source_code_manager.root_source_dir)
+        # Test construction
+        command = factory.make_command(options)
+        self.assertEqual((factory, options, 123, init_dict), command.test_init_args)
+        self.assertFalse(command.preprocessed)
+        self.assertEqual(factory, command.factory)
+        self.assertEqual(factory.name, command.name)
+        key_func = lambda repo: repo.name
+        expect_list = [
+            command.source_code_manager.make_repository_spec(name)
+            for name in ALL_STANDARD_TEST_BOM_REPO_NAMES
+        ]
+        self.assertEqual(
+            sorted(expect_list, key=key_func),
+            sorted(command.source_repositories, key=key_func),
+        )
+        self.assertEqual(
+            os.path.join(options.input_dir, options.command),
+            command.source_code_manager.root_source_dir,
+        )
 
-    # Test invocation
-    if command_name == FAILURE_COMMAND_NAME:
-      with self.assertRaises(ValueError):
-        command()
-      self.assertIsNone(command.postprocess_dict)
-    else:
-      self.assertEqual({'foo': 'bar'}, command())
-      self.assertEqual(command.postprocess_dict,
-                       {name: 'TEST ' + name
-                        for name in ALL_STANDARD_TEST_BOM_REPO_NAMES})
+        # Test invocation
+        if command_name == FAILURE_COMMAND_NAME:
+            with self.assertRaises(ValueError):
+                command()
+            self.assertIsNone(command.postprocess_dict)
+        else:
+            self.assertEqual({"foo": "bar"}, command())
+            self.assertEqual(
+                command.postprocess_dict,
+                {name: "TEST " + name for name in ALL_STANDARD_TEST_BOM_REPO_NAMES},
+            )
 
-    self.assertTrue(command.preprocessed)
-    self.assertEqual(set([repo.name for repo in command.source_repositories]),
-                     command.ensured)
-    self.assertEqual(command.ensured, command.repositories)
+        self.assertTrue(command.preprocessed)
+        self.assertEqual(
+            set([repo.name for repo in command.source_repositories]), command.ensured
+        )
+        self.assertEqual(command.ensured, command.repositories)
 
-    return command
+        return command
 
-  def test_concurrent_command(self):
-    test_command_name = 'concurrent_command'
-    options = self.options
-    options.command = test_command_name
-    command = self.do_test_command(options, test_command_name)
-    self.assertNotEqual(command.test_repo_threadid[0],
-                        command.test_repo_threadid[1])
+    def test_concurrent_command(self):
+        test_command_name = "concurrent_command"
+        options = self.options
+        options.command = test_command_name
+        command = self.do_test_command(options, test_command_name)
+        self.assertNotEqual(
+            command.test_repo_threadid[0], command.test_repo_threadid[1]
+        )
 
-    outcome_name = 'RunCommand_Outcome'
-    family = command.metrics.lookup_family_or_none(outcome_name)
-    self.assertIsNotNone(family)
-    self.assertEqual(family.family_type, family.TIMER)
-    self.assertEqual(family.name, outcome_name)
-    self.assertEqual(1, len(family.instance_list))
-    metric = next(iter(family.instance_list), None)
-    self.assertEqual(1, metric.count)
-    self.assertEqual(True, metric.labels.get('success'))
-    self.assertEqual(test_command_name, metric.labels.get('command'))
-
-    outcome_name = 'RunRepositoryCommand_Outcome'
-    family = command.metrics.lookup_family_or_none(outcome_name)
-    self.assertIsNotNone(family)
-    self.assertEqual(family.family_type, family.TIMER)
-    self.assertEqual(family.name, outcome_name)
-    repository_names = set(
-        [metric.labels.get('repository')
-         for metric in family.instance_list
-         if metric.labels.get('command') == test_command_name])
-    self.assertEqual(2, len(repository_names))
-    self.assertEqual(repository_names, set(ALL_STANDARD_TEST_BOM_REPO_NAMES))
-    for metric in family.instance_list:
-      self.assertEqual(family, metric.family)
-      self.assertEqual(outcome_name, metric.name)
-      self.assertEqual(1, metric.count)
-      self.assertEqual(True, metric.labels.get('success'))
-
-  def test_serialized_command(self):
-    test_command_name = 'serialized_command'
-    options = self.options
-    options.one_at_a_time = True
-    options.command = test_command_name
-    command = self.do_test_command(options, test_command_name)
-    self.assertEqual(command.test_repo_threadid[0],
-                     command.test_repo_threadid[1])
-
-  def test_failed_command(self):
-    test_command_name = FAILURE_COMMAND_NAME
-    options = self.options
-    options.command = test_command_name
-    command = self.do_test_command(options, test_command_name)
-    self.assertNotEqual(command.test_repo_threadid[0],
-                        command.test_repo_threadid[1])
-
-    for test_repository_command in [True, False]:
-      outcome_name = ('RunRepositoryCommand_Outcome'
-                      if test_repository_command
-                      else 'RunCommand_Outcome')
-      family = command.metrics.lookup_family_or_none(outcome_name)
-      self.assertIsNotNone(family)
-      self.assertEqual(family.family_type, family.TIMER)
-      self.assertEqual(family.name, outcome_name)
-      if test_repository_command:
-        repository_names = set([
-            metric.labels.get('repository')
-            for metric in family.instance_list
-            if metric.labels.get('command') == test_command_name])
-        self.assertEqual(2, len(repository_names))
-        self.assertEqual(repository_names,
-                         set(ALL_STANDARD_TEST_BOM_REPO_NAMES))
-
-      found = False
-      for metric in family.instance_list:
-        if metric.labels.get('command') != test_command_name:
-          continue  # Metric was from a different test
-        found = True
-        self.assertEqual(family, metric.family)
-        self.assertEqual(outcome_name, metric.name)
+        outcome_name = "RunCommand_Outcome"
+        family = command.metrics.lookup_family_or_none(outcome_name)
+        self.assertIsNotNone(family)
+        self.assertEqual(family.family_type, family.TIMER)
+        self.assertEqual(family.name, outcome_name)
+        self.assertEqual(1, len(family.instance_list))
+        metric = next(iter(family.instance_list), None)
         self.assertEqual(1, metric.count)
-        self.assertEqual(False, metric.labels.get('success'))
-      self.assertTrue(found)
+        self.assertEqual(True, metric.labels.get("success"))
+        self.assertEqual(test_command_name, metric.labels.get("command"))
+
+        outcome_name = "RunRepositoryCommand_Outcome"
+        family = command.metrics.lookup_family_or_none(outcome_name)
+        self.assertIsNotNone(family)
+        self.assertEqual(family.family_type, family.TIMER)
+        self.assertEqual(family.name, outcome_name)
+        repository_names = set(
+            [
+                metric.labels.get("repository")
+                for metric in family.instance_list
+                if metric.labels.get("command") == test_command_name
+            ]
+        )
+        self.assertEqual(2, len(repository_names))
+        self.assertEqual(repository_names, set(ALL_STANDARD_TEST_BOM_REPO_NAMES))
+        for metric in family.instance_list:
+            self.assertEqual(family, metric.family)
+            self.assertEqual(outcome_name, metric.name)
+            self.assertEqual(1, metric.count)
+            self.assertEqual(True, metric.labels.get("success"))
+
+    def test_serialized_command(self):
+        test_command_name = "serialized_command"
+        options = self.options
+        options.one_at_a_time = True
+        options.command = test_command_name
+        command = self.do_test_command(options, test_command_name)
+        self.assertEqual(command.test_repo_threadid[0], command.test_repo_threadid[1])
+
+    def test_failed_command(self):
+        test_command_name = FAILURE_COMMAND_NAME
+        options = self.options
+        options.command = test_command_name
+        command = self.do_test_command(options, test_command_name)
+        self.assertNotEqual(
+            command.test_repo_threadid[0], command.test_repo_threadid[1]
+        )
+
+        for test_repository_command in [True, False]:
+            outcome_name = (
+                "RunRepositoryCommand_Outcome"
+                if test_repository_command
+                else "RunCommand_Outcome"
+            )
+            family = command.metrics.lookup_family_or_none(outcome_name)
+            self.assertIsNotNone(family)
+            self.assertEqual(family.family_type, family.TIMER)
+            self.assertEqual(family.name, outcome_name)
+            if test_repository_command:
+                repository_names = set(
+                    [
+                        metric.labels.get("repository")
+                        for metric in family.instance_list
+                        if metric.labels.get("command") == test_command_name
+                    ]
+                )
+                self.assertEqual(2, len(repository_names))
+                self.assertEqual(
+                    repository_names, set(ALL_STANDARD_TEST_BOM_REPO_NAMES)
+                )
+
+            found = False
+            for metric in family.instance_list:
+                if metric.labels.get("command") != test_command_name:
+                    continue  # Metric was from a different test
+                found = True
+                self.assertEqual(family, metric.family)
+                self.assertEqual(outcome_name, metric.name)
+                self.assertEqual(1, metric.count)
+                self.assertEqual(False, metric.labels.get("success"))
+            self.assertTrue(found)
 
 
-if __name__ == '__main__':
-  init_runtime()
-  unittest.main(verbosity=2)
+if __name__ == "__main__":
+    init_runtime()
+    unittest.main(verbosity=2)

--- a/unittest/buildtool/subprocess_test.py
+++ b/unittest/buildtool/subprocess_test.py
@@ -25,121 +25,127 @@ from buildtool import (
     check_subprocess,
     check_subprocesses_to_logfile,
     run_subprocess,
-    ExecutionError)
+    ExecutionError,
+)
 
 from test_util import init_runtime
 
 
 class TestRunner(unittest.TestCase):
-  @classmethod
-  def setUpClass(cls):
-    cls.base_temp_dir = tempfile.mkdtemp(prefix='buildtool.subprocess_test')
+    @classmethod
+    def setUpClass(cls):
+        cls.base_temp_dir = tempfile.mkdtemp(prefix="buildtool.subprocess_test")
 
-  @classmethod
-  def tearDownClass(cls):
-    shutil.rmtree(cls.base_temp_dir)
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.base_temp_dir)
 
-  def do_run_subprocess_ok(self, check, logfile=None):
-    if os.path.exists('/bin/true'):
-      true_path = '/bin/true'
-    elif os.path.exists('/usr/bin/true'):
-      true_path = '/usr/bin/true'
-    else:
-      raise NotImplementedError('Unsupported test platform.')
+    def do_run_subprocess_ok(self, check, logfile=None):
+        if os.path.exists("/bin/true"):
+            true_path = "/bin/true"
+        elif os.path.exists("/usr/bin/true"):
+            true_path = "/usr/bin/true"
+        else:
+            raise NotImplementedError("Unsupported test platform.")
 
-    tests = [(true_path, ''),
-             ('/bin/echo Hello', 'Hello'),
-             ('/bin/echo "Hello"', 'Hello'),
-             ('/bin/echo "Hello World"', 'Hello World'),
-             ('/bin/echo "Hello\nWorld"', 'Hello\nWorld'),
-             ('/bin/echo \'"Hello World"\'', '"Hello World"')]
-    for cmd, expect in tests:
-      if logfile:
-        output = check_subprocesses_to_logfile('Test Logfile', logfile, [cmd])
-      elif check:
-        output = check_subprocess(cmd)
-      else:
-        code, output = run_subprocess(cmd)
-        self.assertEqual(0, code)
+        tests = [
+            (true_path, ""),
+            ("/bin/echo Hello", "Hello"),
+            ('/bin/echo "Hello"', "Hello"),
+            ('/bin/echo "Hello World"', "Hello World"),
+            ('/bin/echo "Hello\nWorld"', "Hello\nWorld"),
+            ("/bin/echo '\"Hello World\"'", '"Hello World"'),
+        ]
+        for cmd, expect in tests:
+            if logfile:
+                output = check_subprocesses_to_logfile("Test Logfile", logfile, [cmd])
+            elif check:
+                output = check_subprocess(cmd)
+            else:
+                code, output = run_subprocess(cmd)
+                self.assertEqual(0, code)
 
-      if logfile:
-        self.assertTrue(os.path.exists(logfile))
-        self.assertIsNone(output)
-        with io.open(logfile, 'r', encoding='utf-8') as stream:
-          lines = stream.read().split('\n')
-        self.assertTrue('Spawning' in lines[0])
-        self.assertTrue('process completed with' in lines[-2])
-        body = '\n'.join(lines[3:-3]).strip()
+            if logfile:
+                self.assertTrue(os.path.exists(logfile))
+                self.assertIsNone(output)
+                with io.open(logfile, "r", encoding="utf-8") as stream:
+                    lines = stream.read().split("\n")
+                self.assertTrue("Spawning" in lines[0])
+                self.assertTrue("process completed with" in lines[-2])
+                body = "\n".join(lines[3:-3]).strip()
+                self.assertEqual(expect, body)
+            else:
+                self.assertEqual(expect, output)
+
+    def test_run_subprocess_ok(self):
+        self.do_run_subprocess_ok(False)
+
+    def test_check_subprocess_ok(self):
+        self.do_run_subprocess_ok(False)
+
+    def test_run_subprocess_fail(self):
+        if os.path.exists("/bin/false"):
+            false_path = "/bin/false"
+        elif os.path.exists("/usr/bin/false"):
+            false_path = "/usr/bin/false"
+        else:
+            raise NotImplementedError("Unsupported test platform.")
+
+        got, output = run_subprocess(false_path)
+        self.assertEqual((1, ""), (got, output))
+
+        got, output = run_subprocess("/bin/ls /abc/def")
+        self.assertNotEqual(0, got)
+        self.assertTrue(output.find("No such file or directory") >= 0)
+
+    def test_check_subprocess_fail(self):
+        if os.path.exists("/bin/false"):
+            false_path = "/bin/false"
+        elif os.path.exists("/usr/bin/false"):
+            false_path = "/usr/bin/false"
+        else:
+            raise NotImplementedError("Unsupported test platform.")
+
+        tests = [false_path, "/bin/ls /abc/def"]
+        for test in tests:
+            with self.assertRaises(ExecutionError) as ex:
+                check_subprocess(test)
+            self.assertTrue(hasattr(ex.exception, "loggedit"))
+
+    def test_check_to_file_subprocess_ok(self):
+        path = os.path.join(self.base_temp_dir, "check_ok.log")
+        self.do_run_subprocess_ok(False, logfile=path)
+
+    def test_check_to_file_subprocess_failed(self):
+        cmd = "/bin/ls /abc/def"
+        path = os.path.join(self.base_temp_dir, "check_failed.log")
+        with self.assertRaises(ExecutionError) as ex:
+            check_subprocesses_to_logfile("Test Logfile", path, [cmd])
+        self.assertTrue(hasattr(ex.exception, "loggedit"))
+        self.assertTrue(os.path.exists(path))
+        with open(path, "r") as stream:
+            lines = stream.read().split("\n")
+        body = "\n".join(lines[3:-3]).strip()
+        expect = "/bin/ls: cannot access '/abc/def': No such file or directory"
         self.assertEqual(expect, body)
-      else:
-        self.assertEqual(expect, output)
 
-  def test_run_subprocess_ok(self):
-    self.do_run_subprocess_ok(False)
-
-  def test_check_subprocess_ok(self):
-    self.do_run_subprocess_ok(False)
-
-  def test_run_subprocess_fail(self):
-    if os.path.exists('/bin/false'):
-      false_path = '/bin/false'
-    elif os.path.exists('/usr/bin/false'):
-      false_path = '/usr/bin/false'
-    else:
-      raise NotImplementedError('Unsupported test platform.')
-
-    got, output = run_subprocess(false_path)
-    self.assertEqual((1, ''), (got, output))
-
-    got, output = run_subprocess('/bin/ls /abc/def')
-    self.assertNotEqual(0, got)
-    self.assertTrue(output.find('No such file or directory') >= 0)
-
-  def test_check_subprocess_fail(self):
-    if os.path.exists('/bin/false'):
-      false_path = '/bin/false'
-    elif os.path.exists('/usr/bin/false'):
-      false_path = '/usr/bin/false'
-    else:
-      raise NotImplementedError('Unsupported test platform.')
-
-    tests = [false_path, '/bin/ls /abc/def']
-    for test in tests:
-      with self.assertRaises(ExecutionError) as ex:
-        check_subprocess(test)
-      self.assertTrue(hasattr(ex.exception, 'loggedit'))
-
-  def test_check_to_file_subprocess_ok(self):
-    path = os.path.join(self.base_temp_dir, 'check_ok.log')
-    self.do_run_subprocess_ok(False, logfile=path)
-
-  def test_check_to_file_subprocess_failed(self):
-    cmd = '/bin/ls /abc/def'
-    path = os.path.join(self.base_temp_dir, 'check_failed.log')
-    with self.assertRaises(ExecutionError) as ex:
-      check_subprocesses_to_logfile('Test Logfile', path, [cmd])
-    self.assertTrue(hasattr(ex.exception, 'loggedit'))
-    self.assertTrue(os.path.exists(path))
-    with open(path, 'r') as stream:
-      lines = stream.read().split('\n')
-    body = '\n'.join(lines[3:-3]).strip()
-    expect = "/bin/ls: cannot access '/abc/def': No such file or directory"
-    self.assertEqual(expect, body)
-
-  def test_run_subprocess_get_pid(self):
-    # See if we can run a job by looking up our job
-    # This is also testing parsing command lines.
-    code, output = run_subprocess('/bin/ps -x')
-    self.assertEqual(0, code)
-    my_pid = '%d ' % os.getpid()
-    candidates = [line for line in output.split('\n')
-                  if line.find(my_pid) >= 0 and line.find('python') > 0]
-    if len(candidates) != 1:
-      logging.error('Unexpected output\n%s', output)
-    self.assertEqual(1, len(candidates))
-    self.assertTrue(candidates[0].find(' python ') > 0)
+    def test_run_subprocess_get_pid(self):
+        # See if we can run a job by looking up our job
+        # This is also testing parsing command lines.
+        code, output = run_subprocess("/bin/ps -x")
+        self.assertEqual(0, code)
+        my_pid = "%d " % os.getpid()
+        candidates = [
+            line
+            for line in output.split("\n")
+            if line.find(my_pid) >= 0 and line.find("python") > 0
+        ]
+        if len(candidates) != 1:
+            logging.error("Unexpected output\n%s", output)
+        self.assertEqual(1, len(candidates))
+        self.assertTrue(candidates[0].find(" python ") > 0)
 
 
-if __name__ == '__main__':
-  init_runtime()
-  unittest.main(verbosity=2)
+if __name__ == "__main__":
+    init_runtime()
+    unittest.main(verbosity=2)

--- a/unittest/buildtool/test_util.py
+++ b/unittest/buildtool/test_util.py
@@ -20,198 +20,206 @@ import unittest
 import yaml
 from mock import patch
 
-from buildtool import (
-    check_subprocess_sequence,
-    check_subprocess,
-    MetricsManager)
+from buildtool import check_subprocess_sequence, check_subprocess, MetricsManager
 
 
 def init_runtime(options=None):
-  logging.basicConfig(
-      format='%(levelname).1s %(asctime)s.%(msecs)03d %(message)s',
-      datefmt='%H:%M:%S',
-      level=logging.DEBUG)
+    logging.basicConfig(
+        format="%(levelname).1s %(asctime)s.%(msecs)03d %(message)s",
+        datefmt="%H:%M:%S",
+        level=logging.DEBUG,
+    )
 
-  if not options:
-    class Options(object):
-      pass
-    options = Options()
-    options.metric_name_scope = 'unittest'
-    options.monitoring_flush_frequency = -1
-    options.monitoring_system = 'file'
-    options.monitoring_enabled = False
+    if not options:
 
-  MetricsManager.startup_metrics(options)
+        class Options(object):
+            pass
+
+        options = Options()
+        options.metric_name_scope = "unittest"
+        options.monitoring_flush_frequency = -1
+        options.monitoring_system = "file"
+        options.monitoring_enabled = False
+
+    MetricsManager.startup_metrics(options)
 
 
 #  These are used to define the standard test repositories
-NORMAL_SERVICE = 'gate'
+NORMAL_SERVICE = "gate"
 NORMAL_REPO = NORMAL_SERVICE
-OUTLIER_SERVICE = 'monitoring-daemon'
-OUTLIER_REPO = 'spinnaker-monitoring'
-EXTRA_REPO = 'spinnaker.io'
+OUTLIER_SERVICE = "monitoring-daemon"
+OUTLIER_REPO = "spinnaker-monitoring"
+EXTRA_REPO = "spinnaker.io"
 EXTRA_SERVICE = EXTRA_REPO
 
-STANDARD_GIT_HOST = 'test-gitserver'
+STANDARD_GIT_HOST = "test-gitserver"
 OUTLIER_GIT_HOST = STANDARD_GIT_HOST
-STANDARD_GIT_OWNER = 'spinnaker'
-OUTLIER_GIT_OWNER = 'spinnaker'
+STANDARD_GIT_OWNER = "spinnaker"
+OUTLIER_GIT_OWNER = "spinnaker"
 
-BASE_VERSION_TAG = 'v7.8.9'
-BASE_VERSION_NUMBER = '7.8.9'
-PATCH_BRANCH = 'patch'
-UNTAGGED_BRANCH = 'untagged-branch'
+BASE_VERSION_TAG = "v7.8.9"
+BASE_VERSION_NUMBER = "7.8.9"
+PATCH_BRANCH = "patch"
+UNTAGGED_BRANCH = "untagged-branch"
 
 
 def make_standard_git_repo(git_dir):
-  """Initialize local standard test repos.
+    """Initialize local standard test repos.
 
-  These are used by tests that interact with a git repository.
-  """
-  branch_commits = {'ORIGIN': git_dir}
-  repo_name = os.path.basename(git_dir)
+    These are used by tests that interact with a git repository.
+    """
+    branch_commits = {"ORIGIN": git_dir}
+    repo_name = os.path.basename(git_dir)
 
-  run_git = lambda cmd: 'git %s' % cmd
-  os.makedirs(git_dir)
-  logging.debug('Initializing git repository in "%s"', git_dir)
+    run_git = lambda cmd: "git %s" % cmd
+    os.makedirs(git_dir)
+    logging.debug('Initializing git repository in "%s"', git_dir)
 
-  check_subprocess_sequence(
-      [
-          'touch  %s-basefile.txt' % repo_name,
-          run_git('init'),
-          run_git('add %s-basefile.txt' % repo_name),
-          run_git('commit -a -m "feat(first): first commit"'),
-          run_git('tag %s HEAD' % BASE_VERSION_TAG),
-      ],
-      cwd=git_dir)
-  branch_commits['master'] = check_subprocess('git rev-parse HEAD', cwd=git_dir)
+    check_subprocess_sequence(
+        [
+            "touch  %s-basefile.txt" % repo_name,
+            run_git("init"),
+            run_git("add %s-basefile.txt" % repo_name),
+            run_git('commit -a -m "feat(first): first commit"'),
+            run_git("tag %s HEAD" % BASE_VERSION_TAG),
+        ],
+        cwd=git_dir,
+    )
+    branch_commits["master"] = check_subprocess("git rev-parse HEAD", cwd=git_dir)
 
-  check_subprocess_sequence(
-      [
-          run_git('checkout -b ' + PATCH_BRANCH),
-          'touch %s-patchfile.txt' % repo_name,
-          run_git('add %s-patchfile.txt' % repo_name),
-          run_git('commit -a -m "fix(patch): added patch change"')
-      ],
-      cwd=git_dir)
-  branch_commits[PATCH_BRANCH] = check_subprocess(
-      'git rev-parse HEAD', cwd=git_dir)
+    check_subprocess_sequence(
+        [
+            run_git("checkout -b " + PATCH_BRANCH),
+            "touch %s-patchfile.txt" % repo_name,
+            run_git("add %s-patchfile.txt" % repo_name),
+            run_git('commit -a -m "fix(patch): added patch change"'),
+        ],
+        cwd=git_dir,
+    )
+    branch_commits[PATCH_BRANCH] = check_subprocess("git rev-parse HEAD", cwd=git_dir)
 
-  check_subprocess_sequence(
-      [
-          run_git('checkout master'),
-          run_git('checkout -b %s-branch' % repo_name),
-          'touch %s-unique.txt' % repo_name,
-          run_git('add %s-unique.txt' % repo_name),
-          run_git('commit -a -m "chore(uniq): unique commit"')
-      ],
-      cwd=git_dir)
-  branch_commits['%s-branch' % repo_name] = check_subprocess(
-      'git rev-parse HEAD', cwd=git_dir)
+    check_subprocess_sequence(
+        [
+            run_git("checkout master"),
+            run_git("checkout -b %s-branch" % repo_name),
+            "touch %s-unique.txt" % repo_name,
+            run_git("add %s-unique.txt" % repo_name),
+            run_git('commit -a -m "chore(uniq): unique commit"'),
+        ],
+        cwd=git_dir,
+    )
+    branch_commits["%s-branch" % repo_name] = check_subprocess(
+        "git rev-parse HEAD", cwd=git_dir
+    )
 
-  check_subprocess_sequence(
-      [
-          run_git('checkout master'),
-          run_git('checkout -b %s' % UNTAGGED_BRANCH),
-          'touch %s-untagged.txt' % repo_name,
-          run_git('add %s-untagged.txt' % repo_name),
-          run_git('commit -a -m "chore(uniq): untagged commit"'),
-      ],
-      cwd=git_dir)
-  branch_commits[UNTAGGED_BRANCH] = check_subprocess(
-      'git rev-parse HEAD', cwd=git_dir)
+    check_subprocess_sequence(
+        [
+            run_git("checkout master"),
+            run_git("checkout -b %s" % UNTAGGED_BRANCH),
+            "touch %s-untagged.txt" % repo_name,
+            run_git("add %s-untagged.txt" % repo_name),
+            run_git('commit -a -m "chore(uniq): untagged commit"'),
+        ],
+        cwd=git_dir,
+    )
+    branch_commits[UNTAGGED_BRANCH] = check_subprocess(
+        "git rev-parse HEAD", cwd=git_dir
+    )
 
-  return branch_commits
+    return branch_commits
+
 
 ALL_STANDARD_TEST_REPO_NAMES = [NORMAL_REPO, OUTLIER_REPO, EXTRA_REPO]
 ALL_STANDARD_TEST_BOM_REPO_NAMES = [NORMAL_REPO, OUTLIER_REPO]
 
+
 def make_all_standard_git_repos(base_dir):
-  """Creates git repositories for each of the standard test repos."""
+    """Creates git repositories for each of the standard test repos."""
 
-  result = {}
+    result = {}
 
-  path = os.path.join(base_dir, STANDARD_GIT_OWNER, NORMAL_REPO)
-  result[NORMAL_REPO] = make_standard_git_repo(path)
+    path = os.path.join(base_dir, STANDARD_GIT_OWNER, NORMAL_REPO)
+    result[NORMAL_REPO] = make_standard_git_repo(path)
 
-  path = os.path.join(base_dir, STANDARD_GIT_OWNER, EXTRA_REPO)
-  result[EXTRA_REPO] = make_standard_git_repo(path)
+    path = os.path.join(base_dir, STANDARD_GIT_OWNER, EXTRA_REPO)
+    result[EXTRA_REPO] = make_standard_git_repo(path)
 
-  path = os.path.join(base_dir, OUTLIER_GIT_OWNER, OUTLIER_REPO)
-  result[OUTLIER_REPO] = make_standard_git_repo(path)
+    path = os.path.join(base_dir, OUTLIER_GIT_OWNER, OUTLIER_REPO)
+    result[OUTLIER_REPO] = make_standard_git_repo(path)
 
-  return result
+    return result
 
 
 class BaseTestFixture(unittest.TestCase):
-  @classmethod
-  def setUpClass(cls):
-    logging.debug('BEGIN setUpClass %s', cls.__name__)
-    cls.base_temp_dir = tempfile.mkdtemp(prefix=cls.__name__)
+    @classmethod
+    def setUpClass(cls):
+        logging.debug("BEGIN setUpClass %s", cls.__name__)
+        cls.base_temp_dir = tempfile.mkdtemp(prefix=cls.__name__)
 
-  @classmethod
-  def tearDownClass(cls):
-    shutil.rmtree(cls.base_temp_dir)
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.base_temp_dir)
 
-  def make_test_options(self):
-    class Options(object):
-      pass
-    options = Options()
-    options.command = self._testMethodName
-    options.input_dir = os.path.join(self.test_root, 'input_dir')
-    options.output_dir = os.path.join(self.test_root, 'output_dir')
-    return options
+    def make_test_options(self):
+        class Options(object):
+            pass
 
-  def setUp(self):
-    self.test_root = os.path.join(self.base_temp_dir, self._testMethodName)
-    self.options = self.make_test_options()
+        options = Options()
+        options.command = self._testMethodName
+        options.input_dir = os.path.join(self.test_root, "input_dir")
+        options.output_dir = os.path.join(self.test_root, "output_dir")
+        return options
+
+    def setUp(self):
+        self.test_root = os.path.join(self.base_temp_dir, self._testMethodName)
+        self.options = self.make_test_options()
 
 
 class BaseGitRepoTestFixture(BaseTestFixture):
-  @classmethod
-  def setUpClass(cls):
-    super(BaseGitRepoTestFixture, cls).setUpClass()
-    cls.repo_commit_map = make_all_standard_git_repos(cls.base_temp_dir)
-    source_path = os.path.join(os.path.dirname(__file__),
-                               'standard_test_bom.yml')
+    @classmethod
+    def setUpClass(cls):
+        super(BaseGitRepoTestFixture, cls).setUpClass()
+        cls.repo_commit_map = make_all_standard_git_repos(cls.base_temp_dir)
+        source_path = os.path.join(os.path.dirname(__file__), "standard_test_bom.yml")
 
-    # Adjust the golden bom so it references the details of
-    # the test instance specific origin repo we just created in test_util.
-    with open(source_path, 'r') as stream:
-      cls.golden_bom = yaml.safe_load(stream.read())
+        # Adjust the golden bom so it references the details of
+        # the test instance specific origin repo we just created in test_util.
+        with open(source_path, "r") as stream:
+            cls.golden_bom = yaml.safe_load(stream.read())
 
-      #  Change the bom's default gitPrefix to our origin root
-      cls.golden_bom['artifactSources']['gitPrefix'] = (
-          os.path.dirname(cls.repo_commit_map[NORMAL_REPO]['ORIGIN']))
+            #  Change the bom's default gitPrefix to our origin root
+            cls.golden_bom["artifactSources"]["gitPrefix"] = os.path.dirname(
+                cls.repo_commit_map[NORMAL_REPO]["ORIGIN"]
+            )
 
-      # Update the service commit id's in the BOM to the actual id's
-      # so we can check them out later.
-      services = cls.golden_bom['services']
-      for name, entry in services.items():
-        repo_name = name
-        if name in ['monitoring-third-party', 'monitoring-daemon']:
-          repo_name = name = 'spinnaker-monitoring'
-        if name == OUTLIER_SERVICE:
-          repo_name = OUTLIER_REPO
-        entry['commit'] = cls.repo_commit_map[repo_name][PATCH_BRANCH]
-    logging.debug('FINISH setUpClass %s', cls.__name__)
+            # Update the service commit id's in the BOM to the actual id's
+            # so we can check them out later.
+            services = cls.golden_bom["services"]
+            for name, entry in services.items():
+                repo_name = name
+                if name in ["monitoring-third-party", "monitoring-daemon"]:
+                    repo_name = name = "spinnaker-monitoring"
+                if name == OUTLIER_SERVICE:
+                    repo_name = OUTLIER_REPO
+                entry["commit"] = cls.repo_commit_map[repo_name][PATCH_BRANCH]
+        logging.debug("FINISH setUpClass %s", cls.__name__)
 
-  @classmethod
-  def to_origin(cls, repo_name):
-    return cls.repo_commit_map[repo_name]['ORIGIN']
+    @classmethod
+    def to_origin(cls, repo_name):
+        return cls.repo_commit_map[repo_name]["ORIGIN"]
 
-  def patch_function(self, name):
-    patcher = patch(name)
-    hook = patcher.start()
-    self.addCleanup(patcher.stop)
-    return hook
+    def patch_function(self, name):
+        patcher = patch(name)
+        hook = patcher.start()
+        self.addCleanup(patcher.stop)
+        return hook
 
-  def patch_method(self, klas, method):
-    patcher = patch.object(klas, method)
-    hook = patcher.start()
-    self.addCleanup(patcher.stop)
-    return hook
+    def patch_method(self, klas, method):
+        patcher = patch.object(klas, method)
+        hook = patcher.start()
+        self.addCleanup(patcher.stop)
+        return hook
 
-  def setUp(self):
-    super(BaseGitRepoTestFixture, self).setUp()
-    self.options.github_repository_root = self.base_temp_dir
+    def setUp(self):
+        super(BaseGitRepoTestFixture, self).setUp()
+        self.options.github_repository_root = self.base_temp_dir

--- a/unittest/buildtool/util_test.py
+++ b/unittest/buildtool/util_test.py
@@ -21,63 +21,61 @@ import shutil
 import tempfile
 import unittest
 
-from buildtool import (
-    ensure_dir_exists,
-    timedelta_string,
-    write_to_path)
+from buildtool import ensure_dir_exists, timedelta_string, write_to_path
 
 
 class TestRunner(unittest.TestCase):
-  @classmethod
-  def setUpClass(cls):
-    cls.base_temp_dir = tempfile.mkdtemp(prefix='buildtool.util_test')
+    @classmethod
+    def setUpClass(cls):
+        cls.base_temp_dir = tempfile.mkdtemp(prefix="buildtool.util_test")
 
-  @classmethod
-  def tearDownClass(cls):
-    shutil.rmtree(cls.base_temp_dir)
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.base_temp_dir)
 
-  def test_ensure_dir(self):
-    want = os.path.join(self.base_temp_dir, 'ensure', 'a', 'b', 'c')
-    self.assertFalse(os.path.exists(want))
-    ensure_dir_exists(want)
-    self.assertTrue(os.path.exists(want))
+    def test_ensure_dir(self):
+        want = os.path.join(self.base_temp_dir, "ensure", "a", "b", "c")
+        self.assertFalse(os.path.exists(want))
+        ensure_dir_exists(want)
+        self.assertTrue(os.path.exists(want))
 
-    # Ok if already exists
-    ensure_dir_exists(want)
-    self.assertTrue(os.path.exists(want))
+        # Ok if already exists
+        ensure_dir_exists(want)
+        self.assertTrue(os.path.exists(want))
 
-  def test_write_to_path_string(self):
-    path = os.path.join(self.base_temp_dir, 'test_write', 'file')
-    content = 'First Line\nSecond Line'
-    write_to_path(content, path)
-    with open(path, 'r') as f:
-      self.assertEqual(content, f.read())
+    def test_write_to_path_string(self):
+        path = os.path.join(self.base_temp_dir, "test_write", "file")
+        content = "First Line\nSecond Line"
+        write_to_path(content, path)
+        with open(path, "r") as f:
+            self.assertEqual(content, f.read())
 
-  def test_write_to_path_unicode(self):
-    path = os.path.join(self.base_temp_dir, 'test_write', 'file')
-    content = u'First Line\nSecond Line'
-    write_to_path(content, path)
-    with open(path, 'r') as f:
-      self.assertEqual(content, f.read())
+    def test_write_to_path_unicode(self):
+        path = os.path.join(self.base_temp_dir, "test_write", "file")
+        content = "First Line\nSecond Line"
+        write_to_path(content, path)
+        with open(path, "r") as f:
+            self.assertEqual(content, f.read())
 
-  def test_deltatime_string(self):
-    timedelta = datetime.timedelta
-    tests = [
-        (timedelta(1, 60 * 60 * 4 + 60 * 5 + 2, 123456), 'days=1 + 04:05:02'),
-        (timedelta(1, 60 * 5 + 2, 123456), 'days=1 + 00:05:02'),
-        (timedelta(1, 2, 123456), 'days=1 + 00:00:02'),
-        (timedelta(0, 60 * 60 * 4 + 60 * 5 + 2, 123456), '04:05:02'),
-        (timedelta(0, 60 * 5 + 2, 123456), '05:02'),
-        (timedelta(0, 2, 123456), '2.123 secs')
-    ]
-    for test in tests:
-      self.assertEqual(test[1], timedelta_string(test[0]))
+    def test_deltatime_string(self):
+        timedelta = datetime.timedelta
+        tests = [
+            (timedelta(1, 60 * 60 * 4 + 60 * 5 + 2, 123456), "days=1 + 04:05:02"),
+            (timedelta(1, 60 * 5 + 2, 123456), "days=1 + 00:05:02"),
+            (timedelta(1, 2, 123456), "days=1 + 00:00:02"),
+            (timedelta(0, 60 * 60 * 4 + 60 * 5 + 2, 123456), "04:05:02"),
+            (timedelta(0, 60 * 5 + 2, 123456), "05:02"),
+            (timedelta(0, 2, 123456), "2.123 secs"),
+        ]
+        for test in tests:
+            self.assertEqual(test[1], timedelta_string(test[0]))
 
 
-if __name__ == '__main__':
-  logging.basicConfig(
-      format='%(levelname).1s %(asctime)s.%(msecs)03d %(message)s',
-      datefmt='%H:%M:%S',
-      level=logging.DEBUG)
+if __name__ == "__main__":
+    logging.basicConfig(
+        format="%(levelname).1s %(asctime)s.%(msecs)03d %(message)s",
+        datefmt="%H:%M:%S",
+        level=logging.DEBUG,
+    )
 
-  unittest.main(verbosity=2)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Linters can be both helpful and pedantic.

Start with GitHub's "python starter" which fails on some key errors and only
warns on other conditions.
https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#using-the-python-starter-workflow

Potentially a pre-commit hook could be used like `spotless` in java
service repo's.

Apply `Black`'s PEP8 compliant linter. This clears up a ton of indentation and 
other stylistic noise in IDE.
Could also be run on a pre-commit hook at a later time.