### PR TITLE
feat(ci): Add new command tag_branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ At time of writing, tagging designated (`master` and `release-*`) branches will:
    and build a new set of artifacts.
 
 ```
-./dev/buildtool.sh tag_branches \
+./dev/buildtool.sh tag_branch \
   --git_branch master
 ```
 
@@ -85,7 +85,7 @@ disabling git push:
 git_branch=master
 fork_owner=<you>
 
-./dev/buildtool.sh tag_branches \
+./dev/buildtool.sh tag_branch \
   --git_branch "${git_branch}" \
   --github_owner "${fork_owner}" \
   --only_repositories clouddriver \

--- a/README.md
+++ b/README.md
@@ -59,16 +59,17 @@ FAILED (errors=4)
 Tag repositories with their respective next tag.
 
 - branches without any new commits since the last tag will not be re-tagged.
-- `master` branches will be tagged with the next `{minor}` and `{patch}` of `0`.
+- `master` branches are tagged with the next `{minor}` and `{patch}` of `0`.
   For example, a repo with `master` tagged `1.2.0` will be tagged `1.3.0`.
-- all other branches (e.g: `release-*`) will be tagged with the next `{patch}`.
+- all other branches (e.g: `release-*`) are tagged with the next `{patch}`.
   For example, a repo with `release-1.27.x` tagged `1.2.3` will be tagged `1.2.4`.
 
 At time of writing, tagging designated (`master` and `release-*`) branches will:
 
-1. (on `master`) provide a commit SHA to create new `release-*` branches at.
-1. trigger GitHub Actions to build new artifacts with the tag
-1. trigger auto-bump Pull Request's across services bumping dependency versions.
+1. (on `master`) provide a marker (the tag) to create a new `release-*` branch
+1. (on both) trigger GitHub Actions to build new artifacts with the tag
+1. (on both) trigger auto-bump Pull Request's across services bumping
+   dependency versions.
    NOTE: This will in-turn increment `{minor}` tag on the downstream service
    and build a new set of artifacts.
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ Tag repositories with their respective next tag.
 
 At time of writing, tagging designated (`master` and `release-*`) branches will:
 
-1. (on `master`) provide a commit SHA to branch at for a new Spinnaker Release,
-   e.g: `1.28.0`.
+1. (on `master`) provide a commit SHA to create new `release-*` branches at.
 1. trigger GitHub Actions to build new artifacts with the tag
 1. trigger auto-bump Pull Request's across services bumping dependency versions.
    NOTE: This will in-turn increment `{minor}` tag on the downstream service

--- a/dev/buildtool/__init__.py
+++ b/dev/buildtool/__init__.py
@@ -15,6 +15,7 @@ SPINNAKER_RUNNABLE_REPOSITORY_NAMES = [
     "orca",
     "rosco",
 ]
+# These are not included in the BOM but are included in some buildtool tasks
 SPINNAKER_RUNNABLE_NON_CORE_REPOSITORY_NAMES = ["keel"]
 
 # For building and validating a release

--- a/dev/buildtool/__init__.py
+++ b/dev/buildtool/__init__.py
@@ -15,6 +15,7 @@ SPINNAKER_RUNNABLE_REPOSITORY_NAMES = [
     "orca",
     "rosco",
 ]
+SPINNAKER_RUNNABLE_NON_CORE_REPOSITORY_NAMES = ["keel"]
 
 # For building and validating a release
 SPINNAKER_PROCESS_REPOSITORY_NAMES = ["buildtool", "spinrel"]

--- a/dev/buildtool/git_support.py
+++ b/dev/buildtool/git_support.py
@@ -863,7 +863,7 @@ class GitRunner:
         if tag_commit == commit_id:
             logging.debug("Commit %s is already tagged with %s", tag_commit, tag)
         else:
-            logging.warning(
+            logging.debug(
                 "%s HEAD commit of %s is newer than %s tag at %s. Using last tag & its commit",
                 git_dir.split("/")[2],
                 commit_id,
@@ -1161,6 +1161,10 @@ class GitRunner:
 
     def checkout(self, repository, commit):
         self.check_run(repository.git_dir, "checkout -q " + commit, echo=True)
+
+    def tag_commit(self, git_dir, tag, commit_id):
+        """Add tag to the local repository at commit_id."""
+        self.check_run(git_dir, f"tag {tag} {commit_id}")
 
     def tag_head(self, git_dir, tag):
         """Add tag to the local repository HEAD."""

--- a/dev/buildtool/source_commands.py
+++ b/dev/buildtool/source_commands.py
@@ -157,7 +157,7 @@ class TagBranchCommand(RepositoryCommandProcessor):
     def _do_repository(self, repository):
         """Implements RepositoryCommandProcessor interface."""
         head_commit_id = self.__git.query_local_repository_commit_id(repository.git_dir)
-        logging.debug("repo: %s - HEAD commit: %s", repository.name, head_commit_id)
+        logging.debug("%s HEAD commit: %s", repository.name, head_commit_id)
 
         (
             latest_tag,
@@ -167,7 +167,7 @@ class TagBranchCommand(RepositoryCommandProcessor):
         )
         if latest_tag_commit_id == head_commit_id:
             logging.info(
-                "repo: %s - HEAD commit: %s is already tagged at: %s. Not generating a new tag.",
+                "%s HEAD commit: %s already tagged at: %s. Skipping.",
                 repository.name,
                 head_commit_id,
                 latest_tag,
@@ -175,7 +175,7 @@ class TagBranchCommand(RepositoryCommandProcessor):
             return
 
         logging.debug(
-            "repo: %s - latest tag: %s - latest tag commit: %s",
+            "%s latest tag: %s - latest tag commit: %s",
             repository.name,
             latest_tag,
             latest_tag_commit_id,
@@ -191,7 +191,7 @@ class TagBranchCommand(RepositoryCommandProcessor):
         next_tag = next_semver.to_tag()
 
         logging.info(
-            "repo: %s - latest tag: %s not at HEAD, generating next tag: %s",
+            "%s latest tag: %s not at HEAD, generating next tag: %s",
             repository.name,
             latest_tag,
             next_tag,
@@ -213,22 +213,6 @@ class TagBranchCommandFactory(RepositoryCommandFactory):
     def init_argparser(self, parser, defaults):
         super().init_argparser(parser, defaults)
         GitRunner.add_publishing_parser_args(parser, defaults)
-        self.add_argument(
-            parser,
-            "delete_existing",
-            defaults,
-            False,
-            type=bool,
-            help="Force a new clone by removing existing directories if present.",
-        )
-        self.add_argument(
-            parser,
-            "skip_existing",
-            defaults,
-            False,
-            type=bool,
-            help="Ignore directories that are already present.",
-        )
 
 
 def register_commands(registry, subparsers, defaults):

--- a/dev/buildtool/source_commands.py
+++ b/dev/buildtool/source_commands.py
@@ -151,7 +151,6 @@ class TagBranchCommand(RepositoryCommandProcessor):
 
         all_names = list(SPINNAKER_RUNNABLE_REPOSITORY_NAMES)
         all_names.extend(SPINNAKER_RUNNABLE_NON_CORE_REPOSITORY_NAMES)
-        all_names.extend(SPIN_REPOSITORY_NAMES)
         super().__init__(factory, options, source_repository_names=all_names)
 
     def _do_repository(self, repository):

--- a/dev/buildtool/source_commands.py
+++ b/dev/buildtool/source_commands.py
@@ -157,7 +157,12 @@ class TagBranchCommand(RepositoryCommandProcessor):
     def _do_repository(self, repository):
         """Implements RepositoryCommandProcessor interface."""
         head_commit_id = self.__git.query_local_repository_commit_id(repository.git_dir)
-        logging.debug("%s HEAD commit: %s", repository.name, head_commit_id)
+        logging.debug(
+            "%s %s branch HEAD commit: %s",
+            repository.name,
+            self.options.git_branch,
+            head_commit_id,
+        )
 
         (
             latest_tag,
@@ -167,16 +172,18 @@ class TagBranchCommand(RepositoryCommandProcessor):
         )
         if latest_tag_commit_id == head_commit_id:
             logging.info(
-                "%s HEAD commit: %s already tagged at: %s. Skipping.",
+                "%s %s branch HEAD commit: %s already tagged at: %s. Skipping.",
                 repository.name,
+                self.options.git_branch,
                 head_commit_id,
                 latest_tag,
             )
             return
 
         logging.debug(
-            "%s latest tag: %s - latest tag commit: %s",
+            "%s %s branch latest tag: %s - latest tag commit: %s",
             repository.name,
+            self.options.git_branch,
             latest_tag,
             latest_tag_commit_id,
         )
@@ -191,8 +198,9 @@ class TagBranchCommand(RepositoryCommandProcessor):
         next_tag = next_semver.to_tag()
 
         logging.info(
-            "%s latest tag: %s not at HEAD, generating next tag: %s",
+            "%s %s branch latest tag: %s not at HEAD, generating next tag: %s",
             repository.name,
+            self.options.git_branch,
             latest_tag,
             next_tag,
         )

--- a/dev/buildtool/source_commands.py
+++ b/dev/buildtool/source_commands.py
@@ -20,12 +20,17 @@ import shutil
 
 from buildtool import (
     DEFAULT_BUILD_NUMBER,
+    SPIN_REPOSITORY_NAMES,
     SPINNAKER_BOM_REPOSITORY_NAMES,
     SPINNAKER_HALYARD_REPOSITORY_NAME,
     SPINNAKER_PROCESS_REPOSITORY_NAMES,
+    SPINNAKER_RUNNABLE_NON_CORE_REPOSITORY_NAMES,
+    SPINNAKER_RUNNABLE_REPOSITORY_NAMES,
     BranchSourceCodeManager,
+    GitRunner,
     RepositoryCommandFactory,
     RepositoryCommandProcessor,
+    SemanticVersion,
     raise_and_log_error,
     ConfigError,
 )
@@ -40,9 +45,7 @@ class FetchSourceCommand(RepositoryCommandProcessor):
         all_names = list(SPINNAKER_BOM_REPOSITORY_NAMES)
         all_names.append(SPINNAKER_HALYARD_REPOSITORY_NAME)
         all_names.extend(SPINNAKER_PROCESS_REPOSITORY_NAMES)
-        super().__init__(
-            factory, options, source_repository_names=all_names
-        )
+        super().__init__(factory, options, source_repository_names=all_names)
 
     def ensure_local_repository(self, repository):
         """Implements RepositoryCommandProcessor interface."""
@@ -138,6 +141,97 @@ class ExtractSourceInfoCommandFactory(RepositoryCommandFactory):
         )
 
 
+class TagBranchCommand(RepositoryCommandProcessor):
+    """Implements the tag_branch command."""
+
+    def __init__(self, factory, options):
+        """Implements CommandProcessor interface."""
+
+        self.__git = GitRunner(options)
+
+        all_names = list(SPINNAKER_RUNNABLE_REPOSITORY_NAMES)
+        all_names.extend(SPINNAKER_RUNNABLE_NON_CORE_REPOSITORY_NAMES)
+        all_names.extend(SPIN_REPOSITORY_NAMES)
+        super().__init__(factory, options, source_repository_names=all_names)
+
+    def _do_repository(self, repository):
+        """Implements RepositoryCommandProcessor interface."""
+        head_commit_id = self.__git.query_local_repository_commit_id(repository.git_dir)
+        logging.debug("repo: %s - HEAD commit: %s", repository.name, head_commit_id)
+
+        (
+            latest_tag,
+            latest_tag_commit_id,
+        ) = self.__git.find_newest_tag_and_common_commit_from_id(
+            repository.git_dir, head_commit_id
+        )
+        if latest_tag_commit_id == head_commit_id:
+            logging.info(
+                "repo: %s - HEAD commit: %s is already tagged at: %s. Not generating a new tag.",
+                repository.name,
+                head_commit_id,
+                latest_tag,
+            )
+            return
+
+        logging.debug(
+            "repo: %s - latest tag: %s - latest tag commit: %s",
+            repository.name,
+            latest_tag,
+            latest_tag_commit_id,
+        )
+
+        latest_tag_semver = SemanticVersion.make(latest_tag)
+
+        if self.options.git_branch == "master":
+            next_semver = latest_tag_semver.next(2)  # increment minor
+        else:
+            next_semver = latest_tag_semver.next(3)  # increment patch
+
+        next_tag = next_semver.to_tag()
+
+        logging.info(
+            "repo: %s - latest tag: %s not at HEAD, generating next tag: %s",
+            repository.name,
+            latest_tag,
+            next_tag,
+        )
+
+        self.__git.tag_commit(repository.git_dir, next_tag, head_commit_id)
+        self.__git.push_tag_to_origin(repository.git_dir, next_tag)
+
+
+class TagBranchCommandFactory(RepositoryCommandFactory):
+    def __init__(self):
+        super().__init__(
+            "tag_branch",
+            TagBranchCommand,
+            "Tag HEAD of service repository branches if there are commits since previous tag.",
+            BranchSourceCodeManager,
+        )
+
+    def init_argparser(self, parser, defaults):
+        super().init_argparser(parser, defaults)
+        GitRunner.add_publishing_parser_args(parser, defaults)
+        self.add_argument(
+            parser,
+            "delete_existing",
+            defaults,
+            False,
+            type=bool,
+            help="Force a new clone by removing existing directories if present.",
+        )
+        self.add_argument(
+            parser,
+            "skip_existing",
+            defaults,
+            False,
+            type=bool,
+            help="Ignore directories that are already present.",
+        )
+
+
 def register_commands(registry, subparsers, defaults):
     ExtractSourceInfoCommandFactory().register(registry, subparsers, defaults)
     FetchSourceCommandFactory().register(registry, subparsers, defaults)
+    TagBranchCommandFactory().register(registry, subparsers, defaults)

--- a/unittest/buildtool/source_commands_test.py
+++ b/unittest/buildtool/source_commands_test.py
@@ -1,0 +1,170 @@
+# Copyright 2022 Salesforce.com, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import unittest
+
+from test_util import (
+    BASE_VERSION_TAG,
+    NORMAL_REPO,
+    UNTAGGED_BRANCH,
+    init_runtime,
+    BaseGitRepoTestFixture,
+)
+
+import buildtool.__main__ as buildtool_main
+import buildtool.source_commands
+from buildtool import GitRunner
+from buildtool import check_subprocess_sequence
+
+NEW_MINOR_TAG = "v7.9.0"
+NEW_PATCH_TAG = "v7.8.10"
+
+
+class TestSpinnakerCommandFixture(BaseGitRepoTestFixture):
+    def setUp(self):
+        super().setUp()
+        self.parser = argparse.ArgumentParser()
+        self.subparsers = self.parser.add_subparsers(title="command", dest="command")
+
+    def test_tag_branch_master_command(self):
+        """assert tagging behaviour on master branch:
+        1. when tagged at HEAD a new tag should not generated and pushed
+        2. when NOT tagged at HEAD a new minor tag should be generated and pushed
+        """
+
+        defaults = {
+            "input_dir": self.options.input_dir,
+            "output_dir": self.options.output_dir,
+            "only_repositories": NORMAL_REPO,
+            "github_owner": "default",
+            "git_branch": "master",
+            "github_repository_root": self.options.github_repository_root,
+        }
+
+        registry = {}
+        buildtool_main.add_standard_parser_args(self.parser, defaults)
+        buildtool.source_commands.register_commands(registry, self.subparsers, defaults)
+
+        factory = registry["tag_branch"]
+        factory.init_argparser(self.parser, defaults)
+
+        options = self.parser.parse_args(["tag_branch"])
+
+        mock_push_tag = self.patch_method(GitRunner, "push_tag_to_origin")
+
+        command = factory.make_command(options)
+        command()
+
+        base_git_dir = os.path.join(options.input_dir, "tag_branch")
+        self.assertEqual(os.listdir(base_git_dir), [NORMAL_REPO])
+        git_dir = os.path.join(base_git_dir, NORMAL_REPO)
+
+        head_commit_id = GitRunner(options).query_local_repository_commit_id(git_dir)
+
+        latest_tag, _ = GitRunner(options).find_newest_tag_and_common_commit_from_id(
+            git_dir, head_commit_id
+        )
+
+        # master branch already tagged at HEAD so no new tag should be added
+        # and pushed.
+        self.assertEqual(BASE_VERSION_TAG, latest_tag)
+        self.assertEqual(0, mock_push_tag.call_count)
+
+        # now add a commit to master branch and validate a tag is generated.
+
+        check_subprocess_sequence(
+            [
+                f"touch  {NORMAL_REPO}-basefile-2.txt",
+                f"git add {NORMAL_REPO}-basefile-2.txt",
+                'git commit -a -m "feat(second): second commit"',
+            ],
+            cwd=git_dir,
+        )
+
+        command()
+
+        head_commit_id_2 = GitRunner(options).query_local_repository_commit_id(git_dir)
+        latest_tag_2, _ = GitRunner(options).find_newest_tag_and_common_commit_from_id(
+            git_dir, head_commit_id_2
+        )
+
+        # master branch not tagged at HEAD so a new minor tag should be added
+        # and pushed.
+        self.assertEqual(NEW_MINOR_TAG, latest_tag_2)
+        self.assertEqual(1, mock_push_tag.call_count)
+
+    def test_tag_branch_untagged_command(self):
+        """assert tagging behaviour on non-master branches:
+        1. when NOT tagged at HEAD a new patch tag should be generated and pushed
+        2. when tagged at HEAD a new tag should not generated and pushed
+        """
+
+        defaults = {
+            "input_dir": self.options.input_dir,
+            "output_dir": self.options.output_dir,
+            "only_repositories": NORMAL_REPO,
+            "github_owner": "default",
+            "git_branch": UNTAGGED_BRANCH,
+            "github_repository_root": self.options.github_repository_root,
+        }
+
+        registry = {}
+        buildtool_main.add_standard_parser_args(self.parser, defaults)
+        buildtool.source_commands.register_commands(registry, self.subparsers, defaults)
+
+        factory = registry["tag_branch"]
+        factory.init_argparser(self.parser, defaults)
+
+        options = self.parser.parse_args(["tag_branch"])
+
+        mock_push_tag = self.patch_method(GitRunner, "push_tag_to_origin")
+
+        command = factory.make_command(options)
+        command()
+
+        base_git_dir = os.path.join(options.input_dir, "tag_branch")
+        self.assertEqual(os.listdir(base_git_dir), [NORMAL_REPO])
+        git_dir = os.path.join(base_git_dir, NORMAL_REPO)
+
+        head_commit_id = GitRunner(options).query_local_repository_commit_id(git_dir)
+
+        latest_tag, _ = GitRunner(options).find_newest_tag_and_common_commit_from_id(
+            git_dir, head_commit_id
+        )
+
+        # non-master branch not tagged at HEAD so a new patch tag should be
+        # added and pushed.
+        self.assertEqual(NEW_PATCH_TAG, latest_tag)
+        self.assertEqual(1, mock_push_tag.call_count)
+
+        # run command again and confirm that no new tag was added as we haven't
+        # added any commits.
+
+        command()
+        head_commit_id_2 = GitRunner(options).query_local_repository_commit_id(git_dir)
+        latest_tag_2, _ = GitRunner(options).find_newest_tag_and_common_commit_from_id(
+            git_dir, head_commit_id_2
+        )
+
+        # non-master branch already tagged at HEAD so no new tag should be
+        # added and pushed.
+        self.assertEqual(NEW_PATCH_TAG, latest_tag_2)
+        self.assertEqual(1, mock_push_tag.call_count)
+
+
+if __name__ == "__main__":
+    init_runtime()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Builds on #189 

- tag `master` branch with next semVer minor version.
- tag all other branches (eg: `release-*`) with next semVer patch version.

Because of auto-bump GitHub Actions kicking off a fresh round of tag
bumps across some service repositories we can't just use the freshly
created tag here in BOM generation.
