### PR TITLE
feat(ci): Add support for managing Halyard's versions.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,3 +394,80 @@ The previous step created a branch in a local copy of your fork here:
 
     1. Raise a PR to:
        [github.com/spinnaker/spinnaker.io](https://github.com/spinnaker/spinnaker/io/pulls)
+
+### Fetch versions.yml
+
+Halyard uses `versions.yml` as the source of truth for available Spinnaker
+versions to deploy. Fetch the file from GCS bucket for editing.
+
+```
+./dev/buildtool.sh fetch_versions
+```
+
+To troubleshoot, check the fetched file.
+
+```
+$ cat output/fetch_versions/versions.yml
+illegalVersions:
+- reason: Broken apache config makes the UI unreachable
+  version: 1.2.0
+- reason: UI does not load
+  version: 1.4.0
+latestHalyard: 1.49.0
+latestSpinnaker: 1.28.1
+versions:
+- alias: v1.28.1
+  changelog: https://spinnaker.io/changelogs/1.28.1-changelog/
+  lastUpdate: 1661279166000
+  minimumHalyardVersion: '1.45'
+  version: 1.28.1
+  <snip>
+```
+
+### Update versions.yml
+
+Add the new Spinnaker release version to `versions.yml`.
+
+```
+version=1.27.0
+halyard_version=1.45.0
+latest_halyard_version=1.51.0 # optional
+versions_yml_path=source_code/update_versions/versions.yml
+
+./dev/buildtool.sh update_versions \
+  --versions_yml_path "${versions_path}" \
+  --spinnaker_version "${version}" \
+  --minimum_halyard_version "${halyard_version}" \
+  --latest_halyard_version "${latest_halyard_version}"
+```
+
+To troubleshoot, check input and output `versions.yml` files.
+
+```
+diff \
+  source_code/fetch_versions/versions.yml \
+  source_code/update_versions/versions.yml \
+```
+
+### Publish versions.yml
+
+When ready to release the new Spinnaker version to users, publish the
+`versions.yml` file to GCS bucket.
+
+```
+versions_yml_path=source_code/update_versions/versions.yml
+
+./dev/buildtool.sh publish_versions \
+  --versions_yml_path "${versions_path}" \
+  --dry_run false
+```
+
+To troubleshoot, try a dry run (the default) to confirm paths are correct:
+
+```
+versions_yml_path=source_code/update_versions/versions.yml
+
+./dev/buildtool.sh publish_versions \
+  --versions_yml_path "${versions_path}" \
+  --dry_run true
+```

--- a/README.md
+++ b/README.md
@@ -39,14 +39,16 @@ See [testing/citest/README.md](testing/citest/README.md)
 run all unittests:
 
 ```
-./unittest/run_tests.sh
+# Avoid personal git config interfering with tests
+GIT_CONFIG_GLOBAL=/dev/null ./unittest/run_tests.sh
 
 ```
 
 run a specific test:
 
 ```
-python ./unittest/buildtool/git_support_test.py -v
+# Avoid personal git config interfering with tests
+GIT_CONFIG_GLOBAL=/dev/null python ./unittest/buildtool/git_support_test.py -v
 <snip>
 Ran 25 tests in 2.509s
 

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ versions:
 
 ### Update versions.yml
 
-Add the new Spinnaker release version to `versions.yml`.
+Add a new Spinnaker version to `versions.yml`.
 
 ```
 version=1.27.0
@@ -453,8 +453,8 @@ diff \
 
 ### Publish versions.yml
 
-When ready to release the new Spinnaker version to users, publish the
-`versions.yml` file to GCS bucket.
+When ready to release a new Spinnaker version to users, publish the
+`versions.yml` file to GCS.
 
 ```
 versions_yml_path=source_code/update_versions/versions.yml

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ The previous step created a branch in a local copy of your fork here:
 ### Fetch versions.yml
 
 Halyard uses `versions.yml` as the source of truth for available Spinnaker
-versions to deploy. Fetch the file from GCS bucket for editing.
+versions to deploy. Fetch the file from GCS for editing.
 
 ```
 ./dev/buildtool.sh fetch_versions

--- a/dev/buildtool/__init__.py
+++ b/dev/buildtool/__init__.py
@@ -32,11 +32,13 @@ SPINNAKER_HALYARD_REPOSITORY_NAME = "halyard"
 
 # Documentation is version agnostic
 SPINNAKER_IO_REPOSITORY_NAME = "spinnaker.io"
+SPINNAKER_CHANGELOG_BASE_URL = "https://spinnaker.io/changelogs"  # /M.m.p-changelog/
 
 # Artifact sources are per GitHub Action build jobs
 SPINNAKER_DEBIAN_REPOSITORY = "https://us-apt.pkg.dev/projects/spinnaker-community"
 SPINNAKER_DOCKER_REGISTRY = "us-docker.pkg.dev/spinnaker-community/docker"
 SPINNAKER_GOOGLE_IMAGE_PROJECT = "marketplace-spinnaker-release"
+SPINNAKER_HALYARD_GCS_BUCKET_NAME = "halconfig"
 
 
 from buildtool.util import (

--- a/dev/buildtool/__main__.py
+++ b/dev/buildtool/__main__.py
@@ -268,6 +268,7 @@ def main():
             "image",
             "source",
             "spinnaker",
+            "versions",
             "inspection",
         ]
     ]

--- a/dev/buildtool/requirements.txt
+++ b/dev/buildtool/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML
+schema
 
 # This is for testing
 python-dateutil

--- a/dev/buildtool/versions_commands.py
+++ b/dev/buildtool/versions_commands.py
@@ -177,7 +177,7 @@ class VersionsBuilder:
         minimum_halyard_version,
         latest_halyard_version=None,
     ):
-        """Build versions.yml. If an optional versions_dict is supplied then update."""
+        """Build versions.yml."""
 
         new_release = self.build_single_release_dict(
             new_spinnaker_version, minimum_halyard_version

--- a/dev/buildtool/versions_commands.py
+++ b/dev/buildtool/versions_commands.py
@@ -1,0 +1,432 @@
+# Copyright 2022 Salesforce.com Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implements versions commands for buildtool."""
+
+import copy
+import logging
+import time
+import yaml
+
+from schema import Optional, Regex, Schema, SchemaError
+
+from buildtool import (
+    SPINNAKER_HALYARD_GCS_BUCKET_NAME,
+    SPINNAKER_CHANGELOG_BASE_URL,
+    CommandFactory,
+    CommandProcessor,
+    check_options_set,
+    check_path_exists,
+    check_subprocess,
+    raise_and_log_error,
+    write_to_path,
+)
+
+# Three stable versions are maintained at a time. https://spinnaker.io/docs/releases/versions/
+MAXIMUM_SPINNAKER_RELEASE_COUNT = 3
+
+# https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+SEMVER_REGEX = r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+
+# https://github.com/spinnaker/halyard/blob/d6b5ec9b98d4903824c18a603884dde0c4f4165a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/Versions.java#L33
+VERSIONS_YML_SCHEMA = Schema(
+    {
+        Optional("illegalVersions"): [{"reason": str, "version": Regex(SEMVER_REGEX)}],
+        "latestHalyard": Regex(SEMVER_REGEX),
+        "latestSpinnaker": Regex(SEMVER_REGEX),
+        "versions": [
+            {
+                "alias": str,
+                "changelog": str,
+                "lastUpdate": int,
+                "minimumHalyardVersion": str,
+                "version": Regex(SEMVER_REGEX),
+            }
+        ],
+    }
+)
+
+
+def now():
+    """Hook for easier mocking."""
+    return time.time_ns() // 1_000_000
+
+
+class VersionsBuilder:
+    """Helper class for UpdateVersionsCommand that constructs the versions.yml specification."""
+
+    @staticmethod
+    def new_from_versions(versions):
+        """Create a new VersionsBuilder with the supplied versions.yml as a dict."""
+        return VersionsBuilder(base_versions=versions)
+
+    @property
+    def base_versions(self):
+        return self.__base_versions_dict
+
+    def __init__(self, base_versions=None):
+        """Construct new builder.
+
+        Args:
+          base_versions[dict]: If defined, this is a versions dict to start with.
+                          It is intended to support an "update" use case where
+                          only a subset of entries are updated within it.
+        """
+        self.__base_versions_dict = base_versions or {
+            "latestHalyard": "0.0.0",
+            "latestSpinnaker": "0.0.0",
+            "versions": [],
+        }
+
+    @staticmethod
+    def validate_versions_yml(versions_dict):
+        """Validate versions.yml adheres to schema."""
+        try:
+            VERSIONS_YML_SCHEMA.validate(versions_dict)
+            logging.debug("Validated versions.yml schema")
+        except SchemaError as se:
+            raise se
+
+    @staticmethod
+    def build_single_release_dict(spinnaker_version, minimum_halyard_version):
+        """Build a single release object for inclusion in available Spinnaker
+        versions list."""
+        current_epoch_ms = now()
+        release = {
+            "alias": f"v{spinnaker_version}",
+            "changelog": f"{SPINNAKER_CHANGELOG_BASE_URL}/{spinnaker_version}-changelog/",
+            "lastUpdate": current_epoch_ms,
+            "minimumHalyardVersion": f"{minimum_halyard_version}",
+            "version": spinnaker_version,
+        }
+        return release
+
+    @staticmethod
+    def get_major_minor_patch_version(version):
+        """Split a M.m.p version string into an list of [major, minor, patch]."""
+        major, minor, patch = version.split(".")
+        return [major, minor, patch]
+
+    def add_or_replace_release(self, new_release, versions):
+        """Add new minor release versions to version list. If it's a new patch
+        release version then find the previous patch version in the list and
+        replace it. For example 1.28.0 will be added. 1.27.1 will replace 1.27.0."""
+
+        new_release_semver = new_release["version"]
+
+        patched_existing_version = False
+
+        # loop over list in versions.yml["versions"]
+        for idx, existing_release in enumerate(versions):
+
+            existing_release_semver = existing_release["version"]
+
+            major1, minor1, patch1 = self.get_major_minor_patch_version(
+                new_release_semver
+            )
+            major2, minor2, patch2 = self.get_major_minor_patch_version(
+                existing_release_semver
+            )
+
+            # check if matching minor, eg: new 1.27.1 and current version_block is 1.27.x
+            if (major1 == major2) and (minor1 == minor2):
+                if patch1 == patch2:
+                    raise_and_log_error(
+                        ValueError(
+                            f"Spinnaker version already exists in versions.yml: {new_release_semver}"
+                        )
+                    )
+
+                elif patch1 < patch2:
+                    # new version older than previous release.
+                    # e.g: spinnaker_version = 1.27.0 but versions.yml has 1.27.1
+                    raise_and_log_error(
+                        ValueError(
+                            f"Spinnaker version {new_release_semver} superceded by newer patch version: {existing_release_semver}"
+                        )
+                    )
+
+                else:
+                    logging.info(
+                        "Replacing version %s with new version %s",
+                        existing_release_semver,
+                        new_release_semver,
+                    )
+                    versions[idx] = new_release
+                    patched_existing_version = True
+
+        if not patched_existing_version:
+            versions.append(new_release)
+
+        return versions
+
+    def build(
+        self,
+        new_spinnaker_version,
+        minimum_halyard_version,
+        latest_halyard_version=None,
+    ):
+        """Build versions.yml. If an optional versions_dict is supplied then update."""
+
+        new_release = self.build_single_release_dict(
+            new_spinnaker_version, minimum_halyard_version
+        )
+
+        logging.debug("Updating versions.yml with: %s", new_release)
+
+        updated_versions = self.add_or_replace_release(
+            new_release, self.__base_versions_dict["versions"]
+        )
+
+        sorted_versions = sorted(
+            updated_versions, key=lambda d: d["version"], reverse=True
+        )
+
+        trimmed_versions = sorted_versions[:MAXIMUM_SPINNAKER_RELEASE_COUNT]
+
+        final_versions = self.__base_versions_dict
+        final_versions["versions"] = trimmed_versions
+        final_versions["latestSpinnaker"] = final_versions["versions"][0]["version"]
+
+        if latest_halyard_version:
+            final_versions["latestHalyard"] = latest_halyard_version
+
+        self.validate_versions_yml(final_versions)
+
+        return final_versions
+
+
+class FetchVersionsFactory(CommandFactory):
+    """Fetches versions.yml file."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            "fetch_versions",
+            FetchVersionsCommand,
+            "Fetch Halyard's versions.yml file.",
+            **kwargs,
+        )
+
+
+class FetchVersionsCommand(CommandProcessor):
+    """Implements the fetch_versions command."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, factory, options, **kwargs):
+        options_copy = copy.copy(options)
+
+        super().__init__(factory, options_copy, **kwargs)
+
+    def _do_command(self):
+        """Implements CommandProcessor interface."""
+
+        logging.info(
+            "Fetching Spinnaker versions from gs://%s/versions.yml",
+            SPINNAKER_HALYARD_GCS_BUCKET_NAME,
+        )
+
+        version_data = check_subprocess(
+            f"gsutil cat gs://{SPINNAKER_HALYARD_GCS_BUCKET_NAME}/versions.yml"
+        )
+        versions_yaml = yaml.safe_load(version_data)
+
+        versions_text = yaml.safe_dump(versions_yaml, default_flow_style=False)
+        path = "output/fetch_versions/versions.yml"
+        write_to_path(versions_text, path)
+        logging.info("Wrote Spinnaker versions to %s", path)
+
+
+class UpdateVersionsFactory(CommandFactory):
+    """Updates versions.yml file."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            "update_versions",
+            UpdateVersionsCommand,
+            "Update Halyard's versions.yml and write it out to a file.",
+            **kwargs,
+        )
+
+    def init_argparser(self, parser, defaults):
+        """Adds command-specific arguments."""
+        super().init_argparser(parser, defaults)
+
+        self.add_argument(
+            parser,
+            "versions_yml_path",
+            defaults,
+            None,
+            help="The path to the local versions.yml file to update.",
+        )
+
+        self.add_argument(
+            parser,
+            "latest_halyard_version",
+            defaults,
+            None,
+            help="The latest Halyard version, not necessarily the latest required by Spinnaker.",
+        )
+
+        self.add_argument(
+            parser,
+            "spinnaker_version",
+            defaults,
+            None,
+            help="The new version to add.",
+        )
+
+        self.add_argument(
+            parser,
+            "minimum_halyard_version",
+            defaults,
+            None,
+            help="The minimum Halyard version required for spinnaker_version.",
+        )
+
+
+class UpdateVersionsCommand(CommandProcessor):
+    """Implements the update_versions command."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, factory, options, **kwargs):
+        check_options_set(
+            options,
+            [
+                "versions_yml_path",
+                # "latest_halyard_version" # optional
+                "spinnaker_version",
+                "minimum_halyard_version",
+            ],
+        )
+
+        super().__init__(factory, options, **kwargs)
+
+    def __load_versions_from_path(self, path):
+        """Load versions.yml from a file."""
+        logging.debug("Loading versions.yml from %s", path)
+        with open(path, encoding="utf-8") as f:
+            versions_yaml_string = f.read()
+        versions_dict = yaml.safe_load(versions_yaml_string)
+
+        return versions_dict
+
+    def _do_command(self):
+        """Implements CommandProcessor interface."""
+        options = self.options
+
+        check_path_exists(options.versions_yml_path, why="options.versions_yml_path")
+        versions_dict = self.__load_versions_from_path(options.versions_yml_path)
+
+        if options.latest_halyard_version is None:
+            logging.debug(
+                "latest_halyard_version not set, using existing value from versions.yml: %s",
+                versions_dict["latestHalyard"],
+            )
+            options.latest_halyard_version = versions_dict["latestHalyard"]
+
+        builder = VersionsBuilder.new_from_versions(versions_dict)
+
+        updated_versions = builder.build(
+            options.spinnaker_version,
+            options.minimum_halyard_version,
+            options.latest_halyard_version,
+        )
+
+        versions_text = yaml.safe_dump(updated_versions, default_flow_style=False)
+        path = "output/update_versions/versions.yml"
+        write_to_path(versions_text, path)
+        logging.info("Wrote Spinnaker versions to %s", path)
+
+
+class PublishVersionsFactory(CommandFactory):
+    """Publish versions.yml file."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            "publish_versions",
+            PublishVersionsCommand,
+            "Publish Halyard's versions.yml.",
+            **kwargs,
+        )
+
+    def init_argparser(self, parser, defaults):
+        super().init_argparser(parser, defaults)
+
+        self.add_argument(
+            parser,
+            "versions_yml_path",
+            defaults,
+            None,
+            help="The path to the local versions.yml file to publish.",
+        )
+
+        self.add_argument(
+            parser,
+            "dry_run",
+            defaults,
+            True,
+            type=bool,
+            help="Show proposed actions, don't actually do them. Default True.",
+        )
+
+
+class PublishVersionsCommand(CommandProcessor):
+    """Implements publish_versions command."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, factory, options, **kwargs):
+        check_options_set(options, ["versions_yml_path"])
+        check_path_exists(options.versions_yml_path, why="versions_yml_path")
+
+        options_copy = copy.copy(options)
+        super().__init__(factory, options_copy, **kwargs)
+
+    def gcs_upload(self, file, url):
+        """Upload file to GCS Bucket"""
+        result = check_subprocess(f"gsutil cp {file} {url}")
+        logging.info("Published versions.yml: %s", result)
+
+    def _do_command(self):
+        """Implements CommandProcessor interface."""
+        options = self.options
+
+        versions_url = f"gs://{SPINNAKER_HALYARD_GCS_BUCKET_NAME}/versions.yml"
+
+        if options.dry_run:
+            logging.info(
+                "Dry run selected, not publishing %s to: %s",
+                options.versions_yml_path,
+                versions_url,
+            )
+        else:
+            logging.info(
+                "Publishing %s to: %s", options.versions_yml_path, versions_url
+            )
+            self.gcs_upload(options.versions_yml_path, versions_url)
+
+
+def register_commands(registry, subparsers, defaults):
+    """Registers all the commands for this module."""
+    FetchVersionsFactory().register(registry, subparsers, defaults)
+    UpdateVersionsFactory().register(registry, subparsers, defaults)
+    PublishVersionsFactory().register(registry, subparsers, defaults)

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML>=3.13
+schema>=0.7.5
 PyGithub>=1.32
 google-cloud-pubsub>=0.40.0
 google-cloud-storage>=1.14.0

--- a/unittest/buildtool/standard_test_versions.yml
+++ b/unittest/buildtool/standard_test_versions.yml
@@ -1,0 +1,23 @@
+illegalVersions:
+- reason: Broken apache config makes the UI unreachable
+  version: 1.2.0
+- reason: UI does not load
+  version: 1.4.0
+latestHalyard: 1.49.0
+latestSpinnaker: 1.28.1
+versions:
+- alias: v1.28.1
+  changelog: https://spinnaker.io/changelogs/1.28.1-changelog/
+  lastUpdate: 1661279166000
+  minimumHalyardVersion: '1.45'
+  version: 1.28.1
+- alias: v1.27.1
+  changelog: https://spinnaker.io/changelogs/1.27.1-changelog/
+  lastUpdate: 1660858660000
+  minimumHalyardVersion: '1.45'
+  version: 1.27.1
+- alias: v1.26.7
+  changelog: https://gist.github.com/spinnaker-release/e3714a97bbdd3e7c3b4d92adec938e7f
+  lastUpdate: 1625100544812
+  minimumHalyardVersion: '1.41'
+  version: 1.26.7

--- a/unittest/buildtool/test_util.py
+++ b/unittest/buildtool/test_util.py
@@ -170,6 +170,18 @@ class BaseTestFixture(unittest.TestCase):
         options.output_dir = os.path.join(self.test_root, "output_dir")
         return options
 
+    def patch_function(self, name):
+        patcher = patch(name)
+        hook = patcher.start()
+        self.addCleanup(patcher.stop)
+        return hook
+
+    def patch_method(self, klas, method):
+        patcher = patch.object(klas, method)
+        hook = patcher.start()
+        self.addCleanup(patcher.stop)
+        return hook
+
     def setUp(self):
         self.test_root = os.path.join(self.base_temp_dir, self._testMethodName)
         self.options = self.make_test_options()
@@ -207,18 +219,6 @@ class BaseGitRepoTestFixture(BaseTestFixture):
     @classmethod
     def to_origin(cls, repo_name):
         return cls.repo_commit_map[repo_name]["ORIGIN"]
-
-    def patch_function(self, name):
-        patcher = patch(name)
-        hook = patcher.start()
-        self.addCleanup(patcher.stop)
-        return hook
-
-    def patch_method(self, klas, method):
-        patcher = patch.object(klas, method)
-        hook = patcher.start()
-        self.addCleanup(patcher.stop)
-        return hook
 
     def setUp(self):
         super().setUp()

--- a/unittest/buildtool/versions_command_test.py
+++ b/unittest/buildtool/versions_command_test.py
@@ -1,0 +1,290 @@
+# Copyright 2022 Salesforce.com, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import unittest
+from unittest.mock import patch
+import yaml
+
+from test_util import init_runtime, BaseTestFixture
+
+from buildtool import SPINNAKER_HALYARD_GCS_BUCKET_NAME, SPINNAKER_CHANGELOG_BASE_URL
+
+import buildtool.__main__ as bomtool_main
+import buildtool.versions_commands
+
+from buildtool.versions_commands import (
+    VersionsBuilder,
+    PublishVersionsCommand,
+    MAXIMUM_SPINNAKER_RELEASE_COUNT,
+)
+
+
+class TestVersionsBuilder(BaseTestFixture):
+    """Test Version Builder."""
+
+    def setUp(self):
+        super().setUp()
+        self.test_root = os.path.join(self.base_temp_dir, self._testMethodName)
+
+    def test_build_single_version_dict(self):
+        """A single release version"""
+        builder = VersionsBuilder()
+
+        with patch("buildtool.versions_commands.now") as mock_now:
+            mock_now.return_value = 1234567890000
+            got = builder.build_single_release_dict(
+                "1.29.0",
+                "1.50.0",
+            )
+
+        expected = {
+            "alias": "v1.29.0",
+            "changelog": f"{SPINNAKER_CHANGELOG_BASE_URL}/1.29.0-changelog/",
+            "lastUpdate": 1234567890000,
+            "minimumHalyardVersion": "1.50.0",
+            "version": "1.29.0",
+        }
+        self.assertDictEqual(expected, got)
+
+    def test_get_major_minor_patch_version(self):
+        """A version string should get split into an array of strings: major, minor, patch."""
+        version = "1.2.3"
+        expected = ["1", "2", "3"]
+        builder = VersionsBuilder()
+        got = builder.get_major_minor_patch_version(version)
+        self.assertListEqual(expected, got)
+
+    def test_add_or_replace_release_new_minor(self):
+        """A new minor version should be added to versions.yml and the list of
+        versions should increase by one."""
+        builder = VersionsBuilder()
+
+        release_100 = builder.build_single_release_dict("1.0.0", "1.50.0")
+        release_110 = builder.build_single_release_dict("1.1.0", "1.50.0")
+        release_120 = builder.build_single_release_dict("1.2.0", "1.50.0")
+        releases = [release_100, release_110, release_120]
+
+        release_140 = builder.build_single_release_dict("1.4.0", "1.50.0")
+
+        got = builder.add_or_replace_release(release_140, releases)
+
+        self.assertEqual(len(got), 4)  # count of releases has increased
+        self.assertDictEqual(got[-1], release_140)
+
+    def test_add_or_replace_release_new_patch(self):
+        """A new patch version should replace existing in versions.yml and
+        there should remain our accepted maximum versions in the list."""
+        builder = VersionsBuilder()
+
+        release_100 = builder.build_single_release_dict("1.0.0", "1.50.0")
+        release_110 = builder.build_single_release_dict("1.1.0", "1.50.0")
+        release_120 = builder.build_single_release_dict("1.2.0", "1.50.0")
+        releases = [release_100, release_110, release_120]
+
+        release_111 = builder.build_single_release_dict("1.1.1", "1.50.0")
+
+        got = builder.add_or_replace_release(release_111, releases)
+
+        self.assertEqual(len(got), 3)  # count of releases has not increased
+        self.assertDictEqual(got[1], release_111)  # replaced 1.1.0 at index '0'
+
+    def test_add_or_replace_release_minor_already_exists(self):
+        """Adding a duplicate new version should error."""
+        builder = VersionsBuilder()
+
+        release_100 = builder.build_single_release_dict("1.0.0", "1.50.0")
+        release_110 = builder.build_single_release_dict("1.1.0", "1.50.0")
+        release_120 = builder.build_single_release_dict("1.2.0", "1.50.0")
+
+        releases = [release_100, release_110, release_120]
+
+        with self.assertRaises(ValueError):
+            builder.add_or_replace_release(release_120, releases)
+
+    def test_build_new_version_latest_halyard_unchanged(self):
+        """Adding a new version should update all of the fields."""
+
+        path = os.path.join(os.path.dirname(__file__), "standard_test_versions.yml")
+        with open(path, encoding="utf-8") as f:
+            versions_yaml_string = f.read()
+        versions_dict = yaml.safe_load(versions_yaml_string)
+
+        builder = VersionsBuilder.new_from_versions(versions_dict)
+
+        spinnaker_version = "1.29.0"
+        minimum_halyard_version = "1.75.0"
+        latest_halyard_version = "1.99.0"
+        got = builder.build(
+            spinnaker_version,
+            minimum_halyard_version,
+            latest_halyard_version,
+        )
+
+        self.assertEqual(len(got["versions"]), MAXIMUM_SPINNAKER_RELEASE_COUNT)
+        self.assertEqual(got["latestSpinnaker"], spinnaker_version)
+        self.assertEqual(got["latestHalyard"], latest_halyard_version)
+
+    def test_build_new_version_latest_halyard_changed(self):
+        """Adding a new version should update all of the fields."""
+
+        path = os.path.join(os.path.dirname(__file__), "standard_test_versions.yml")
+        with open(path, encoding="utf-8") as f:
+            versions_yaml_string = f.read()
+        versions_dict = yaml.safe_load(versions_yaml_string)
+
+        builder = VersionsBuilder.new_from_versions(versions_dict)
+
+        spinnaker_version = "1.27.2"
+        minimum_halyard_version = "1.46"
+        got = builder.build(
+            spinnaker_version,
+            minimum_halyard_version,
+        )
+
+        self.assertEqual(len(got["versions"]), MAXIMUM_SPINNAKER_RELEASE_COUNT)
+        self.assertEqual(got["latestSpinnaker"], "1.28.1")  # standard_test_versions.yml
+        self.assertEqual(got["latestHalyard"], "1.49.0")  # standard_test_versions.yml
+
+
+class TestUpdateVersionsCommand(BaseTestFixture):
+    """Test update_versions command."""
+
+    def setUp(self):
+        super().setUp()
+        self.parser = argparse.ArgumentParser()
+        self.subparsers = self.parser.add_subparsers()
+
+    def test_default_update_versions_options(self):
+        """Test update_versions default argument options"""
+        registry = {}
+        buildtool.versions_commands.register_commands(registry, self.subparsers, {})
+        self.assertTrue("update_versions" in registry)
+
+        options = self.parser.parse_args(["update_versions"])
+        option_dict = vars(options)
+
+        for key in [
+            "versions_yml_path",
+            "latest_halyard_version",
+            "spinnaker_version",
+            "minimum_halyard_version",
+        ]:
+            self.assertIsNone(option_dict[key])
+
+    def test_update_versions(self):
+        """Fail updating versions.yml if the new version is an older patch
+        version"""
+
+        options = self.options
+        options.versions_yml_path = os.path.join(
+            os.path.dirname(__file__), "standard_test_versions.yml"
+        )
+        options.spinnaker_version = "1.29.0"  # not in standard_test_versions.yml
+        options.minimum_halyard_version = "1.99.1"
+        options.latest_halyard_version = None
+
+        defaults = vars(self.options)
+        parser = argparse.ArgumentParser()
+        registry = bomtool_main.make_registry(
+            [buildtool.versions_commands], parser, defaults
+        )
+        bomtool_main.add_standard_parser_args(parser, defaults)
+        factory = registry["update_versions"]
+        command = factory.make_command(options)
+
+        command()
+
+
+class TestPublishVersionsCommand(BaseTestFixture):
+    """Test publish_versions command."""
+
+    def setUp(self):
+        super().setUp()
+        self.parser = argparse.ArgumentParser()
+        self.subparsers = self.parser.add_subparsers()
+
+    def test_default_publish_versions_options(self):
+        """Test publish_versions default argument options"""
+        registry = {}
+        buildtool.versions_commands.register_commands(registry, self.subparsers, {})
+        self.assertTrue("publish_versions" in registry)
+
+        options = self.parser.parse_args(["publish_versions"])
+        option_dict = vars(options)
+
+        self.assertEqual(True, options.dry_run)
+
+        self.assertIsNone(option_dict["versions_yml_path"])
+
+    def test_publish_versions_dry_run(self):
+        """Test publish_versions with dry_run enabled.
+        gcs_upload function should not be called."""
+
+        options = self.options
+
+        options.versions_yml_path = os.path.join(
+            os.path.dirname(__file__), "standard_test_versions.yml"
+        )
+        options.dry_run = True
+
+        mock_gcs_upload = self.patch_method(PublishVersionsCommand, "gcs_upload")
+
+        defaults = vars(self.options)
+        parser = argparse.ArgumentParser()
+        registry = bomtool_main.make_registry(
+            [buildtool.versions_commands], parser, defaults
+        )
+        bomtool_main.add_standard_parser_args(parser, defaults)
+        factory = registry["publish_versions"]
+        command = factory.make_command(options)
+        command()
+
+        self.assertEqual(0, mock_gcs_upload.call_count)
+
+    def test_publish_versions(self):
+        """Test publish_versions with dry_run disabled.
+        Verify mocked gsutil command is called with test versions.yml file
+        path and GCS Bucket url."""
+
+        options = self.options
+
+        options.versions_yml_path = os.path.join(
+            os.path.dirname(__file__), "standard_test_versions.yml"
+        )
+        options.dry_run = False
+
+        mock_gcs_upload = self.patch_method(PublishVersionsCommand, "gcs_upload")
+
+        defaults = vars(self.options)
+        parser = argparse.ArgumentParser()
+        registry = bomtool_main.make_registry(
+            [buildtool.versions_commands], parser, defaults
+        )
+        bomtool_main.add_standard_parser_args(parser, defaults)
+        factory = registry["publish_versions"]
+        command = factory.make_command(options)
+        command()
+
+        # dry run disabled, upload versions.yml file (path on disk) to GCS bucket
+        mock_gcs_upload.assert_called_once_with(
+            options.versions_yml_path,
+            f"gs://{SPINNAKER_HALYARD_GCS_BUCKET_NAME}/versions.yml",
+        )
+
+
+if __name__ == "__main__":
+    init_runtime()
+    unittest.main(verbosity=2)

--- a/unittest/buildtool/versions_command_test.py
+++ b/unittest/buildtool/versions_command_test.py
@@ -114,6 +114,24 @@ class TestVersionsBuilder(BaseTestFixture):
         with self.assertRaises(ValueError):
             builder.add_or_replace_release(release_120, releases)
 
+    def test_build_new_version_with_default_base(self):
+        """Adding a new version to default base_versions_dict should update all of the fields."""
+
+        builder = VersionsBuilder()
+
+        spinnaker_version = "1.29.0"
+        minimum_halyard_version = "1.75.0"
+        latest_halyard_version = "1.99.0"
+        got = builder.build(
+            spinnaker_version,
+            minimum_halyard_version,
+            latest_halyard_version,
+        )
+
+        self.assertEqual(len(got["versions"]), 1)
+        self.assertEqual(got["latestSpinnaker"], spinnaker_version)
+        self.assertEqual(got["latestHalyard"], latest_halyard_version)
+
     def test_build_new_version_latest_halyard_unchanged(self):
         """Adding a new version should update all of the fields."""
 


### PR DESCRIPTION
versions.yml:
- fetch versions.yml from Halyard's GCS bucket
- update versions.yml with new Spinnaker Version
  - replace any previous patch, eg: `1.27.1` will replace `1.27.0`
  - add any new minor, eg: `1.28.0`
  - keep at most 3 minor variations, eg: 1.27.1, 1.26.7, 1.25.6
  - validate versions.yml conforms to schema (Halyard java)
- publish versions.yml to Halyard's GCS bucket

additional:
- enable all Test classes to patch methods. This means we can use a base Test class instead of having to use a Git specific test class that does setup/teardown tasks that aren't needed.
- show in docs how to bypass local git config which can interfere with test runs (git commit/tag editor interaction)