### PR TITLE
feat(ci): Publish Spinnaker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,29 @@ FAILED (errors=4)
 
 ## Release
 
+Publish a new Spinnaker release in a single command.
+
+By default `buildtool`:
+
+1. targets `github.com/spinnaker` repositories.
+2. does a dry run, doing all the steps but without pushing back up to git or to
+   any artifact repositories like GCS.
+
+```
+version=1.27.0
+min_hal_version=1.45
+fork_owner=<you>
+
+./dev/buildtool.sh \
+  publish_spinnaker \
+  --spinnaker_version "${version}" \
+  --minimum_halyard_version "${min_hal_version}" \
+  --dry_run true \
+  --github_owner "${fork_owner}"
+```
+
+## Release - Step by Step
+
 ### Tag branches
 
 Tag repositories with their respective next tag.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ By default `buildtool`:
 2. does a dry run, doing all the steps but without pushing back up to git or to
    any artifact repositories like GCS.
 
+When releasing a new minor version `x.y.0` make sure to update the Release
+Notes per: [Add next release preview](https://github.com/spinnaker/buildtool#for-new-minor-xy0-releases---add-next-release-preview)
+
 ```
 version=1.27.0
 min_hal_version=1.45

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ FAILED (errors=4)
 
 ## Release
 
+WARNING: `release-*` branches must be tagged and bumpdeps propagated before
+running this because buildtool tagging & branch creation is disabled in the
+`publish_spinnaker` command below.
+
 Publish a new Spinnaker release in a single command.
 
 By default `buildtool`:

--- a/dev/buildtool/bom_commands.py
+++ b/dev/buildtool/bom_commands.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Implements build_bom command for buildtool."""
+"""Implements bom commands for buildtool."""
 
 import datetime
 import logging

--- a/dev/buildtool/bom_commands.py
+++ b/dev/buildtool/bom_commands.py
@@ -25,10 +25,10 @@ from buildtool import (
     SPINNAKER_DEBIAN_REPOSITORY,
     SPINNAKER_DOCKER_REGISTRY,
     SPINNAKER_GOOGLE_IMAGE_PROJECT,
+    BomSourceCodeManager,
     BranchSourceCodeManager,
     RepositoryCommandFactory,
     RepositoryCommandProcessor,
-    HalRunner,
     GitRunner,
     check_path_exists,
     raise_and_log_error,
@@ -242,7 +242,7 @@ class BuildBomCommand(RepositoryCommandProcessor):
             logging.debug(
                 'Using base bom version "%s"', options.refresh_from_bom_version
             )
-            base_bom = HalRunner(options).retrieve_bom_version(
+            base_bom = BomSourceCodeManager.bom_from_gcs_bucket(
                 options.refresh_from_bom_version
             )
         else:
@@ -292,7 +292,6 @@ class BuildBomCommandFactory(RepositoryCommandFactory):
 
     def init_argparser(self, parser, defaults):
         super().init_argparser(parser, defaults)
-        HalRunner.add_parser_args(parser, defaults)
 
         self.add_argument(
             parser,
@@ -341,7 +340,7 @@ class BuildBomCommandFactory(RepositoryCommandFactory):
             defaults,
             None,
             help="Similar to refresh_from_bom_path but using a version obtained."
-            " from halyard.",
+            " from GCS Bucket.",
         )
         self.add_argument(
             parser,

--- a/dev/buildtool/changelog_commands.py
+++ b/dev/buildtool/changelog_commands.py
@@ -26,6 +26,7 @@ import yaml
 
 from buildtool import (
     SPINNAKER_IO_REPOSITORY_NAME,
+    SPINNAKER_HALYARD_GCS_BUCKET_NAME,
     CommandFactory,
     CommandProcessor,
     RepositoryCommandFactory,
@@ -36,7 +37,6 @@ from buildtool import (
     UnexpectedError,
     CommitMessage,
     GitRunner,
-    HalRunner,
     check_kwargs_empty,
     check_options_set,
     check_path_exists,
@@ -304,7 +304,7 @@ class BuildChangelogCommand(RepositoryCommandProcessor):
             with open(options.relative_to_bom_path, encoding="utf-8") as stream:
                 self.__relative_bom = yaml.safe_load(stream.read())
         elif options.relative_to_bom_version:
-            self.__relative_bom = HalRunner(options).retrieve_bom_version(
+            self.__relative_bom = BomSourceCodeManager.bom_from_gcs_bucket(
                 options.relative_to_bom_version
             )
         else:
@@ -347,7 +347,7 @@ class BuildChangelogFactory(RepositoryCommandFactory):
             BuildChangelogCommand,
             "Build a git changelog and write it out to a file.",
             BomSourceCodeManager,
-            **kwargs
+            **kwargs,
         )
 
     def init_argparser(self, parser, defaults):
@@ -364,7 +364,6 @@ class BuildChangelogFactory(RepositoryCommandFactory):
             " in time sequence in the changelog.",
         )
 
-        HalRunner.add_parser_args(parser, defaults)
         self.add_argument(
             parser,
             "relative_to_bom_path",
@@ -392,7 +391,7 @@ class PublishChangelogFactory(RepositoryCommandFactory):
             PublishChangelogCommand,
             "Publish Spinnaker version Changelog to spinnaker.io.",
             BranchSourceCodeManager,
-            **kwargs
+            **kwargs,
         )
 
     def init_argparser(self, parser, defaults):
@@ -427,7 +426,7 @@ class PublishChangelogCommand(RepositoryCommandProcessor):
             factory,
             make_options_with_fallback(options),
             source_repository_names=[SPINNAKER_IO_REPOSITORY_NAME],
-            **kwargs
+            **kwargs,
         )
 
     def _do_repository(self, repository):

--- a/dev/buildtool/source_commands.py
+++ b/dev/buildtool/source_commands.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Implements fetch_source command for buildtool."""
+"""Implements source commands for buildtool."""
 
 import logging
 import os

--- a/dev/buildtool/spinnaker_commands.py
+++ b/dev/buildtool/spinnaker_commands.py
@@ -237,11 +237,12 @@ class PublishSpinnakerCommand(CommandProcessor):
         release_branch = f"release-{major_minor}.x"
 
         # Tag branches and create release-* branches as required
-        if is_new_minor_version(options.spinnaker_version):
-            self.__tag_branches("master", copy.copy(options))
-            self.__create_branches(release_branch, copy.copy(options))
-        else:
-            self.__tag_branches(release_branch, copy.copy(options))
+        # TODO: Reconcile bumpdeps. Until then tag and branch manually.
+        # if is_new_minor_version(options.spinnaker_version):
+        #     self.__tag_branches("master", copy.copy(options))
+        #     self.__create_branches(release_branch, copy.copy(options))
+        # else:
+        #     self.__tag_branches(release_branch, copy.copy(options))
 
         # TODO: Validation each repository gradle.properties has correct dependency versions.
 

--- a/dev/buildtool/spinnaker_commands.py
+++ b/dev/buildtool/spinnaker_commands.py
@@ -62,7 +62,7 @@ class PublishSpinnakerFactory(CommandFactory):
             "minimum_halyard_version",
             defaults,
             None,
-            help="The minimum halyard version required if changed.",
+            help="The minimum halyard version required for this release.",
         )
         self.add_argument(
             parser,

--- a/unittest/buildtool/spinnaker_commands_test.py
+++ b/unittest/buildtool/spinnaker_commands_test.py
@@ -13,19 +13,11 @@
 # limitations under the License.
 
 import argparse
-import datetime
-import os
-import tempfile
-import textwrap
 import unittest
 
-import yaml
+from test_util import init_runtime, BaseGitRepoTestFixture
 
-import buildtool.__main__ as bomtool_main
 import buildtool.spinnaker_commands
-from buildtool import GitRunner
-
-from test_util import EXTRA_REPO, init_runtime, BaseGitRepoTestFixture
 
 
 class TestSpinnakerCommandFixture(BaseGitRepoTestFixture):
@@ -33,6 +25,24 @@ class TestSpinnakerCommandFixture(BaseGitRepoTestFixture):
         super().setUp()
         self.parser = argparse.ArgumentParser()
         self.subparsers = self.parser.add_subparsers(title="command", dest="command")
+
+    def test_default_publish_spinnaker_options(self):
+        """Test publish_spinnaker default argument options"""
+        registry = {}
+        buildtool.spinnaker_commands.register_commands(registry, self.subparsers, {})
+        self.assertTrue("publish_spinnaker" in registry)
+
+        options = self.parser.parse_args(["publish_spinnaker"])
+        option_dict = vars(options)
+
+        for key in [
+            "spinnaker_version",
+            "latest_halyard_version",
+            "minimum_halyard_version",
+        ]:
+            self.assertIsNone(option_dict[key])
+
+        self.assertEqual(options.dry_run, True)
 
 
 if __name__ == "__main__":

--- a/unittest/buildtool/test_util.py
+++ b/unittest/buildtool/test_util.py
@@ -186,6 +186,18 @@ class BaseTestFixture(unittest.TestCase):
         self.test_root = os.path.join(self.base_temp_dir, self._testMethodName)
         self.options = self.make_test_options()
 
+    def patch_function(self, name):
+        patcher = patch(name)
+        hook = patcher.start()
+        self.addCleanup(patcher.stop)
+        return hook
+
+    def patch_method(self, klas, method):
+        patcher = patch.object(klas, method)
+        hook = patcher.start()
+        self.addCleanup(patcher.stop)
+        return hook
+
 
 class BaseGitRepoTestFixture(BaseTestFixture):
     @classmethod


### PR DESCRIPTION
This PR:
1. creates a new `publish_spinnaker --spinnaker_version 1.29.1 ...` command which is going to be our orchestrator and entrypoint for doing all the things. To date we've been running commands manually.
2. wires up existing functionality into this command
3. adds missing publish bom, publish changelog (that we used for 1.29.0 release)
4. works directly with GCS buckets rather than leveraging a Halyard running somewhere
5. defaults to `--dry_run true`
6. was run against fork `--github_owner kskewes-sf`

Overall we still need to:
1. add a mechanism for handling bumpdeps. Potentially we bump kork, fiat, orca by hand, wait for final bumpdep, then run `buildtool publish_spinnaker` to do the rest.
2. add method to confirm `gradle.properties` versions are all in sync
3. add `regctl` binary to Dockerfile and commands for container tagging
4. wire up a GitHub Action
5. TBD