### PR TITLE
feat(ci): Add GHA manual workflow trigger support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: 'release: ${{ inputs.spinnakerVersion }} - halyard: ${{ inputs.minimumHalyardVersion }} - dry run: ${{ inputs.dryRun }}'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,25 @@
 name: Release
 
 on:
-  push:
-    tags:
-    - "v[0-9]+.[0-9]+.[0-9]+"
-    - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
-
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Release version, for example: v1.30.0, v1.31.1-rc.1'
+      spinnakerVersion:
+        description: 'Spinnaker release version, for example: 1.30.0 or 1.30.1'
+        type: string
+        required: true
+      minimumHalyardVersion:
+        description: 'Minimum Halyard version required for release, "major.minor", For example: 1.45'
+        default: '1.45'
         type: string
         required: true
       dryRun:
-        description: 'Perform a dry_run regardless of tag. "-rc*" are always dry run.'
+        description: 'Perform a dry run without publishing to git or artifact repositories.'
         default: 'true'
         options:
         - 'true'
         - 'false'
         type: choice
         required: true
-
-env:
-  # Bump this when new releases require a newer Halyard version.
-  MINIMUM_HALYARD_VERSION: "1.45"
 
 jobs:
   release:
@@ -51,42 +47,17 @@ jobs:
         run: |
           echo REPOSITORY_OWNER="${GITHUB_REPOSITORY%/*}" >> $GITHUB_OUTPUT
 
-          if [[ "${{ inputs.tag }}" != "" ]]; then
-            tag="${{ inputs.tag }}"
-          else
-            tag="$( echo ${{ github.ref }} | sed 's@refs/tags/@@')"
-          fi
-          echo "Using tag: ${tag}"
+          echo "Running publish_spinnaker for:
+            release version: ${{ inputs.spinnakerVersion }}
+            minimum Halyard version: ${{ inputs.minimumHalyardVersion }}
+            dry run enabled: ${{ inputs.dryRun }}"
 
-          semver="${tag##v}"
-          echo "Using semver: ${semver}"
-
-          if [[ "${semver}" == *-rc* ]]; then
-            echo "Release candidate detected."
-            rc="true"
-            version="${semver%%-rc*}"
-          else
-           echo "Final version detected."
-           rc="false"
-           version="${semver}"
-          fi
-
-          if [[ "${{ inputs.dryRun }}" == "true" ]]; then
-            echo "Manual trigger with dry run selected, overriding release candidate status."
-            rc="true"
-          fi
-
-          echo IS_CANDIDATE="${rc}" >> $GITHUB_OUTPUT
-          echo VERSION="${version}" >> $GITHUB_OUTPUT
-
-          echo "Running publish_spinnaker for version: ${version} - release candidate: ${rc}"
-
-      - name: Publish release - dry run
+      - name: Publish release
         run: |
           ./dev/buildtool.sh \
             publish_spinnaker \
-            --spinnaker_version "${{ steps.release_info.outputs.VERSION }}" \
-            --minimum_halyard_version "${{ env.MINIMUM_HALYARD_VERSION }}" \
+            --spinnaker_version "${{ inputs.spinnakerVersion }}" \
+            --minimum_halyard_version "${{ inputs.minimumHalyardVersion }}" \
             --github_owner "${{ steps.release_info.outputs.REPOSITORY_OWNER }}" \
             --dry_run true
 
@@ -101,7 +72,7 @@ jobs:
       - name: Attach output files to GHA Job
         uses: actions/upload-artifact@v3
         with:
-          name: spinnaker_release_${{ steps.release_info.outputs.VERSION }}
+          name: spinnaker_release_${{ inputs.spinnakerVersion }}
           path: |
             output/build_bom/*.yml
             output/publish_spinnaker/changelog.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,21 @@ on:
     - "v[0-9]+.[0-9]+.[0-9]+"
     - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
 
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release version, for example: v1.30.0, v1.31.1-rc.1'
+        type: string
+        required: true
+      dryRun:
+        description: 'Perform a dry_run regardless of tag. "-rc*" are always dry run.'
+        default: 'true'
+        options:
+        - 'true'
+        - 'false'
+        type: choice
+        required: true
+
 env:
   # Bump this when new releases require a newer Halyard version.
   MINIMUM_HALYARD_VERSION: "1.45"
@@ -35,21 +50,38 @@ jobs:
         id: release_info
         run: |
           echo REPOSITORY_OWNER="${GITHUB_REPOSITORY%/*}" >> $GITHUB_OUTPUT
-          tag="$( echo ${{ github.ref }} | sed 's@refs/tags/@@')"
-          version="${tag##v}"
-          echo "Running publish_spinnaker for version: ${version}"
-          if [[ "${version}" == *-rc* ]]; then
-            echo "Release candidate detected."
-            echo IS_CANDIDATE="true" >> $GITHUB_OUTPUT
-            echo VERSION="${version%%-rc*}" >> $GITHUB_OUTPUT
-            echo "Version: ${version%%-rc*}"
+
+          if [[ "${{ inputs.tag }}" != "" ]]; then
+            tag="${{ inputs.tag }}"
           else
-            echo IS_CANDIDATE="false" >> $GITHUB_OUTPUT
-            echo VERSION="${version}" >> $GITHUB_OUTPUT
-            echo "Version: ${version}"
+            tag="$( echo ${{ github.ref }} | sed 's@refs/tags/@@')"
+          fi
+          echo "Using tag: ${tag}"
+
+          semver="${tag##v}"
+          echo "Using semver: ${semver}"
+
+          if [[ "${semver}" == *-rc* ]]; then
+            echo "Release candidate detected."
+            rc="true"
+            version="${semver%%-rc*}"
+          else
+           echo "Final version detected."
+           rc="false"
+           version="${semver}"
           fi
 
-      - name: Run dry_run of release
+          if [[ "${{ inputs.dryRun }}" == "true" ]]; then
+            echo "Manual trigger with dry run selected, overriding release candidate status."
+            rc="true"
+          fi
+
+          echo IS_CANDIDATE="${rc}" >> $GITHUB_OUTPUT
+          echo VERSION="${version}" >> $GITHUB_OUTPUT
+
+          echo "Running publish_spinnaker for version: ${version} - release candidate: ${rc}"
+
+      - name: Publish release - dry run
         run: |
           ./dev/buildtool.sh \
             publish_spinnaker \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
             --spinnaker_version "${{ inputs.spinnakerVersion }}" \
             --minimum_halyard_version "${{ inputs.minimumHalyardVersion }}" \
             --github_owner "${{ steps.release_info.outputs.REPOSITORY_OWNER }}" \
-            --dry_run true
+            --dry_run ${{ inputs.dryRun }}
 
       - name: Cat output files for review
         run: |

--- a/README.md
+++ b/README.md
@@ -57,20 +57,40 @@ FAILED (errors=4)
 
 ## Release
 
-WARNING: `release-*` branches must be tagged and bumpdeps propagated before
-running this because buildtool tagging & branch creation is disabled in the
-`publish_spinnaker` command below.
+WARNING: Before performing a release:
 
-Publish a new Spinnaker release in a single command.
+- `release-*` branches must be created
+- branches tagged
+- bumpdeps propagated
 
-By default `buildtool`:
+This is because buildtool tagging & branch creation is disabled in the
+`publish_spinnaker` command. TODO: add validation/bumpdep wait support.
+
+When releasing a new minor version `x.y.0` make sure to update the Release
+Notes per: [Add next release preview](https://github.com/spinnaker/buildtool#for-new-minor-xy0-releases---add-next-release-preview)
+
+### Using GitHub Actions
+
+1. Open the [release workflow action](https://github.com/spinnaker/buildtool/actions/workflows/release.yml)
+2. Click `Run workflow` at the top right
+3. Fill out all fields. Do a dry run first and check the job output.
+
+To bump the default `Minimum Halyard Version` edit the `release.yml` workflow
+file.
+
+### Using buildtool
+
+Publish a new Spinnaker release in a single command. GitHub Actions use this
+under the covers.
+
+By default `buildtool publish_spinnaker`:
 
 1. targets `github.com/spinnaker` repositories.
 2. does a dry run, doing all the steps but without pushing back up to git or to
    any artifact repositories like GCS.
 
-When releasing a new minor version `x.y.0` make sure to update the Release
-Notes per: [Add next release preview](https://github.com/spinnaker/buildtool#for-new-minor-xy0-releases---add-next-release-preview)
+When troubleshooting try using your (in sync) forks and disabling `git push`
+and artifactory repository uploads:
 
 ```
 version=1.27.0


### PR DESCRIPTION
- enabled running the `buildtool publish_spinnaker` command without pushing a tag.
- provide a mechanism to override `publish_spinnaker --dry_run true` although for now we always run in dry run mode anyway.
- due to the way `workflow_dispatch` works, we need to do some switching based on the presence of its `inputs`.