### PR TITLE
feat(regctl): Support tagging containers with regctl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,11 @@ jobs:
         run: |
           pip install -r dev/requirements.txt
           pip install -r dev/buildtool/requirements.txt
+      - name: Install regctl for container image tagging
+        run: |
+          curl -L https://github.com/regclient/regclient/releases/download/v0.4.5/regctl-linux-amd64 >regctl
+          install --mode 755 regctl /usr/local/bin/
+          regctl version
       - name: Setup for tests
         run: |
           git config --global user.email "sig-platform@spinnaker.io"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,11 @@ jobs:
           pip install flake8
           pip install -r dev/requirements.txt
           pip install -r dev/buildtool/requirements.txt
+      - name: Install regctl for container image tagging
+        run: |
+          curl -L https://github.com/regclient/regclient/releases/download/v0.4.5/regctl-linux-amd64 >regctl
+          install --mode 755 regctl /usr/local/bin/
+          regctl version
       - name: Setup for tests
         run: |
           git config --global user.email "sig-platform@spinnaker.io"

--- a/dev/buildtool/__main__.py
+++ b/dev/buildtool/__main__.py
@@ -264,6 +264,7 @@ def main():
             "apidocs",
             "bom",
             "changelog",
+            "container",
             "halyard",
             "image",
             "source",

--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -1,0 +1,155 @@
+# Copyright 2023 Karl Skewes. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implements container commands for buildtool."""
+
+import copy
+import logging
+import os
+import yaml
+
+
+from buildtool import (
+    SPINNAKER_DOCKER_REGISTRY,
+    SPINNAKER_RUNNABLE_REPOSITORY_NAMES,
+    CommandFactory,
+    CommandProcessor,
+    check_options_set,
+    check_path_exists,
+    check_subprocess,
+    raise_and_log_error,
+)
+
+
+class TagContainersFactory(CommandFactory):
+    """Tags container images."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            "tag_containers",
+            TagContainersCommand,
+            "Tag containers with regctl.",
+            **kwargs,
+        )
+
+    def init_argparser(self, parser, defaults):
+        super().init_argparser(parser, defaults)
+
+        self.add_argument(
+            parser,
+            "spinnaker_version",
+            defaults,
+            None,
+            help="The new Spinnaker release version to tag containers with.",
+        )
+
+        self.add_argument(
+            parser,
+            "bom_path",
+            defaults,
+            None,
+            help="The path to the local BOM file with service to version mappings.",
+        )
+
+        self.add_argument(
+            parser,
+            "dry_run",
+            defaults,
+            True,
+            type=bool,
+            help="Show proposed actions, don't actually do them. Default True.",
+        )
+
+
+class TagContainersCommand(CommandProcessor):
+    """Implements tag_containers command."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, factory, options, **kwargs):
+        check_options_set(options, ["bom_path", "spinnaker_version"])
+        check_path_exists(options.bom_path, why="bom_path")
+
+        options_copy = copy.copy(options)
+        super().__init__(factory, options_copy, **kwargs)
+
+    def __load_bom_from_path(self, path):
+        """Load bom.yml from a file."""
+        logging.debug("Loading bom.yml from %s", path)
+        with open(path, encoding="utf-8") as f:
+            bom_yaml_string = f.read()
+        bom_dict = yaml.safe_load(bom_yaml_string)
+
+        return bom_dict
+
+    def regctl_image_copy(self, existing_image, new_image):
+        """Tag Alpine and Ubuntu container images with regctl"""
+        # https://github.com/google-github-actions/auth/blob/main/README.md#other-inputs
+        # describes GOOGLE_GHA_CREDS_PATH
+        if "GOOGLE_GHA_CREDS_PATH" in os.environ:
+            creds_path = os.environ["GOOGLE_GHA_CREDS_PATH"]
+            result = check_subprocess(
+                f"gcloud auth activate-service-account --key-file={creds_path}"
+            )
+            logging.info("gcloud auth result: %s", result)
+
+        result = check_subprocess(
+            f"regctl --verbosity info image copy {existing_image} {new_image}"
+        )
+        logging.info("Container tag result: %s", result)
+
+    def _do_command(self):
+        """Implements CommandProcessor interface."""
+        options = self.options
+
+        bom_dict = self.__load_bom_from_path(options.bom_path)
+
+        logging.info("Tagging containers in bom: %s", options.bom_path)
+
+        for service in bom_dict["services"]:
+            if service == "monitoring-third-party":
+                continue
+
+            version = bom_dict["services"][service]["version"]
+            existing_image = (
+                f"{SPINNAKER_DOCKER_REGISTRY}/{service}:{version}-unvalidated"
+            )
+
+            tag_permutations = [f"{version}", f"spinnaker-{options.spinnaker_version}"]
+
+            if options.dry_run:
+                logging.warning(
+                    "SKIP tagging %s containers because --dry_run=true"
+                    "\nNew tags were: %s",
+                    service,
+                    tag_permutations,
+                )
+                continue
+
+            logging.info("Tagging container: %s(-ubuntu)", existing_image)
+
+            for tag in tag_permutations:
+
+                alpine_image = f"{SPINNAKER_DOCKER_REGISTRY}/{service}:{tag}"
+                self.regctl_image_copy(existing_image, alpine_image)
+
+                ubuntu_image = f"{SPINNAKER_DOCKER_REGISTRY}/{service}:{tag}-ubuntu"
+                self.regctl_image_copy(f"{existing_image}-ubuntu", ubuntu_image)
+
+
+def register_commands(registry, subparsers, defaults):
+    """Registers all the commands for this module."""
+    TagContainersFactory().register(registry, subparsers, defaults)

--- a/dev/buildtool/spinnaker_commands.py
+++ b/dev/buildtool/spinnaker_commands.py
@@ -28,13 +28,14 @@ from buildtool.bom_commands import (
     BuildBomCommandFactory,
     PublishBomCommandFactory,
 )
+from buildtool.changelog_commands import BuildChangelogFactory, PublishChangelogFactory
+from buildtool.container_commands import TagContainersFactory
+from buildtool.source_commands import TagBranchCommandFactory, NewReleaseBranchFactory
 from buildtool.versions_commands import (
     FetchVersionsFactory,
     PublishVersionsFactory,
     UpdateVersionsFactory,
 )
-from buildtool.source_commands import TagBranchCommandFactory, NewReleaseBranchFactory
-from buildtool.changelog_commands import BuildChangelogFactory, PublishChangelogFactory
 
 
 class PublishSpinnakerFactory(CommandFactory):
@@ -208,6 +209,15 @@ class PublishSpinnakerCommand(CommandProcessor):
         command = UpdateVersionsFactory().make_command(options)
         command()
 
+    def __tag_containers(self, bom_path, spinnaker_version, options):
+        """Tag containers."""
+        logging.debug("Tagging containers - options: %s", options)
+        options.bom_path = bom_path
+        options.spinnaker_version = spinnaker_version
+
+        command = TagContainersFactory().make_command(options)
+        command()
+
     def __publish_versions(self, versions_yml_path, options):
         """Publish versions.yml."""
         options.versions_yml_path = versions_yml_path
@@ -271,8 +281,7 @@ class PublishSpinnakerCommand(CommandProcessor):
         )
 
         # Publishing Actions
-
-        # Tag containers with regctl
+        self.__tag_containers(bom_path, options.spinnaker_version, copy.copy(options))
 
         self.__publish_changelog(
             changelog_path, options.spinnaker_version, copy.copy(options)

--- a/unittest/buildtool/container_commands_test.py
+++ b/unittest/buildtool/container_commands_test.py
@@ -1,0 +1,154 @@
+# Copyright 2023 Karl Skewes. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import unittest
+from unittest.mock import patch, call
+import yaml
+
+from test_util import init_runtime, BaseTestFixture
+
+from buildtool import SPINNAKER_DOCKER_REGISTRY
+
+import buildtool.__main__ as bomtool_main
+import buildtool.container_commands
+
+from buildtool.container_commands import TagContainersCommand
+
+
+class TestTagContainersCommand(BaseTestFixture):
+    """Test tag_containers command."""
+
+    def setUp(self):
+        super().setUp()
+        self.parser = argparse.ArgumentParser()
+        self.subparsers = self.parser.add_subparsers()
+
+    def test_default_tag_containers_options(self):
+        """Test tag_containers default argument options"""
+        registry = {}
+        buildtool.container_commands.register_commands(registry, self.subparsers, {})
+        self.assertTrue("tag_containers" in registry)
+
+        options = self.parser.parse_args(["tag_containers"])
+        option_dict = vars(options)
+
+        self.assertEqual(True, options.dry_run)
+
+        self.assertIsNone(option_dict["bom_path"])
+        self.assertIsNone(option_dict["spinnaker_version"])
+
+    def test_tag_containers_dry_run(self):
+        """Test tag_containers with dry_run enabled.
+        regctl command should not be called."""
+
+        options = self.options
+
+        options.spinnaker_version = "1.2.3"
+        options.bom_path = os.path.join(
+            os.path.dirname(__file__), "standard_test_bom.yml"
+        )
+        options.dry_run = True
+
+        mock_regctl_image_copy = self.patch_method(
+            TagContainersCommand, "regctl_image_copy"
+        )
+
+        defaults = vars(self.options)
+        parser = argparse.ArgumentParser()
+        registry = bomtool_main.make_registry(
+            [buildtool.container_commands], parser, defaults
+        )
+        bomtool_main.add_standard_parser_args(parser, defaults)
+        factory = registry["tag_containers"]
+        command = factory.make_command(options)
+        command()
+
+        self.assertEqual(0, mock_regctl_image_copy.call_count)
+
+    def test_tag_containers(self):
+        """Test tag_containers with dry_run disabled.
+        Verify mocked regctl command is called for each tag permutation."""
+
+        options = self.options
+
+        options.spinnaker_version = "1.2.3"
+        options.bom_path = os.path.join(
+            os.path.dirname(__file__), "standard_test_bom.yml"
+        )
+        options.dry_run = False
+
+        mock_regctl_image_copy = self.patch_method(
+            TagContainersCommand, "regctl_image_copy"
+        )
+
+        defaults = vars(self.options)
+        parser = argparse.ArgumentParser()
+        registry = bomtool_main.make_registry(
+            [buildtool.container_commands], parser, defaults
+        )
+        bomtool_main.add_standard_parser_args(parser, defaults)
+        factory = registry["tag_containers"]
+        command = factory.make_command(options)
+        command()
+
+        # BOM services gate & monitoring daemon should be tagged:
+        # without "-unvalidated" and with "spinnaker-{version}", 4 variations
+        # each service (2 services), 8 permutations.
+        # BOM service "monitoring-third-party" should be ignored.
+        calls = [
+            call(
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-unvalidated",
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405",
+            ),
+            call(
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-unvalidated-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-ubuntu",
+            ),
+            call(
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-unvalidated",
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:spinnaker-1.2.3",
+            ),
+            call(
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-unvalidated-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:spinnaker-1.2.3-ubuntu",
+            ),
+            call(
+                f"{SPINNAKER_DOCKER_REGISTRY}/monitoring-daemon:7.8.9-20180908070605-unvalidated",
+                f"{SPINNAKER_DOCKER_REGISTRY}/monitoring-daemon:7.8.9-20180908070605",
+            ),
+            call(
+                f"{SPINNAKER_DOCKER_REGISTRY}/monitoring-daemon:7.8.9-20180908070605-unvalidated-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/monitoring-daemon:7.8.9-20180908070605-ubuntu",
+            ),
+            call(
+                f"{SPINNAKER_DOCKER_REGISTRY}/monitoring-daemon:7.8.9-20180908070605-unvalidated",
+                f"{SPINNAKER_DOCKER_REGISTRY}/monitoring-daemon:spinnaker-1.2.3",
+            ),
+            call(
+                f"{SPINNAKER_DOCKER_REGISTRY}/monitoring-daemon:7.8.9-20180908070605-unvalidated-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/monitoring-daemon:spinnaker-1.2.3-ubuntu",
+            ),
+        ]
+
+        mock_regctl_image_copy.assert_has_calls(calls)
+
+        # Should only be eight permutations, no more (e.g: NOT monitoring-third-party)
+        self.assertEqual(mock_regctl_image_copy.call_count, 8)
+
+
+if __name__ == "__main__":
+    init_runtime()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
`regctl` supports tagging containers directly in a container registry without doing a pull/tag/push flow. This is great because it saves a lot of time with network transfers.

When cutting a Spinnaker release we need to tag slim (Alpine) and Ubuntu containers at a specific `<tag>`:
- without `-unvalidated`
- with our `spinnaker-<release_version>`.

Default to `--dry_run true` mode to prevent tagging containers in the registry by mistake.
