### PR TITLE
fix(release): add regctl to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
         run: |
           pip install -r dev/requirements.txt
           pip install -r dev/buildtool/requirements.txt
+      - name: Install regctl for container image tagging
+        run: |
+          curl -L https://github.com/regclient/regclient/releases/download/v0.4.5/regctl-linux-amd64 >regctl
+          install --mode 755 regctl /usr/local/bin/
+          regctl version
       - name: Setup git
         run: |
           git config --global user.email "sig-platform@spinnaker.io"


### PR DESCRIPTION
to prevent failures like

FileNotFoundError: [Errno 2] No such file or directory: 'regctl'

from https://github.com/spinnaker/buildtool/actions/runs/4306194404/jobs/7509677659
