### PR TITLE
chore(build): tag JRE 11 images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ on:
         type: choice
         required: true
       tagJava11:
-        description: 'Tag Java 11 variants of images.'
+        description: 'Tag Java 11 variants of images. Only set to True for versions after 1.32.0.'
         default: 'true'
         options:
           - 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,14 @@ on:
         - 'false'
         type: choice
         required: true
+      tagJava11:
+        description: 'Tag Java 11 variants of images.'
+        default: 'true'
+        options:
+          - 'true'
+          - 'false'
+        type: choice
+        required: true
 
 jobs:
   release:
@@ -62,7 +70,8 @@ jobs:
             release version: ${{ inputs.spinnakerVersion }}
             minimum Halyard version: ${{ inputs.minimumHalyardVersion }}
             latest Halyard version: ${{ inputs.latestHalyardVersion }}
-            dry run enabled: ${{ inputs.dryRun }}"
+            dry run enabled: ${{ inputs.dryRun }}
+            tag Java 11 variants: ${{ inputs.tagJava11 }}"
 
       - name: Login to GAR
         # This is required to tag docker images
@@ -93,7 +102,8 @@ jobs:
             --latest_halyard_version "${{ inputs.latestHalyardVersion }}" \
             --github_owner "${{ steps.release_info.outputs.REPOSITORY_OWNER }}" \
             --github_oauth_token "${{ secrets.SPINNAKERBOT_PERSONAL_ACCESS_TOKEN }}" \
-            --dry_run ${{ inputs.dryRun }}
+            --dry_run ${{ inputs.dryRun }} \
+            --tag_java11 ${{ inputs.tagJava11 }}
 
       - name: Cat output files for review
         run: |

--- a/dev/buildtool/__init__.py
+++ b/dev/buildtool/__init__.py
@@ -2,6 +2,11 @@
 
 # pylint: disable=wrong-import-position
 
+SPINNAKER_JAVA11_VARIANT_REPOSITORY_NAMES = [
+    "front50",
+    "igor"
+]
+
 # These would be required if running from source code
 SPINNAKER_RUNNABLE_REPOSITORY_NAMES = [
     "clouddriver",
@@ -15,6 +20,7 @@ SPINNAKER_RUNNABLE_REPOSITORY_NAMES = [
     "orca",
     "rosco",
 ]
+
 # These are not included in the BOM but are included in some buildtool tasks
 SPINNAKER_RUNNABLE_NON_CORE_REPOSITORY_NAMES = ["keel"]
 

--- a/dev/buildtool/spinnaker_commands.py
+++ b/dev/buildtool/spinnaker_commands.py
@@ -84,7 +84,8 @@ class PublishSpinnakerFactory(CommandFactory):
             parser,
             "tag_java11",
             defaults,
-            "",
+            True,
+            type=bool,
             help="Tag JRE 11 variants of images for specified services. Default None.",
         )
 

--- a/dev/buildtool/spinnaker_commands.py
+++ b/dev/buildtool/spinnaker_commands.py
@@ -86,7 +86,7 @@ class PublishSpinnakerFactory(CommandFactory):
             defaults,
             True,
             type=bool,
-            help="Tag JRE 11 variants of images for specified services. Default None.",
+            help="Tag JRE 11 variants of images for specified services. Default True.",
         )
 
 

--- a/dev/buildtool/spinnaker_commands.py
+++ b/dev/buildtool/spinnaker_commands.py
@@ -80,6 +80,13 @@ class PublishSpinnakerFactory(CommandFactory):
             type=bool,
             help="Show proposed actions, don't actually do them. Default True.",
         )
+        self.add_argument(
+            parser,
+            "tag_java11",
+            defaults,
+            "",
+            help="Tag JRE 11 variants of images for specified services. Default None.",
+        )
 
 
 class PublishSpinnakerCommand(CommandProcessor):

--- a/unittest/buildtool/bom_command_test.py
+++ b/unittest/buildtool/bom_command_test.py
@@ -310,8 +310,8 @@ class TestBomBuilder(BaseGitRepoTestFixture):
         }
 
         for key, value in bom["services"].items():
-            # gate has extra commit on branch so commit id's should not match
-            if key in ["gate", "monitoring-daemon", "monitoring-third-party"]:
+            # front50 has extra commit on branch so commit id's should not match
+            if key in ["front50", "monitoring-daemon", "monitoring-third-party"]:
                 self.assertNotEqual(
                     value,
                     golden_bom["services"][key],

--- a/unittest/buildtool/bom_repository_command_test.py
+++ b/unittest/buildtool/bom_repository_command_test.py
@@ -91,9 +91,9 @@ class TestBomRepositoryCommandProcessor(BaseGitRepoTestFixture):
 
         for repository in command.source_repositories:
             self.assertTrue(os.path.exists(repository.git_dir))
-            # gate and spinnaker-monitoring have extra commits after last tag so the
+            # front50 and spinnaker-monitoring have extra commits after last tag so the
             # repo_commit_map won't match the summary we get (which is up to last tag)
-            if repository.name in ["gate", "spinnaker-monitoring"]:
+            if repository.name in ["front50", "spinnaker-monitoring"]:
                 self.assertNotEqual(
                     command.summary_info[repository.name].commit_id,
                     self.repo_commit_map[repository.name][PATCH_BRANCH],

--- a/unittest/buildtool/container_commands_test.py
+++ b/unittest/buildtool/container_commands_test.py
@@ -46,6 +46,7 @@ class TestTagContainersCommand(BaseTestFixture):
         option_dict = vars(options)
 
         self.assertEqual(True, options.dry_run)
+        self.assertEqual("", options.tag_java11)
 
         self.assertIsNone(option_dict["bom_path"])
         self.assertIsNone(option_dict["spinnaker_version"])
@@ -61,6 +62,7 @@ class TestTagContainersCommand(BaseTestFixture):
             os.path.dirname(__file__), "standard_test_bom.yml"
         )
         options.dry_run = True
+        options.tag_java11 = "gate"
 
         mock_regctl_image_copy = self.patch_method(
             TagContainersCommand, "regctl_image_copy"
@@ -89,6 +91,7 @@ class TestTagContainersCommand(BaseTestFixture):
             os.path.dirname(__file__), "standard_test_bom.yml"
         )
         options.dry_run = False
+        options.tag_java11 = "gate"
 
         mock_regctl_image_copy = self.patch_method(
             TagContainersCommand, "regctl_image_copy"
@@ -108,6 +111,7 @@ class TestTagContainersCommand(BaseTestFixture):
         # without "-unvalidated" and with "spinnaker-{version}", 4 variations
         # each service (2 services), 8 permutations.
         # BOM service "monitoring-third-party" should be ignored.
+        # When tag_java11 flag set, extra 4 permutations per service
         calls = [
             call(
                 f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-unvalidated",
@@ -118,12 +122,28 @@ class TestTagContainersCommand(BaseTestFixture):
                 f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-ubuntu",
             ),
             call(
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-java11-unvalidated",
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-java11",
+            ),
+            call(
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-java11-unvalidated-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-java11-ubuntu",
+            ),
+            call(
                 f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-unvalidated",
                 f"{SPINNAKER_DOCKER_REGISTRY}/gate:spinnaker-1.2.3",
             ),
             call(
                 f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-unvalidated-ubuntu",
                 f"{SPINNAKER_DOCKER_REGISTRY}/gate:spinnaker-1.2.3-ubuntu",
+            ),
+            call(
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-java11-unvalidated",
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:spinnaker-1.2.3-java11",
+            ),
+            call(
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-java11-unvalidated-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/gate:spinnaker-1.2.3-java11-ubuntu",
             ),
             call(
                 f"{SPINNAKER_DOCKER_REGISTRY}/monitoring-daemon:7.8.9-20180908070605-unvalidated",
@@ -146,7 +166,8 @@ class TestTagContainersCommand(BaseTestFixture):
         mock_regctl_image_copy.assert_has_calls(calls)
 
         # Should only be eight permutations, no more (e.g: NOT monitoring-third-party)
-        self.assertEqual(mock_regctl_image_copy.call_count, 8)
+        # Should be 12 when tagging JRE 11 images for Gate only
+        self.assertEqual(mock_regctl_image_copy.call_count, 12)
 
 
 if __name__ == "__main__":

--- a/unittest/buildtool/container_commands_test.py
+++ b/unittest/buildtool/container_commands_test.py
@@ -46,7 +46,7 @@ class TestTagContainersCommand(BaseTestFixture):
         option_dict = vars(options)
 
         self.assertEqual(True, options.dry_run)
-        self.assertEqual("", options.tag_java11)
+        self.assertEqual(True, options.tag_java11)
 
         self.assertIsNone(option_dict["bom_path"])
         self.assertIsNone(option_dict["spinnaker_version"])
@@ -62,7 +62,7 @@ class TestTagContainersCommand(BaseTestFixture):
             os.path.dirname(__file__), "standard_test_bom.yml"
         )
         options.dry_run = True
-        options.tag_java11 = "gate"
+        options.tag_java11 = True
 
         mock_regctl_image_copy = self.patch_method(
             TagContainersCommand, "regctl_image_copy"
@@ -91,7 +91,7 @@ class TestTagContainersCommand(BaseTestFixture):
             os.path.dirname(__file__), "standard_test_bom.yml"
         )
         options.dry_run = False
-        options.tag_java11 = "gate"
+        options.tag_java11 = True
 
         mock_regctl_image_copy = self.patch_method(
             TagContainersCommand, "regctl_image_copy"
@@ -107,43 +107,43 @@ class TestTagContainersCommand(BaseTestFixture):
         command = factory.make_command(options)
         command()
 
-        # BOM services gate & monitoring daemon should be tagged:
+        # BOM services front50 & monitoring daemon should be tagged:
         # without "-unvalidated" and with "spinnaker-{version}", 4 variations
         # each service (2 services), 8 permutations.
         # BOM service "monitoring-third-party" should be ignored.
         # When tag_java11 flag set, extra 4 permutations per service
         calls = [
             call(
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-unvalidated",
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-unvalidated",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405",
             ),
             call(
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-unvalidated-ubuntu",
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-unvalidated-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-ubuntu",
             ),
             call(
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-java11-unvalidated",
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-java11",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-java11-unvalidated",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-java11",
             ),
             call(
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-java11-unvalidated-ubuntu",
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-java11-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-java11-unvalidated-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-java11-ubuntu",
             ),
             call(
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-unvalidated",
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:spinnaker-1.2.3",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-unvalidated",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:spinnaker-1.2.3",
             ),
             call(
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-unvalidated-ubuntu",
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:spinnaker-1.2.3-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-unvalidated-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:spinnaker-1.2.3-ubuntu",
             ),
             call(
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-java11-unvalidated",
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:spinnaker-1.2.3-java11",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-java11-unvalidated",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:spinnaker-1.2.3-java11",
             ),
             call(
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:7.8.9-20180102030405-java11-unvalidated-ubuntu",
-                f"{SPINNAKER_DOCKER_REGISTRY}/gate:spinnaker-1.2.3-java11-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-java11-unvalidated-ubuntu",
+                f"{SPINNAKER_DOCKER_REGISTRY}/front50:spinnaker-1.2.3-java11-ubuntu",
             ),
             call(
                 f"{SPINNAKER_DOCKER_REGISTRY}/monitoring-daemon:7.8.9-20180908070605-unvalidated",
@@ -166,7 +166,7 @@ class TestTagContainersCommand(BaseTestFixture):
         mock_regctl_image_copy.assert_has_calls(calls)
 
         # Should only be eight permutations, no more (e.g: NOT monitoring-third-party)
-        # Should be 12 when tagging JRE 11 images for Gate only
+        # Should be 12 when tagging JRE 11 images for front50 only
         self.assertEqual(mock_regctl_image_copy.call_count, 12)
 
 

--- a/unittest/buildtool/standard_test_bom.yml
+++ b/unittest/buildtool/standard_test_bom.yml
@@ -11,7 +11,7 @@ dependencies:
   vault:
     version: 0.7.0
 services:
-  gate:
+  front50:
     commit: normalserviceocmmitid
     version: 7.8.9-20180102030405
   monitoring-daemon:

--- a/unittest/buildtool/test_util.py
+++ b/unittest/buildtool/test_util.py
@@ -45,7 +45,7 @@ def init_runtime(options=None):
 
 
 #  These are used to define the standard test repositories
-NORMAL_SERVICE = "gate"
+NORMAL_SERVICE = "front50"
 NORMAL_REPO = NORMAL_SERVICE
 OUTLIER_SERVICE = "monitoring-daemon"
 OUTLIER_REPO = "spinnaker-monitoring"


### PR DESCRIPTION
Some repos will move to default to JRE 17. These repos will also publish JRE 11 versions tagged `java11-unvalidated` for the time being. This change should handle releasing these variants where present.

End users should be able to specify `imageVariant` as `java11` in their halconfig/operator config to use the JRE 11 versions if they encounter issues with JRE 17.