### PR TITLE
chore(build): remove option to tag java 11 images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,6 @@ on:
         - 'false'
         type: choice
         required: true
-      tagJava11:
-        description: 'Tag Java 11 variants of images. Only set to True for versions after 1.32.0.'
-        default: 'true'
-        options:
-          - 'true'
-          - 'false'
-        type: choice
-        required: true
 
 jobs:
   release:
@@ -71,7 +63,6 @@ jobs:
             minimum Halyard version: ${{ inputs.minimumHalyardVersion }}
             latest Halyard version: ${{ inputs.latestHalyardVersion }}
             dry run enabled: ${{ inputs.dryRun }}
-            tag Java 11 variants: ${{ inputs.tagJava11 }}"
 
       - name: Login to GAR
         # This is required to tag docker images
@@ -103,7 +94,6 @@ jobs:
             --github_owner "${{ steps.release_info.outputs.REPOSITORY_OWNER }}" \
             --github_oauth_token "${{ secrets.SPINNAKERBOT_PERSONAL_ACCESS_TOKEN }}" \
             --dry_run ${{ inputs.dryRun }} \
-            --tag_java11 ${{ inputs.tagJava11 }}
 
       - name: Cat output files for review
         run: |

--- a/dev/buildtool/__init__.py
+++ b/dev/buildtool/__init__.py
@@ -2,18 +2,6 @@
 
 # pylint: disable=wrong-import-position
 
-SPINNAKER_JAVA11_VARIANT_REPOSITORY_NAMES = [
-    "clouddriver",
-    "echo",
-    "fiat",
-    "front50",
-    "gate",
-    "igor",
-    "kayenta",
-    "orca",
-    "rosco"
-]
-
 # These would be required if running from source code
 SPINNAKER_RUNNABLE_REPOSITORY_NAMES = [
     "clouddriver",

--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -23,7 +23,6 @@ import yaml
 from buildtool import (
     SPINNAKER_DOCKER_REGISTRY,
     SPINNAKER_RUNNABLE_REPOSITORY_NAMES,
-    SPINNAKER_JAVA11_VARIANT_REPOSITORY_NAMES,
     CommandFactory,
     CommandProcessor,
     check_options_set,
@@ -72,15 +71,6 @@ class TagContainersFactory(CommandFactory):
             True,
             type=bool,
             help="Show proposed actions, don't actually do them. Default True.",
-        )
-
-        self.add_argument(
-            parser,
-            "tag_java11",
-            defaults,
-            True,
-            type=bool,
-            help="Tag JRE 11 variants of images for specified services. Default True.",
         )
 
 
@@ -136,9 +126,6 @@ class TagContainersCommand(CommandProcessor):
             existing_image = (
                 f"{SPINNAKER_DOCKER_REGISTRY}/{service}:{version}-unvalidated"
             )
-            existing_image_java11 = (
-                f"{SPINNAKER_DOCKER_REGISTRY}/{service}:{version}-java11-unvalidated"
-            )
 
             tag_permutations = [f"{version}", f"spinnaker-{options.spinnaker_version}"]
 
@@ -152,8 +139,6 @@ class TagContainersCommand(CommandProcessor):
                 continue
 
             logging.info("Tagging container: %s(-ubuntu)", existing_image)
-            if options.tag_java11 and service in SPINNAKER_JAVA11_VARIANT_REPOSITORY_NAMES:
-                logging.info("Tagging JRE 11 container variants: %s(-ubuntu)", existing_image_java11)
 
             for tag in tag_permutations:
                 alpine_image = f"{SPINNAKER_DOCKER_REGISTRY}/{service}:{tag}"
@@ -161,13 +146,6 @@ class TagContainersCommand(CommandProcessor):
 
                 ubuntu_image = f"{SPINNAKER_DOCKER_REGISTRY}/{service}:{tag}-ubuntu"
                 self.regctl_image_copy(f"{existing_image}-ubuntu", ubuntu_image)
-
-                if options.tag_java11 and service in SPINNAKER_JAVA11_VARIANT_REPOSITORY_NAMES:
-                    alpine_image_java11 = f"{SPINNAKER_DOCKER_REGISTRY}/{service}:{tag}-java11"
-                    self.regctl_image_copy(existing_image_java11, alpine_image_java11)
-
-                    ubuntu_image_java11 = f"{SPINNAKER_DOCKER_REGISTRY}/{service}:{tag}-java11-ubuntu"
-                    self.regctl_image_copy(f"{existing_image_java11}-ubuntu", ubuntu_image_java11)
 
 
 def register_commands(registry, subparsers, defaults):

--- a/dev/buildtool/spinnaker_commands.py
+++ b/dev/buildtool/spinnaker_commands.py
@@ -80,14 +80,6 @@ class PublishSpinnakerFactory(CommandFactory):
             type=bool,
             help="Show proposed actions, don't actually do them. Default True.",
         )
-        self.add_argument(
-            parser,
-            "tag_java11",
-            defaults,
-            True,
-            type=bool,
-            help="Tag JRE 11 variants of images for specified services. Default True.",
-        )
 
 
 class PublishSpinnakerCommand(CommandProcessor):

--- a/unittest/buildtool/container_commands_test.py
+++ b/unittest/buildtool/container_commands_test.py
@@ -46,7 +46,6 @@ class TestTagContainersCommand(BaseTestFixture):
         option_dict = vars(options)
 
         self.assertEqual(True, options.dry_run)
-        self.assertEqual(True, options.tag_java11)
 
         self.assertIsNone(option_dict["bom_path"])
         self.assertIsNone(option_dict["spinnaker_version"])
@@ -62,7 +61,6 @@ class TestTagContainersCommand(BaseTestFixture):
             os.path.dirname(__file__), "standard_test_bom.yml"
         )
         options.dry_run = True
-        options.tag_java11 = True
 
         mock_regctl_image_copy = self.patch_method(
             TagContainersCommand, "regctl_image_copy"
@@ -91,7 +89,6 @@ class TestTagContainersCommand(BaseTestFixture):
             os.path.dirname(__file__), "standard_test_bom.yml"
         )
         options.dry_run = False
-        options.tag_java11 = True
 
         mock_regctl_image_copy = self.patch_method(
             TagContainersCommand, "regctl_image_copy"
@@ -111,7 +108,6 @@ class TestTagContainersCommand(BaseTestFixture):
         # without "-unvalidated" and with "spinnaker-{version}", 4 variations
         # each service (2 services), 8 permutations.
         # BOM service "monitoring-third-party" should be ignored.
-        # When tag_java11 flag set, extra 4 permutations per service
         calls = [
             call(
                 f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-unvalidated",
@@ -122,28 +118,12 @@ class TestTagContainersCommand(BaseTestFixture):
                 f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-ubuntu",
             ),
             call(
-                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-java11-unvalidated",
-                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-java11",
-            ),
-            call(
-                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-java11-unvalidated-ubuntu",
-                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-java11-ubuntu",
-            ),
-            call(
                 f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-unvalidated",
                 f"{SPINNAKER_DOCKER_REGISTRY}/front50:spinnaker-1.2.3",
             ),
             call(
                 f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-unvalidated-ubuntu",
                 f"{SPINNAKER_DOCKER_REGISTRY}/front50:spinnaker-1.2.3-ubuntu",
-            ),
-            call(
-                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-java11-unvalidated",
-                f"{SPINNAKER_DOCKER_REGISTRY}/front50:spinnaker-1.2.3-java11",
-            ),
-            call(
-                f"{SPINNAKER_DOCKER_REGISTRY}/front50:7.8.9-20180102030405-java11-unvalidated-ubuntu",
-                f"{SPINNAKER_DOCKER_REGISTRY}/front50:spinnaker-1.2.3-java11-ubuntu",
             ),
             call(
                 f"{SPINNAKER_DOCKER_REGISTRY}/monitoring-daemon:7.8.9-20180908070605-unvalidated",
@@ -166,8 +146,7 @@ class TestTagContainersCommand(BaseTestFixture):
         mock_regctl_image_copy.assert_has_calls(calls)
 
         # Should only be eight permutations, no more (e.g: NOT monitoring-third-party)
-        # Should be 12 when tagging JRE 11 images for front50 only
-        self.assertEqual(mock_regctl_image_copy.call_count, 12)
+        self.assertEqual(mock_regctl_image_copy.call_count, 8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
now that everything builds for java 17 only
