### PR TITLE
fix: return integers from VersionsBuilder.get_major_minor_patch_version

### DIFF
--- a/dev/buildtool/versions_commands.py
+++ b/dev/buildtool/versions_commands.py
@@ -117,7 +117,7 @@ class VersionsBuilder:
     def get_major_minor_patch_version(version):
         """Split a M.m.p version string into an list of [major, minor, patch]."""
         major, minor, patch = version.split(".")
-        return [major, minor, patch]
+        return [int(major), int(minor), int(patch)]
 
     def add_or_replace_release(self, new_release, versions):
         """Add new minor release versions to version list. If it's a new patch

--- a/unittest/buildtool/versions_command_test.py
+++ b/unittest/buildtool/versions_command_test.py
@@ -62,7 +62,15 @@ class TestVersionsBuilder(BaseTestFixture):
     def test_get_major_minor_patch_version(self):
         """A version string should get split into an array of strings: major, minor, patch."""
         version = "1.2.3"
-        expected = ["1", "2", "3"]
+        expected = [1, 2, 3]
+        builder = VersionsBuilder()
+        got = builder.get_major_minor_patch_version(version)
+        self.assertListEqual(expected, got)
+
+    def test_get_major_minor_patch_version_with_multiple_digits(self):
+        """A version string should get split into an array of strings: major, minor, patch."""
+        version = "1.2.30"
+        expected = [1, 2, 30]
         builder = VersionsBuilder()
         got = builder.get_major_minor_patch_version(version)
         self.assertListEqual(expected, got)


### PR DESCRIPTION
so that 10 is actually considered greater than 9, as in this error from https://github.com/spinnaker/buildtool/actions/runs/14455996449/job/40539260778:
```
E 21:20:51.652 [MainThread.1972] *** ERROR ***: Spinnaker version 1.37.10 superceded by newer patch version: 1.37.9
```